### PR TITLE
fix: Mac OS Builds should be signed

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
     needs: [release-please]
     if: github.ref == 'refs/heads/main'
     runs-on: ${{ matrix.os }}
-    env: 
+    env:
       GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
     strategy:
       matrix:
@@ -44,3 +44,5 @@ jobs:
           github_token: ${{ secrets.github_token }}
           use_vue_cli: true
           release: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          mac_certs: ${{ secrets.MAC_CERTS }}
+          mac_certs_passwords: ${{ secrets.MAC_CERTS_PASSWORD }}


### PR DESCRIPTION
I was able to sign a build locally with these certificates that are now stored in the repo secrets.  This should just work assuming I wrote the yaml correctly.