### PR TITLE
Fix release please action failing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,9 +27,10 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 10
+          node-version: '15'
+          check-latest: true
 
       - name: Build/release Electron app
         uses: samuelmeuli/action-electron-builder@v1


### PR DESCRIPTION
The build-release job was failing because node 10 couldn't parse the output of
./src/assets/tailwind.css. This PR bumps the version of node to 15 to ensure
bundling succeeds

See https://github.com/township-agency/radixdlt-desktop-wallet/runs/2219497551?check_suite_focus=true for a failing example

See https://github.com/township-agency/radixdlt-desktop-wallet/runs/2245416370?check_suite_focus=true for an example of it passing on this branch
