### PR TITLE
fix: Ensure most subscriptions are loaded before rendering the UI

### DIFF
--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -20,7 +20,7 @@
     >
     </wallet-sidebar-accounts>
 
-    <template v-if="activeAddress">
+    <template v-if="loaded">
       <template v-if="view == 'overview'">
         <wallet-overview
           v-if="!loadingBalances"
@@ -608,6 +608,12 @@ const WalletIndex = defineComponent({
   methods: {
     setView (view: string) {
       this.view = view
+    }
+  },
+
+  computed: {
+    loaded () : boolean {
+      return this.activeAddress != null && this.activeStakes != null && this.activeUnstakes != null && this.tokenBalances != null && this.nativeToken != null
     }
   }
 })


### PR DESCRIPTION
Quick fix for ensuring the UI has what it needs before rendering down the tree.