### PR TITLE
chore: install vuex and connect store to pass wallet around

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "vue-concurrency": "^2.0.3",
     "vue-property-decorator": "^10.0.0-rc.2",
     "vue-router": "^4.0.0-0",
-    "vue-rx": "^6.2.0"
+    "vue-rx": "^6.2.0",
+    "vuex": "^4.0.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8",

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,10 @@ import router from './router'
 import VueRx from '@nopr3d/vue-next-rx'
 import './assets/tailwind.css'
 import '@/validations'
+import { store, key } from '@/store'
 
 createApp(App)
   .use(router)
   .use(VueRx)
+  .use(store, key)
   .mount('#app')

--- a/src/shims-vuex.d.ts
+++ b/src/shims-vuex.d.ts
@@ -1,0 +1,15 @@
+import { Store } from 'vuex'
+import { State } from './store'
+
+declare module '@vue/runtime-core' {
+  interface ComponentCustomProperties {
+    $store: Store<State>;
+  }
+}
+
+// Vuex@4.0.0-beta.1 is missing the typing for `useStore`. See https://github.com/vuejs/vuex/issues/1736
+declare module 'vuex' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export function useStore<S = any>(injectKey?: InjectionKey<Store<S>> | string): Store<S>
+  export function createStore<S>(options: StoreOptions<S>): Store<S>
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,28 @@
+import { createStore, useStore as baseUseStore } from 'vuex'
+import { Store } from 'vuex/types'
+import { InjectionKey } from 'vue'
+import { WalletT } from '@radixdlt/account'
+
+interface State {
+  wallet: WalletT | null;
+  count: number;
+}
+
+// Create a new store instance.
+export const store = createStore<State>({
+  state () {
+    return {
+      wallet: null,
+      count: 0
+    }
+  },
+  mutations: {
+  }
+})
+
+// define injection key
+export const key: InjectionKey<Store<State>> = Symbol('key')
+
+export function useStore () {
+  return baseUseStore(key)
+}

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -58,6 +58,7 @@ import { ref } from '@nopr3d/vue-next-rx'
 import { useTask } from 'vue-concurrency'
 import { AbortSignalWithPromise } from 'vue-concurrency/dist/vue3/src/types'
 import { decryptWallet } from '@/actions/vue/create-wallet'
+import { useStore } from '@/store'
 
 const CreateWallet = defineComponent({
   setup () {
@@ -95,6 +96,10 @@ const CreateWallet = defineComponent({
           )
           .add(subs)
       })
+
+    const store = useStore()
+
+    console.log('store', store.state)
     return { createWalletTask, accounts, activeAccount }
   },
 

--- a/vuex.d.ts
+++ b/vuex.d.ts
@@ -1,0 +1,14 @@
+import { ComponentCustomProperties } from 'vue'
+import { Store } from 'vuex'
+import { WalletT } from '@radixdlt/account'
+
+declare module '@vue/runtime-core' {
+  interface State {
+    wallet: WalletT
+  }
+
+  // provide typings for `this.$store`
+  interface ComponentCustomProperties {
+    $store: Store<State>
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13209,6 +13209,11 @@ vue@^3.0.0:
     "@vue/runtime-dom" "3.0.7"
     "@vue/shared" "3.0.7"
 
+vuex@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/vuex/-/vuex-4.0.0.tgz#ac877aa76a9c45368c979471e461b520d38e6cf5"
+  integrity sha512-56VPujlHscP5q/e7Jlpqc40sja4vOhC4uJD1llBCWolVI8ND4+VzisDVkUMl+z5y0MpIImW6HjhNc+ZvuizgOw==
+
 w3c-hr-time@^1.0.1, w3c-hr-time@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"


### PR DESCRIPTION
- chore: install vuex and connect store to pass wallet around

This PR installs vuex with typescript bindings. This will allow us to pass the
wallet instance and other pieces of local state between views.
