### PR TITLE
Reusable submit button

### DIFF
--- a/src/components/ButtonSubmit.vue
+++ b/src/components/ButtonSubmit.vue
@@ -1,9 +1,9 @@
 <template>
   <button
     type="submit"
-    class="inline-flex items-center justify-center px-6 py-4 border font-normal leading-snug rounded transition-colors w-72 mx-auto"
-    :class="{ 'bg-rGray border-rGray text-rGrayDark cursor-not-allowed': disableSubmit, 'bg-rGreen border-rGreen text-white': !disableSubmit }"
-    :disabled="disableSubmit"
+    class="inline-flex items-center justify-center px-6 py-4 border font-normal leading-snug rounded transition-colors w-72"
+    :class="{ 'bg-rGray border-rGray text-rGrayDark cursor-not-allowed': disabled, 'bg-rGreen border-rGreen text-white': !disabled }"
+    :disabled="disabled"
   >
     <slot></slot>
   </button>
@@ -14,7 +14,7 @@ import { defineComponent } from 'vue'
 
 const ButtonSubmit = defineComponent({
   props: {
-    disableSubmit: {
+    disabled: {
       type: Boolean,
       required: true
     }

--- a/src/views/Account/AccountEditName.vue
+++ b/src/views/Account/AccountEditName.vue
@@ -11,14 +11,9 @@
         :placeholder="$t('account.nameInputPlaceholder')"
       />
 
-      <button
-        type="submit"
-        class="inline-flex items-center justify-center px-6 py-4 border font-normal leading-snug rounded w-full transition-colors"
-        :class="{ 'bg-rGray border-rGray text-rGrayDark cursor-not-allowed': !name, 'bg-rGreen border-rGreen text-white': !!name }"
-        :disabed="!name"
-      >
+      <ButtonSubmit :disabled="!name">
         {{ $t('account.updateNameButton') }}
-      </button>
+      </ButtonSubmit>
     </form>
 
     <img src="@/assets/account.svg" class="absolute right-0 top-0 h-full" />
@@ -30,8 +25,13 @@ import { defineComponent, PropType, watch } from 'vue'
 import { getAccountName, saveAccountName } from '@/actions/vue/data-store'
 import { AddressT } from '@radixdlt/account'
 import { ref } from '@nopr3d/vue-next-rx'
+import ButtonSubmit from '@/components/ButtonSubmit.vue'
 
 const AccountEditName = defineComponent({
+  components: {
+    ButtonSubmit
+  },
+
   props: {
     activeAddress: {
       type: Object as PropType<AddressT>,

--- a/src/views/CreateWallet/CreateWalletCreatePasscode.vue
+++ b/src/views/CreateWallet/CreateWalletCreatePasscode.vue
@@ -1,6 +1,6 @@
 <template>
   <div data-ci="create-wallet-create-passcode-component">
-    <form class="flex flex-col w-96">
+    <form class="flex flex-col w-96" @submit.prevent="$emit('confirm', values.password)">
       <div class="mb-14">
         <FormField
           type="password"
@@ -24,17 +24,11 @@
         />
         <FormErrorMessage name="confirmation" />
       </div>
-    </form>
 
-    <button
-      @click="$emit('confirm', values.password)"
-      type="button"
-      class="inline-flex items-center justify-center px-6 py-5 border font-normal leading-snug rounded w-96"
-      :class="{ 'bg-rGray border-rGray text-rGrayDark cursor-not-allowed': disableSubmit, 'bg-rGreen border-rGreen text-white': !disableSubmit }"
-      :disabled="disableSubmit"
-    >
-      {{ $t('createWallet.passwordButton') }}
-    </button>
+      <ButtonSubmit class="w-96" :disabled="disableSubmit">
+        {{ $t('createWallet.passwordButton') }}
+      </ButtonSubmit>
+    </form>
   </div>
 </template>
 
@@ -43,6 +37,7 @@ import { defineComponent } from 'vue'
 import { useForm } from 'vee-validate'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
 import FormField from '@/components/FormField.vue'
+import ButtonSubmit from '@/components/ButtonSubmit.vue'
 
 interface PasswordForm {
   password: string;
@@ -51,6 +46,7 @@ interface PasswordForm {
 
 const CreateWalletCreatePasscode = defineComponent({
   components: {
+    ButtonSubmit,
     FormField,
     FormErrorMessage
   },

--- a/src/views/CreateWallet/CreateWalletCreatePin.vue
+++ b/src/views/CreateWallet/CreateWalletCreatePin.vue
@@ -1,6 +1,6 @@
 <template>
   <div data-ci="create-wallet-create-pin-component">
-    <form>
+    <form @submit.prevent="$emit('confirm', this.values.pin)">
       <pin-input
         name="pin"
         :values="values.pin"
@@ -18,17 +18,11 @@
         data-ci="create-wallet-confirm-input"
       >
       </pin-input>
-    </form>
 
-    <button
-      @click="$emit('confirm', this.values.pin)"
-      type="button"
-      class="inline-flex items-center justify-center px-6 py-5 border font-normal leading-snug rounded w-96"
-      :class="{ 'bg-rGray border-rGray text-rGrayDark cursor-not-allowed': disableSubmit, 'bg-rGreen border-rGreen text-white': !disableSubmit }"
-      :disabled="disableSubmit"
-    >
-      {{ $t('createWallet.pinButton') }}
-    </button>
+      <ButtonSubmit class="w-96" :disabled="disableSubmit">
+        {{ $t('createWallet.pinButton') }}
+      </ButtonSubmit>
+    </form>
   </div>
 </template>
 
@@ -36,6 +30,7 @@
 import { defineComponent } from 'vue'
 import { useForm } from 'vee-validate'
 import PinInput from '@/components/PinInput.vue'
+import ButtonSubmit from '@/components/ButtonSubmit.vue'
 
 interface PasswordForm {
   pin: string;
@@ -44,6 +39,7 @@ interface PasswordForm {
 
 const CreateWalletCreatePin = defineComponent({
   components: {
+    ButtonSubmit,
     PinInput
   },
 

--- a/src/views/CreateWallet/CreateWalletEnterMnemonic.vue
+++ b/src/views/CreateWallet/CreateWalletEnterMnemonic.vue
@@ -1,5 +1,5 @@
 <template>
-  <div data-ci="create-wallet-enter-mnemonic-component">
+  <form data-ci="create-wallet-enter-mnemonic-component" @submit.prevent="$emit('confirm')">
     <div class="flex flex-wrap mb-4">
       <div v-for="(word, i) in mnemonic" :key="i" class="w-1/4 mb-14">
         <mnemonic-input
@@ -10,33 +10,28 @@
       </div>
     </div>
 
-    <button
-      data-ci="create-wallet-enter-mnemonic-component--confirm-button"
-      @click="$emit('confirm')"
-      type="button"
-      class="inline-flex items-center justify-center px-6 py-5 border font-normal leading-snug rounded w-96"
-      :class="{ 'bg-rGray border-rGray text-rGrayDark cursor-not-allowed': !inputsMatch, 'bg-rGreen border-rGreen text-white': inputsMatch }"
-      :disabled="!inputsMatch"
-    >
+    <ButtonSubmit data-ci="create-wallet-enter-mnemonic-component--confirm-button" class="w-96" :disabled="!inputsMatch">
       {{buttonText}}
-    </button>
-  </div>
+    </ButtonSubmit>
+  </form>
 </template>
 
 <script lang="ts">
 import { defineComponent, PropType } from 'vue'
 import MnemonicInput from '@/components/MnemonicInput.vue'
+import ButtonSubmit from '@/components/ButtonSubmit.vue'
 
 const CreateWalletViewMnemonic = defineComponent({
+  components: {
+    ButtonSubmit,
+    MnemonicInput
+  },
+
   props: {
     mnemonic: {
       type: Array as PropType<Array<string>>,
       required: true
     }
-  },
-
-  components: {
-    MnemonicInput
   },
 
   data () {

--- a/src/views/CreateWallet/CreateWalletViewMnemonic.vue
+++ b/src/views/CreateWallet/CreateWalletViewMnemonic.vue
@@ -6,20 +6,21 @@
       </div>
     </div>
 
-    <button
-      @click="$emit('confirm')"
-      type="button"
-      class="inline-flex items-center justify-center px-6 py-5 bg-rGreen border border-rGreen text-white font-normal leading-snug rounded"
-    >
+    <ButtonSubmit @click="$emit('confirm')" :disabled="false" class="w-96">
       {{ $t('createWallet.recoveryButtonOne') }}
-    </button>
+    </ButtonSubmit>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent, PropType } from 'vue'
+import ButtonSubmit from '@/components/ButtonSubmit.vue'
 
 const CreateWalletViewMnemonic = defineComponent({
+  components: {
+    ButtonSubmit
+  },
+
   props: {
     mnemonic: {
       type: Array as PropType<Array<string>>,

--- a/src/views/Home/HomeEnterPasscode.vue
+++ b/src/views/Home/HomeEnterPasscode.vue
@@ -1,7 +1,7 @@
 <template>
   <div data-ci="create-wallet-create-passcode-component">
     <p class="text-rBlack text-base text-center mb-10">{{ $t('home.passwordTitle') }}</p>
-    <form class="flex flex-col w-96 relative">
+    <form @submit.prevent="$emit('submit', values.password)" class="flex flex-col w-96 relative">
       <svg width="24" height="31" viewBox="0 0 24 31" fill="none" xmlns="http://www.w3.org/2000/svg" class="absolute inset-0 opacity transition-opacity" :class="{'opacity-40': disableSubmit}">
         <path d="M3.98975 12.1227V8.91388C3.98975 4.54318 7.55907 1 11.962 1C16.3649 1 19.9342 4.54318 19.9342 8.91388V12.1227" stroke="#00C389" stroke-width="1.5" stroke-miterlimit="10"/>
         <path d="M1 30.3952V11.8662H4.23024H19.7567H22.9869V29.4213H5.57166" stroke="#052CC0" stroke-width="1.5" stroke-miterlimit="10"/>
@@ -18,17 +18,11 @@
         />
         <FormErrorMessage name="password" class="mt-4 text-sm text-red-400" />
       </div>
-    </form>
 
-    <button
-      @click="$emit('submit', values.password)"
-      type="button"
-      class="inline-flex items-center justify-center px-6 py-5 border font-normal leading-snug rounded w-96 transition-colors"
-      :class="{ 'bg-rGray border-rGray text-rGrayDark cursor-not-allowed': disableSubmit, 'bg-rGreen border-rGreen text-white': !disableSubmit }"
-      :disabled="disableSubmit"
-    >
-      {{ $t('home.passwordButton') }}
-    </button>
+      <ButtonSubmit class="w-96" :disabled="disableSubmit">
+        {{ $t('home.passwordButton') }}
+      </ButtonSubmit>
+    </form>
   </div>
 </template>
 
@@ -37,6 +31,7 @@ import { defineComponent } from 'vue'
 import { useForm } from 'vee-validate'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
 import FormField from '@/components/FormField.vue'
+import ButtonSubmit from '@/components/ButtonSubmit.vue'
 
 interface PasswordForm {
   password: string;
@@ -44,6 +39,7 @@ interface PasswordForm {
 
 const HomeEnterPasscode = defineComponent({
   components: {
+    ButtonSubmit,
     FormField,
     FormErrorMessage
   },

--- a/src/views/RestoreWallet/RestoreWalletEnterMnemonic.vue
+++ b/src/views/RestoreWallet/RestoreWalletEnterMnemonic.vue
@@ -1,5 +1,5 @@
 <template>
-  <div data-ci="create-wallet-enter-mnemonic-component">
+  <form data-ci="create-wallet-enter-mnemonic-component" @submit.prevent="$emit('confirm', inputWords)">
     <div class="flex flex-wrap mb-4">
       <div v-for="(word, i) in inputWords" :key="i" class="w-1/4 mb-14">
         <mnemonic-input
@@ -10,25 +10,20 @@
       </div>
     </div>
 
-    <button
-      data-ci="create-wallet-enter-mnemonic-component--confirm-button"
-      @click="$emit('confirm', inputWords)"
-      type="button"
-      class="inline-flex items-center justify-center px-6 py-5 border font-normal leading-snug rounded w-96"
-      :class="{ 'bg-rGray border-rGray text-rGrayDark cursor-not-allowed': !inputValid, 'bg-rGreen border-rGreen text-white': inputValid }"
-      :disabled="!inputValid"
-    >
+    <ButtonSubmit data-ci="create-wallet-enter-mnemonic-component--confirm-button" class="w-96" :disabled="!inputValid">
       {{buttonText}}
-    </button>
-  </div>
+    </ButtonSubmit>
+  </form>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue'
 import MnemonicInput from '@/components/MnemonicInput.vue'
+import ButtonSubmit from '@/components/ButtonSubmit.vue'
 
 const RestoreWalletEnterMnemonic = defineComponent({
   components: {
+    ButtonSubmit,
     MnemonicInput
   },
 

--- a/src/views/Settings/SettingsResetPassword.vue
+++ b/src/views/Settings/SettingsResetPassword.vue
@@ -40,14 +40,9 @@
       <FormErrorMessage name="confirmation" />
     </div>
 
-    <button
-      type="submit"
-      class="inline-flex items-center justify-center px-6 py-5 border font-normal leading-snug rounded w-96"
-      :class="{ 'bg-rGray border-rGray text-rGrayDark cursor-not-allowed': disableSubmit, 'bg-rGreen border-rGreen text-white': !disableSubmit }"
-      :disabled="disableSubmit"
-    >
+    <ButtonSubmit class="w-96" :disabled="disableSubmit">
       {{ $t('createWallet.passwordButton') }}
-    </button>
+    </ButtonSubmit>
   </form>
 </template>
 
@@ -64,6 +59,7 @@ import { useStore } from '@/store'
 import { touchKeystore, createWalletFromMnemonicAndPasscode } from '@/actions/vue/create-wallet'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
 import FormField from '@/components/FormField.vue'
+import ButtonSubmit from '@/components/ButtonSubmit.vue'
 
 interface PasswordForm {
   currentPassword: string;
@@ -73,6 +69,7 @@ interface PasswordForm {
 
 const SettingsResetPassword = defineComponent({
   components: {
+    ButtonSubmit,
     FormField,
     FormErrorMessage
   },

--- a/src/views/Settings/SettingsResetPin.vue
+++ b/src/views/Settings/SettingsResetPin.vue
@@ -9,7 +9,7 @@
       name="currentPin"
       :values="values.currentPin"
       :autofocus="activePin == 0"
-      class="mb-8 mx-auto"
+      class="mb-8 max-w-sm"
       data-ci="current-pin"
       @finished="handleValidatePin"
       @click="activePin = 0"
@@ -21,7 +21,7 @@
       name="pin"
       :values="values.pin"
       :autofocus="activePin == 1"
-      class="mb-8 mx-auto"
+      class="mb-8 max-w-sm"
       data-ci="pin"
       @finished="activePin = 2"
       @click="activePin = 1"
@@ -33,21 +33,16 @@
       name="confirmation"
       :values="values.confirmation"
       :autofocus="activePin == 2"
-      class="mx-auto mb-8"
+      class="mb-8 max-w-sm"
       data-ci="confirmation"
       @finished="activePin = 3"
       @click="activePin = 2"
     >
     </pin-input>
 
-    <button
-      type="submit"
-      class="inline-flex items-center justify-center px-6 py-4 border font-normal leading-snug rounded transition-colors w-72 mx-auto"
-      :class="{ 'bg-rGray border-rGray text-rGrayDark cursor-not-allowed': disableSubmit, 'bg-rGreen border-rGreen text-white': !disableSubmit }"
-      :disabed="!disableSubmit"
-    >
+    <ButtonSubmit class="w-72 mx-auto" :disabled="disableSubmit">
       {{ $t('transaction.confirmButton') }}
-    </button>
+    </ButtonSubmit>
   </form>
 </template>
 
@@ -56,6 +51,7 @@ import { defineComponent } from 'vue'
 import { useForm } from 'vee-validate'
 import PinInput from '@/components/PinInput.vue'
 import { storePin, validatePin } from '@/actions/vue/create-wallet'
+import ButtonSubmit from '@/components/ButtonSubmit.vue'
 
 interface ResetPinForm {
   currentPin: string;
@@ -65,6 +61,7 @@ interface ResetPinForm {
 
 const SettingsResetPin = defineComponent({
   components: {
+    ButtonSubmit,
     PinInput
   },
 

--- a/src/views/Settings/SettingsRevealMnemonic.vue
+++ b/src/views/Settings/SettingsRevealMnemonic.vue
@@ -17,14 +17,14 @@
         </mnemonic-display>
       </div>
 
-      <button-submit
+      <ButtonSubmit
         v-if="mnemonicNotRequested"
-        :disableSubmit="false"
+        :disabled="false"
         @click="enteringPin = true"
         class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
       >
         {{ $t('settings.accessMnemonicButton') }}
-      </button-submit>
+      </ButtonSubmit>
 
       <template v-if="enteringPin">
         <div
@@ -46,12 +46,12 @@
             @finished="handleValidatePin"
           >
           </pin-input>
-          <button-submit
-            :disableSubmit="disableSubmit"
+          <ButtonSubmit
+            :disabled="disableSubmit"
             class="mb-9"
           >
             {{ $t('settings.accessMnemonicButton') }}
-          </button-submit>
+          </ButtonSubmit>
         </form>
       </template>
     </div>

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -38,14 +38,9 @@
       >
       </pin-input>
 
-      <button
-        type="submit"
-        class="inline-flex items-center justify-center px-6 py-4 border font-normal leading-snug rounded transition-colors w-72 mx-auto"
-        :class="{ 'bg-rGray border-rGray text-rGrayDark cursor-not-allowed': disableSubmit, 'bg-rGreen border-rGreen text-white': !disableSubmit }"
-        :disabed="!disableSubmit"
-      >
+      <ButtonSubmit class="w-72 mx-auto mt-5" :disabled="disableSubmit">
         {{ $t('transaction.confirmButton') }}
-      </button>
+      </ButtonSUbmit>
 
       <button
         class="text-rGrayDark py-4 px-4text-sm mx-auto"
@@ -70,6 +65,7 @@ import { defineComponent, PropType } from 'vue'
 import { useForm } from 'vee-validate'
 import BigAmount from '@/components/BigAmount.vue'
 import PinInput from '@/components/PinInput.vue'
+import ButtonSubmit from '@/components/ButtonSubmit.vue'
 import { validatePin } from '@/actions/vue/create-wallet'
 
 interface ConfirmationForm {
@@ -79,6 +75,7 @@ interface ConfirmationForm {
 const WalletConfirmTransactionModal = defineComponent({
   components: {
     BigAmount,
+    ButtonSubmit,
     PinInput
   },
 

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -48,12 +48,9 @@
           </div>
         </tabs-content>
 
-        <button
-          type="submit"
-          class="inline-flex items-center justify-center px-6 py-4 border font-normal leading-snug rounded w-full mt-12 transition-colors bg-rGreen border-rGreen text-white"
-        >
+        <ButtonSubmit class="mt-12" :disabled="false">
           {{ stakeButtonCopy }}
-        </button>
+        </ButtonSubmit>
       </form>
     </div>
 
@@ -95,6 +92,7 @@ import TabsTab from '@/components/TabsTab.vue'
 import TabsContent from '@/components/TabsContent.vue'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
 import FormField from '@/components/FormField.vue'
+import ButtonSubmit from '@/components/ButtonSubmit.vue'
 
 interface StakeForm {
   validator: string;
@@ -103,6 +101,7 @@ interface StakeForm {
 
 const WalletStaking = defineComponent({
   components: {
+    ButtonSubmit,
     FormField,
     FormErrorMessage,
     StakeListItem,
@@ -145,6 +144,7 @@ const WalletStaking = defineComponent({
       return this.activeForm === 'stake' ? this.$t('staking.stakeDisclaimer') : this.$t('staking.unstakeDisclaimer')
     },
     xrdToken (): TokenBalance | null {
+      console.log('xrdtoken', this.tokenBalances)
       if (this.tokenBalances.tokenBalances && this.tokenBalances.tokenBalances.length > 0) {
         return this.tokenBalances.tokenBalances.find((tb: TokenBalance) => tb.token.symbol === 'XRD') || null
       }
@@ -185,6 +185,7 @@ const WalletStaking = defineComponent({
       this.values.validator = validator.toString()
     },
     handleSubmitStake () {
+      console.log('submitting', this.meta, this.xrdToken)
       if (this.meta.valid && this.xrdToken) {
         const safeAddress = safelyUnwrapAddress(this.values.validator)
         const safeAmount = safelyUnwrapAmount(Number(this.values.amount))

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -89,12 +89,9 @@
           </div>
         </div>
 
-        <button
-          type="submit"
-          class="inline-flex items-center justify-center px-6 py-4 border font-normal leading-snug rounded w-52 transition-colors bg-rGreen border-rGreen text-white"
-        >
+        <ButtonSubmit :disabled="false" class="w-52 ml-full">
           {{ $t('transaction.sendButton') }}
-        </button>
+        </ButtonSubmit>
       </form>
 
       <div v-else>
@@ -113,6 +110,7 @@ import { useForm } from 'vee-validate'
 import ClickToCopy from '@/components/ClickToCopy.vue'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
 import FormField from '@/components/FormField.vue'
+import ButtonSubmit from '@/components/ButtonSubmit.vue'
 
 interface TransactionForm {
   recipient: string;
@@ -122,6 +120,7 @@ interface TransactionForm {
 
 const WalletTransaction = defineComponent({
   components: {
+    ButtonSubmit,
     ClickToCopy,
     FormField,
     FormErrorMessage


### PR DESCRIPTION
- chore: Use reusable submit button on all forms

Updates the code to use the same submit button with consolidated Tailwind
classes for all submit buttons. Also makes sure all forms are submitted from the
form element so users can press "enter" to submit