### PR TITLE
Revert fee calculation and add a loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "rxjs": "7.0.0",
     "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.0",
     "tailwindcss-filters": "^3.0.0",
-    "ts-debounce": "^3.0.0",
     "vee-validate": "^4.4.5",
     "vue": "^3.0.0",
     "vue-class-component": "^8.0.0-0",

--- a/src/components/FormField.vue
+++ b/src/components/FormField.vue
@@ -7,7 +7,6 @@
     :placeholder="placeholder"
     :rules="rules"
     :data-ci="dataCi"
-    :id="id"
   ></Field>
 </template>
 
@@ -42,10 +41,6 @@ const FormField = defineComponent({
       required: false
     },
     label: {
-      type: String,
-      required: false
-    },
-    id: {
       type: String,
       required: false
     }

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -103,6 +103,9 @@
 
       <settings-index v-if="view == 'settings' && !loading" />
     </template>
+    <template v-else>
+      <wallet-loading />
+    </template>
   </div>
 </template>
 

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -40,7 +40,6 @@
           :transactionFee="transactionFee"
           :hasCalculatedFee="hasCalculatedFee"
           @transferTokens="transferTokens"
-          @buildTransaction="buildTransaction"
           ref="walletTransactionComponent"
         />
         <wallet-loading v-else />
@@ -375,12 +374,11 @@ const WalletIndex = defineComponent({
       .pipe(mergeMap(() => radix.tokenBalances))
       .subscribe((tokenBalancesRes: TokenBalances) => { tokenBalances.value = tokenBalancesRes }))
 
-    const confirmAndExecuteTransaction = (transactionTracking: TransactionTracking, showConfirmation: boolean) => {
+    const confirmAndExecuteTransaction = (transactionTracking: TransactionTracking) => {
       const transactionDidComplete = new BehaviorSubject<boolean>(false)
       userDidCancel.next(false)
-      // if (showConfirmation) { transactionState.value = 'building' }
       transactionState.value = 'building'
-      if (showConfirmation) { shouldShowConfirmation.value = showConfirmation }
+      shouldShowConfirmation.value = true
       // Subscribe to initial userConfirmation and display modal
       const createUserConfirmation = userConfirmation
         .subscribe((txnToConfirm: ManualUserConfirmTX) => {
@@ -395,9 +393,7 @@ const WalletIndex = defineComponent({
       // Confirm transaction and move user to history view after they press confirm
       const watchUserDidConfirm = combineLatest<[ManualUserConfirmTX, boolean]>([userConfirmation, userDidConfirm])
         .subscribe(([txnToConfirm, didConfirm]: [ManualUserConfirmTX, boolean]) => {
-          if (!showConfirmation) {
-            if (didConfirm) { txnToConfirm.confirm() }
-          }
+          if (didConfirm) { txnToConfirm.confirm() }
         })
       subs.add(watchUserDidConfirm)
 
@@ -506,28 +502,6 @@ const WalletIndex = defineComponent({
     }
 
     // call transferTokens() with built options and subscribe to confirmation and results
-    const buildTransaction = (transferTokensInput: TransferTokensInput, message: MessageInTransaction, sc: TokenBalance) => {
-      let pollTXStatusTrigger: Observable<unknown>
-      transferInput.value = transferTokensInput
-      selectedCurrency.value = sc
-      activeMessage.value = message.plaintext
-      activeMessageInTransaction.value = message
-      const buildTransferTokens = (): TransferTokensOptions => ({
-        transferInput: transferTokensInput,
-        userConfirmation: userConfirmation,
-        pollTXStatusTrigger: pollTXStatusTrigger
-      })
-
-      const transactionTracking: TransactionTracking = radix.transferTokens({
-        ...buildTransferTokens(),
-        userConfirmation,
-        message
-      })
-
-      confirmAndExecuteTransaction(transactionTracking, false)
-    }
-
-    // call transferTokens() with built options and subscribe to confirmation and results
     const transferTokens = (transferTokensInput: TransferTokensInput, message: MessageInTransaction, sc: TokenBalance) => {
       let pollTXStatusTrigger: Observable<unknown>
       transferInput.value = transferTokensInput
@@ -547,7 +521,7 @@ const WalletIndex = defineComponent({
         message
       })
 
-      confirmAndExecuteTransaction(transactionTracking, true)
+      confirmAndExecuteTransaction(transactionTracking)
     }
 
     // call stakeTokens() with built options and subscribe to confirmation and results
@@ -568,7 +542,7 @@ const WalletIndex = defineComponent({
         userConfirmation
       })
 
-      confirmAndExecuteTransaction(stakingTransactionTracking, true)
+      confirmAndExecuteTransaction(stakingTransactionTracking)
     }
 
     // call unstakeTokens() with built options and subscribe to confirmation and results
@@ -589,7 +563,7 @@ const WalletIndex = defineComponent({
         userConfirmation
       })
 
-      confirmAndExecuteTransaction(unstakingTransactionTracking, true)
+      confirmAndExecuteTransaction(unstakingTransactionTracking)
     }
 
     historyPagination.next({ size: PAGE_SIZE })
@@ -682,7 +656,6 @@ const WalletIndex = defineComponent({
       nextPage,
       previousPage,
       requestFreeTokens,
-      buildTransaction,
 
       // child component refs
       walletTransactionComponent,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12993,11 +12993,6 @@ tryer@^1.0.1:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
-ts-debounce@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ts-debounce/-/ts-debounce-3.0.0.tgz#9beedf59c04de3b5bef8ff28bd6885624df357be"
-  integrity sha512-7jiRWgN4/8IdvCxbIwnwg2W0bbYFBH6BxFqBjMKk442t7+liF2Z1H6AUCcl8e/pD93GjPru+axeiJwFmRww1WQ==
-
 ts-loader@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-6.2.2.tgz#dffa3879b01a1a1e0a4b85e2b8421dc0dfff1c58"


### PR DESCRIPTION
We had previously attempted to eagerly pre-build transactions before the user chose to submit a transaction so that the fee could be calculated.  Even at a two second throttle, this caused both wallet ux issues and major performance problems on the network.  This PR reverts those eager pre-build changes and also adds a loader when switching accounts.