### PR TITLE
fix: Correctly type a pending transaction so it displays in history correctly

### DIFF
--- a/src/views/Wallet/WalletHistory.vue
+++ b/src/views/Wallet/WalletHistory.vue
@@ -129,7 +129,6 @@ const WalletHistory = defineComponent({
 
   computed: {
     transactionsWithMessages (): {tx: ExecutedTransaction, decryptedMessage?: string}[] {
-      console.log('recalculating messages')
       return this.transactions.map((tx) => {
         const msg = this.decryptedMessages.find((msg) => msg.id === tx.txID.toString())
         if (!msg) {

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -415,8 +415,7 @@ const WalletIndex = defineComponent({
       subs.add(transactionTracking.events
         .pipe(filter((trackingEvent: TransactionStateUpdate) => trackingEvent.eventUpdateType === 'INITIATED'))
         .subscribe((res: TransactionStateUpdate) => {
-          const transactionIntent = res as unknown as TransactionIntent
-          draftTransaction.value = transactionIntent
+          draftTransaction.value = (res as TransactionStateSuccess).transactionState as TransactionIntent
         }))
 
       // Track pending transactions augmented with actions array


### PR DESCRIPTION
<img width="945" alt="Screen Shot 2021-07-13 at 7 18 23 PM" src="https://user-images.githubusercontent.com/2738409/125537338-82f8dc20-25f7-488c-92a3-313a751dd241.png">
<img width="922" alt="Screen Shot 2021-07-13 at 7 19 32 PM" src="https://user-images.githubusercontent.com/2738409/125537343-538acb6c-a608-474e-9e53-6f97b15868f1.png">

The `TransactionStateUpdate` type was being cast first to an unknown then to a `TransactionIntent`, which I assume was done to get past a type error.  This PR stores the draftTransaction as the correct `TransactionIntent`