### PR TITLE
fix: Replace number inputs with validated text fields

### DIFF
--- a/src/components/FormField.vue
+++ b/src/components/FormField.vue
@@ -2,7 +2,6 @@
   <Field
     :type="type"
     :name="name"
-    :step="step"
     :label="label"
     class="focus:outline-none focus:ring-transparent focus:shadow-none focus:border-rGreen border-t-0 border-l-0 border-r-0 border-b border-rBlack px-0"
     :placeholder="placeholder"
@@ -38,10 +37,6 @@ const FormField = defineComponent({
       required: true
     },
     dataCi: {
-      type: String,
-      required: false
-    },
-    step: {
       type: String,
       required: false
     },

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -44,7 +44,12 @@ defineRule('validValidator', (validatorString: string) => {
   return !!safeAddress
 })
 
-defineRule('validAmount', (amountString: number) => {
-  const safeAmount = safelyUnwrapAmount(Number(amountString))
-  return !!safeAmount
+defineRule('validAmount', (amountString: string) => {
+  const amountMatch = /^\d*\.?\d*$/
+  const amount = Number(amountString)
+  if (amount && amountString.match(amountMatch)) {
+    const safeAmount = safelyUnwrapAmount(amount)
+    return !!safeAmount
+  }
+  return false
 })

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -32,8 +32,7 @@
                 <div class="text-rGrayDark mb-3">{{ $t('staking.amountLabel')}}</div>
                 <FormField
                   name="amount"
-                  type="number"
-                  step="any"
+                  type="text"
                   class="w-full text-sm"
                   :placeholder="amountPlaceholder"
                   rules="required|validAmount"

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -44,8 +44,7 @@
                 <div class="flex flex-col flex-1 mr-3">
                   <FormField
                     name="amount"
-                    type="number"
-                    step="any"
+                    type="text"
                     class="w-full"
                     :placeholder="amountPlaceholder"
                     :rules="{


### PR DESCRIPTION
`type='number'` input elements are [problematic][1].  On the web, they
offer a myriad of bugs and strange behaviors.  This PR refactors the
amount input fields to use validators to validate an amount rather than
relying on an input field to sanitize the values as they arrive.

[1]: https://css-tricks.com/what-to-use-instead-of-number-inputs/