### PR TITLE
fix: Staking Confrmation Modal does include a message

### DIFF
--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -57,7 +57,7 @@
             </div>
           </div>
 
-          <div class="border-b border-rGray py-3.5 flex items-center">
+          <div class="border-b border-rGray py-3.5 flex items-center" v-if="activeMessage">
             <div class="w-24 text-right text-rGrayDark mr-8">{{ $t('transaction.messageLabel') }}</div>
             <div class="flex-1">
               <div class="flex">


### PR DESCRIPTION
The transaction confirmation modal was throwing an error because stake transactions do not include a message.