### PR TITLE
DO NOT MERGE: Exposing Node Tooling to the Renderer Function w/o Node Integration

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -43,7 +43,8 @@ async function createWindow () {
       nodeIntegration: (process.env
         .ELECTRON_NODE_INTEGRATION as unknown) as boolean,
       preload: path.join(__dirname, 'preload.js'),
-      devTools: isDevelopment
+      devTools: isDevelopment,
+      sandbox: true
     }
   })
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer, IpcRenderer } from 'electron'
+const _process = process
 
 declare global {
   interface Window {
@@ -13,6 +14,10 @@ contextBridge.exposeInMainWorld('ipcRenderer', {
   },
   invoke: (channel: string, args: string[]) =>
     ipcRenderer.invoke(channel, args)
+})
+
+contextBridge.exposeInMainWorld('process', {
+  process: _process
 })
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -244,6 +244,8 @@ const WalletIndex = defineComponent({
       loadingHistory.value = true
     }
 
+    console.log('Process', window.process)
+
     // Return home if wallet is undefined
     if (!store.state.wallet) router.push('/')
 


### PR DESCRIPTION
Hey @AbstractFruitFactory  - I thought this might be a helpful way to review this.

The way Electron advises us to expose Node.js APIs to the renderer is via the [preload](https://www.electronjs.org/docs/tutorial/quick-start#access-nodejs-from-the-renderer-with-a-preload-script) script functionality. This allows us to pick and choose which Node.JS APIs we expose without exposing the whole kit and caboodle. This draft PR exposes the Node `process` on the render's window object using  [contextBridge](https://www.electronjs.org/docs/api/context-bridge).

The [wallet](https://github.com/CityOfZion/neon-wallet) you were referencing is on an older version of Electron, v8.5.2, so they handle it a little differently in their [preload.js](https://github.com/CityOfZion/neon-wallet/blob/dev/preload.js).  I tried using a similar method, without success. I believe this is also no longer best practice, and the contextBridge method is preferred. 

You can see the results here:
<img width="1065" alt="Screen Shot 2021-05-27 at 9 40 41 AM" src="https://user-images.githubusercontent.com/102228/119836437-bdfe4f00-becf-11eb-8cf5-9603e2e87edd.png">
