### PR TITLE
Confirm transactions with pin

### DIFF
--- a/src/actions/electron/create-wallet.ts
+++ b/src/actions/electron/create-wallet.ts
@@ -23,3 +23,6 @@ export const storePin = (event: IpcMainInvokeEvent, pin: string) =>
 export const copyToClipboard = (event: IpcMainEvent, text: string) => {
   clipboard.writeText(text, 'selection')
 }
+
+export const validatePin = (event: IpcMainInvokeEvent, pin: string) =>
+  digestPin(pin).then((inputHash: string) => store.get('pin') === inputHash)

--- a/src/actions/vue/create-wallet.ts
+++ b/src/actions/vue/create-wallet.ts
@@ -40,3 +40,7 @@ export const copyToClipboard = (text: string) => window.ipcRenderer.send('copy-t
 export const storePin = (pin: string): Promise<string> => new Promise((resolve) => {
   resolve(window.ipcRenderer.invoke('create-pin', pin))
 })
+
+export const validatePin = (pin: string): Promise<boolean> => new Promise((resolve) => {
+  resolve(window.ipcRenderer.invoke('validate-pin-message', pin))
+})

--- a/src/background.ts
+++ b/src/background.ts
@@ -4,7 +4,7 @@ import { app, ipcMain, protocol, BrowserWindow } from 'electron'
 import { createProtocol } from 'vue-cli-plugin-electron-builder/lib'
 import installExtension, { VUEJS_DEVTOOLS } from 'electron-devtools-installer'
 import path from 'path'
-import { copyToClipboard, getKeystoreFile, storePin, writeKeystoreFile } from '@/actions/electron/create-wallet'
+import { copyToClipboard, getKeystoreFile, storePin, validatePin, writeKeystoreFile } from '@/actions/electron/create-wallet'
 import { getAccountName, saveAccountName } from './actions/electron/data-store'
 const isDevelopment = process.env.NODE_ENV !== 'production'
 
@@ -79,6 +79,7 @@ ipcMain.on('copy-to-clipboard', copyToClipboard)
 ipcMain.handle('create-pin', storePin)
 ipcMain.handle('save-account-name', saveAccountName)
 ipcMain.handle('get-account-name', getAccountName)
+ipcMain.handle('validate-pin-message', validatePin)
 
 // Exit cleanly on request from parent process in development mode.
 if (isDevelopment) {

--- a/src/components/PinInput.vue
+++ b/src/components/PinInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="flex" :class="{'filter-blurSmall': !autofocus}">
+    <div class="flex -mr-11" :class="{'filter-blurSmall': !autofocus}">
       <div
         v-for="(digit, i) in [1, 2, 3, 4]"
         :key="i"
@@ -12,6 +12,7 @@
       />
     </div>
     <input
+      :name="name"
       type="password"
       class="opacity-0 h-0 m-0 p-0"
       maxlength="4"
@@ -21,7 +22,14 @@
       @blur="focusInput()"
       @input="handleChange($event.target.value)"
     />
-    <span>{{ errorMessage }}</span>
+    <div v-if="errorMessage" class="flex flex-row items-center justify-center text-rRed">
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="mr-3">
+      <circle cx="7" cy="7" r="6.5" transform="rotate(90 7 7)" fill="#EF4136" stroke="#EF4136"/>
+      <rect x="4" y="5" width="1" height="7" transform="rotate(-45 4 5)" fill="white"/>
+      <rect x="8.94971" y="4.29297" width="1" height="7" transform="rotate(45 8.94971 4.29297)" fill="white"/>
+      </svg>
+      <span>{{ errorMessage }}</span>
+    </div>
   </div>
 </template>
 
@@ -39,7 +47,7 @@ const PinInput = defineComponent({
       }
     }
 
-    const { value, errorMessage } = useField<string>(props.name, 'required:length:4')
+    const { value, errorMessage } = useField<string>(props.name, 'required|length:4')
 
     return {
       inputRef,

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -10,7 +10,8 @@ const messages = {
       validAddress: 'Enter a valid address',
       validAmount: 'Enter a valid amount',
       insufficientFunds: '%{field} cannot be greater than account balance',
-      amountOfType: 'Requested amount to send is not a mulltiple of token granularity (%{granularity}), will be unable to send'
+      amountOfType: 'Requested amount to send is not a mulltiple of token granularity (%{granularity}), will be unable to send',
+      invalidPin: 'Your pin was not a match. Try again.'
     },
     home: {
       welcomeOne: 'Welcome to the Radix Betanet.',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,7 @@ module.exports = {
         rBlue: '#052CC0',
         rBlack: '#003057',
         rGreen: '#00C389',
+        rRed: '#EF4136',
         rOffwhite: '#F8F8FD',
         rGrayLightest: '#F7F7FD',
         rGrayLight: '#F2F2FC',


### PR DESCRIPTION
- feat: validate pin input while confirming transaction

Users are now required to enter the correct pin to perform a Token Transfer,
Stake Tokens, and Unstake Tokens. Users see inline validation of the PIN and the
confirm button is disabled if the pin is invalid.

Screenrecording: https://www.loom.com/share/c5f4353e65114923b707bcdf132db513
