### PR TITLE
Polish validation errors

### DIFF
--- a/src/components/FormField.vue
+++ b/src/components/FormField.vue
@@ -1,0 +1,51 @@
+<template>
+  <Field
+    :type="type"
+    :name="name"
+    :step="step"
+    class="focus:outline-none focus:ring-transparent focus:shadow-none focus:border-rGreen border-t-0 border-l-0 border-r-0 border-b border-rBlacks px-0"
+    :placeholder="placeholder"
+    :rules="rules"
+    :data-ci="dataCi"
+  ></Field>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import { Field } from 'vee-validate'
+
+const FormField = defineComponent({
+  components: {
+    Field
+  },
+
+  props: {
+    type: {
+      type: String,
+      required: true
+    },
+    name: {
+      type: String,
+      required: true
+    },
+    placeholder: {
+      type: String,
+      required: true
+    },
+    rules: {
+      type: [String, Object],
+      required: true
+    },
+    dataCi: {
+      type: String,
+      required: false
+    },
+    step: {
+      type: String,
+      required: false
+    }
+  }
+})
+
+export default FormField
+</script>

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -94,7 +94,10 @@ const messages = {
       cancelButton: 'Cancel',
       confirmButton: 'Confirm',
       sendButton: 'Send',
-      insufficientFunds: 'Sorry, but you don\'t have any tokens to send!'
+      insufficientFunds: 'Sorry, but you don\'t have any tokens to send!',
+      recipientPlaceholder: 'enter address',
+      amountPlaceholder: 'Available balance ...',
+      messagePlaceholder: 'Add an optional message'
     },
     staking: {
       currentStakesHeading: 'Current Stakes',

--- a/src/views/CreateWallet/CreateWalletCreatePasscode.vue
+++ b/src/views/CreateWallet/CreateWalletCreatePasscode.vue
@@ -1,25 +1,29 @@
 <template>
   <div data-ci="create-wallet-create-passcode-component">
     <form class="flex flex-col w-96">
-      <Field
-        type="password"
-        name="password"
-        class="focus:outline-none focus:ring-transparent focus:shadow-none border-t-0 border-l-0 border-r-0 border-b border-rBlack mb-14"
-        :placeholder="$t('createWallet.passwordPlaceholder')"
-        rules="required"
-        data-ci="create-wallet-passcode-input"
-      ></Field>
-      <FormErrorMessage name="password" />
+      <div class="mb-14">
+        <FormField
+          type="password"
+          name="password"
+          class="w-full"
+          :placeholder="$t('createWallet.passwordPlaceholder')"
+          rules="required"
+          data-ci="create-wallet-passcode-input"
+        />
+        <FormErrorMessage name="password" />
+      </div>
 
-      <Field
-        type="password"
-        name="confirmation"
-        class="focus:outline-none focus:ring-transparent focus:shadow-none border-t-0 border-l-0 border-r-0 border-b border-rBlack mb-56"
-        :placeholder="$t('createWallet.passwordConfirmationPlaceholder')"
-        rules="required|confirmed:@password"
-        data-ci="create-wallet-confirm-input"
-      ></Field>
-      <FormErrorMessage name="confirmation" />
+      <div class="mb-56">
+        <FormField
+          type="password"
+          name="confirmation"
+          class="w-full"
+          :placeholder="$t('createWallet.passwordConfirmationPlaceholder')"
+          rules="required|confirmed:@password"
+          data-ci="create-wallet-confirm-input"
+        />
+        <FormErrorMessage name="confirmation" />
+      </div>
     </form>
 
     <button
@@ -36,8 +40,9 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-import { useForm, Field } from 'vee-validate'
+import { useForm } from 'vee-validate'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
+import FormField from '@/components/FormField.vue'
 
 interface PasswordForm {
   password: string;
@@ -46,7 +51,7 @@ interface PasswordForm {
 
 const CreateWalletCreatePasscode = defineComponent({
   components: {
-    Field,
+    FormField,
     FormErrorMessage
   },
 

--- a/src/views/CreateWallet/CreateWalletCreatePin.vue
+++ b/src/views/CreateWallet/CreateWalletCreatePin.vue
@@ -6,7 +6,7 @@
         :values="values.pin"
         :autofocus="updatingFirstInput"
         @finished="handleFinished"
-        class="mb-14"
+        class="mb-14 max-w-sm"
         data-ci="create-wallet-pin-input"
       >
       </pin-input>
@@ -14,7 +14,7 @@
         name="confirmation"
         :values="values.confirmation"
         :autofocus="!updatingFirstInput"
-        class="mb-48"
+        class="mb-48 max-w-sm"
         data-ci="create-wallet-confirm-input"
       >
       </pin-input>

--- a/src/views/Home/HomeEnterPasscode.vue
+++ b/src/views/Home/HomeEnterPasscode.vue
@@ -8,14 +8,14 @@
       </svg>
 
       <div class="mb-10 flex flex-col">
-        <Field
+        <FormField
           type="password"
           name="password"
-          class="focus:outline-none focus:ring-transparent focus:shadow-none border-t-0 border-l-0 border-r-0 border-b border-rBlack pl-8"
+          class="pl-8"
           :placeholder="$t('home.passwordPlaceholder')"
           rules="required"
           data-ci="create-wallet-passcode-input"
-        ></Field>
+        />
         <FormErrorMessage name="password" class="mt-4 text-sm text-red-400" />
       </div>
     </form>
@@ -34,8 +34,9 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-import { useForm, Field } from 'vee-validate'
+import { useForm } from 'vee-validate'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
+import FormField from '@/components/FormField.vue'
 
 interface PasswordForm {
   password: string;
@@ -43,7 +44,7 @@ interface PasswordForm {
 
 const HomeEnterPasscode = defineComponent({
   components: {
-    Field,
+    FormField,
     FormErrorMessage
   },
 

--- a/src/views/Settings/SettingsResetPassword.vue
+++ b/src/views/Settings/SettingsResetPassword.vue
@@ -5,38 +5,38 @@
     </div>
 
     <div class="mb-14">
-      <Field
+      <FormField
         type="password"
         name="currentPassword"
-        class="focus:outline-none focus:ring-transparent focus:shadow-none border-t-0 border-l-0 border-r-0 border-b border-rBlack w-full"
+        class="w-full"
         :placeholder="$t('createWallet.passwordPlaceholder')"
         rules="required"
         data-ci="create-wallet-passcode-input"
-      ></Field>
+      />
       <FormErrorMessage name="currentPassword" />
     </div>
 
     <div class="mb-14">
-      <Field
+      <FormField
         type="password"
         name="password"
-        class="focus:outline-none focus:ring-transparent focus:shadow-none border-t-0 border-l-0 border-r-0 border-b border-rBlack w-full"
+        class="w-full"
         :placeholder="$t('createWallet.passwordPlaceholder')"
         rules="required"
         data-ci="create-wallet-passcode-input"
-      ></Field>
+      />
       <FormErrorMessage name="password" />
     </div>
 
     <div class="mb-56">
-      <Field
+      <FormField
         type="password"
         name="confirmation"
-        class="focus:outline-none focus:ring-transparent focus:shadow-none border-t-0 border-l-0 border-r-0 border-b border-rBlack w-full"
+        class="w-full"
         :placeholder="$t('createWallet.passwordConfirmationPlaceholder')"
         rules="required|confirmed:@password"
         data-ci="create-wallet-confirm-input"
-      ></Field>
+      />
       <FormErrorMessage name="confirmation" />
     </div>
 
@@ -53,16 +53,17 @@
 
 <script lang="ts">
 import { defineComponent, onUnmounted } from 'vue'
-import { useForm, Field } from 'vee-validate'
+import { useForm } from 'vee-validate'
 import { Keystore, KeystoreT } from '@radixdlt/crypto'
 import { Radix, mockedAPI } from '@radixdlt/application'
 import { MnemomicT, WalletT } from '@radixdlt/account'
 import { Result } from 'neverthrow'
+import { Subscription } from 'rxjs'
+import { ref } from '@nopr3d/vue-next-rx'
 import { useStore } from '@/store'
 import { touchKeystore, createWalletFromMnemonicAndPasscode } from '@/actions/vue/create-wallet'
-import { Subscription } from 'rxjs'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
-import { ref } from '@nopr3d/vue-next-rx'
+import FormField from '@/components/FormField.vue'
 
 interface PasswordForm {
   currentPassword: string;
@@ -72,7 +73,7 @@ interface PasswordForm {
 
 const SettingsResetPassword = defineComponent({
   components: {
-    Field,
+    FormField,
     FormErrorMessage
   },
 

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -17,31 +17,32 @@
           </div>
           <div class="py-3 px-4 text-sm border-b border-rGray">
             <div class="text-rGrayDark mb-3">{{ $t('staking.validatorLabel')}}</div>
-            <Field
+            <FormField
               name="validator"
-              class="w-full border-b border-rBlack leading-8 focus:ring-0 focus:outline-none focus:border-rGreen"
+              type="text"
+              class="w-full"
               :placeholder="$t('staking.validatorPlaceholder')"
               rules="required|validAddress"
-            ></Field>
+            />
             <FormErrorMessage name="validator" class="mt-4 text-sm text-red-400" />
           </div>
           <div class="py-3 px-4 text-sm">
             <div class="flex flex-row">
               <div class="flex flex-col mr-3 flex-1">
                 <div class="text-rGrayDark mb-3">{{ $t('staking.amountLabel')}}</div>
-                <Field
+                <FormField
                   name="amount"
                   type="number"
                   step="any"
-                  class="w-full border-t-0 border-r-0 border-l-0 p-0 border-b border-rBlack leading-8 focus:ring-0 focus:outline-none focus:border-rGreen text-sm"
+                  class="w-full text-sm"
                   :placeholder="amountPlaceholder"
                   rules="required|validAmount"
-                ></Field>
+                />
                 <FormErrorMessage name="amount" class="mt-4 text-sm text-red-400" />
               </div>
-              <div class="flex flex-col w-32 justify-between">
+              <div class="flex flex-col w-32 ">
                 <div class="text-rGrayDark mb-3">{{ $t('staking.feeLabel')}}</div>
-                <div class="pb-2">0.000</div>
+                <div class="pt-4 pb-2">0.000</div>
               </div>
             </div>
           </div>
@@ -86,13 +87,14 @@
 import { AddressT } from '@radixdlt/account'
 import { StakePosition, TokenBalance, TokenBalances, UnstakePosition } from '@radixdlt/application'
 import { defineComponent, PropType } from 'vue'
-import { useForm, Field } from 'vee-validate'
+import { useForm } from 'vee-validate'
 import StakeListItem from '@/components/StakeListItem.vue'
 import { Amount, AmountT, Denomination } from '@radixdlt/primitives'
 import { safelyUnwrapAddress, safelyUnwrapAmount, validateAmountOfType } from '@/helpers/validateRadixTypes'
 import TabsTab from '@/components/TabsTab.vue'
 import TabsContent from '@/components/TabsContent.vue'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
+import FormField from '@/components/FormField.vue'
 
 interface StakeForm {
   validator: string;
@@ -101,7 +103,7 @@ interface StakeForm {
 
 const WalletStaking = defineComponent({
   components: {
-    Field,
+    FormField,
     FormErrorMessage,
     StakeListItem,
     TabsContent,

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flex flex-col flex-1 min-w-0 overflow-y-scroll">
-    <div class="bg-rGrayLightest py-6 px-8 bg-gray h-full">
+  <div class="flex flex-col flex-1 min-w-0 overflow-y-scroll bg-rGrayLightest">
+    <div class="py-6 px-8 bg-gray h-full">
       <div class="flex justify-between mb-16">
         <h3 class="font-medium text-rBlack">{{ $t('transaction.transactionHeading') }}</h3>
         <div class="flex items-center text-rGrayDark">
@@ -25,12 +25,13 @@
           <div class="border-b border-rGray py-7 flex items-center">
             <div class="w-32 text-right text-rGrayDark mr-8">{{ $t('transaction.toLabel') }}</div>
             <div class="flex-1 pr-8">
-              <Field
+              <FormField
                 name="recipient"
-                class="w-full border-b border-rBlack leading-8 focus:ring-0 focus:outline-none focus:border-rGreen"
-                placeholder="enter address"
+                type="text"
+                class="w-full"
+                :placeholder="$t('transaction.recipientPlaceholder')"
                 rules="required|validAddress"
-              ></Field>
+              />
               <FormErrorMessage name="recipient" class="mt-4 text-sm text-red-400" />
             </div>
           </div>
@@ -39,22 +40,22 @@
             <div class="w-32 text-right text-rGrayDark mr-8">{{ $t('transaction.amountLabel') }}</div>
             <div class="flex-1 flex items-start pr-8">
               <div class="flex flex-col flex-1 mr-3">
-                <Field
+                <FormField
                   name="amount"
                   type="number"
                   step="any"
-                  class="w-full border-t-0 border-r-0 border-l-0 py-0 border-b border-rBlack leading-8 focus:ring-0 focus:outline-none focus:border-rGreen"
+                  class="w-full"
                   :placeholder="amountPlaceholder"
                   :rules="{
                     required: true,
                     validAmount: true,
                     insufficientFunds: this.selectedCurrency.amount.toString()
                   }"
-                ></Field>
+                />
                 <FormErrorMessage name="amount" class="mt-4 text-sm text-red-400" />
               </div>
               <select
-                class="border-t-0 border-r-0 border-l-0 py-1 border-rBlack focus:ring-0 focus:outline-none focus:border-rGreen"
+                class="border-t-0 border-r-0 border-l-0 py-2 border-rBlack focus:ring-0 focus:outline-none focus:border-rGreen"
                 v-model="currency"
               >
                 <option
@@ -71,12 +72,13 @@
           <div class="border-b border-rGray  py-7 flex items-center">
             <div class="w-32 text-right text-rGrayDark mr-8">{{ $t('transaction.messageLabel') }}</div>
             <div class="flex-1 pr-8">
-              <Field
+              <FormField
                 name="message"
-                class="w-full border-b border-rBlack leading-8 focus:ring-0 focus:outline-none focus:border-rGreen"
-                placeholder="Add an optional message"
+                type="text"
+                class="w-full"
+                :placeholder="$t('transaction.messagePlaceholder')"
                 rules=""
-              ></Field>
+              />
               <FormErrorMessage name="message" class="mt-4 text-sm text-red-400" />
             </div>
           </div>
@@ -107,9 +109,10 @@ import { AddressT } from '@radixdlt/account'
 import { defineComponent, PropType } from 'vue'
 import { safelyUnwrapAddress, safelyUnwrapAmount, validateAmountOfType } from '@/helpers/validateRadixTypes'
 import { TokenBalance, TokenBalances } from '@radixdlt/application'
-import { useForm, Field } from 'vee-validate'
+import { useForm } from 'vee-validate'
 import ClickToCopy from '@/components/ClickToCopy.vue'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
+import FormField from '@/components/FormField.vue'
 
 interface TransactionForm {
   recipient: string;
@@ -120,7 +123,7 @@ interface TransactionForm {
 const WalletTransaction = defineComponent({
   components: {
     ClickToCopy,
-    Field,
+    FormField,
     FormErrorMessage
   },
 
@@ -155,7 +158,7 @@ const WalletTransaction = defineComponent({
     },
     amountPlaceholder (): string {
       const availableBalanceForCurrency = this.selectedCurrency && this.selectedCurrency.amount.toString()
-      return `Available balance ... ${availableBalanceForCurrency} `
+      return `${this.$t('transaction.amountPlaceholder')} ${availableBalanceForCurrency} `
     }
   },
 


### PR DESCRIPTION
- chore: Use reusable error message component on all forms
- chore: Use reusable form field component on all forms

Cleans up form components so they are all pulling from the same reusable components. 
Consolidates tailwind styles into these two components and ensures all validation errors
match the design