### PR TITLE
fix: Toast Updates

### DIFF
--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -4,17 +4,15 @@
 
 @tailwind utilities;
 
-@layer components {
-  .placeholder-sans::placeholder {
-    font-family: 'IBM Plex Sans', 'sans-serif';
-  }
-  
-  body {
-    user-select: none;
-  }
+.placeholder-sans::placeholder {
+  font-family: 'IBM Plex Sans', 'sans-serif';
+}
+
+body {
+  user-select: none;
+}
 
 
-  .Vue-Toastification__toast.Vue-Toastification__toast--success {
-    @apply px-4 py-3 text-white rounded-none bg-rGreen min-w-min min-h-0
-  }
+.Vue-Toastification__toast.Vue-Toastification__toast--success {
+  @apply px-4 py-3 text-white rounded-none bg-rGreen min-w-min min-h-0
 }

--- a/src/components/BigAmount.vue
+++ b/src/components/BigAmount.vue
@@ -12,6 +12,7 @@ import { copyToClipboard } from '@/actions/vue/create-wallet'
 import { defineComponent, PropType } from 'vue'
 import { AmountT } from '@radixdlt/application'
 import BigNumber from 'bignumber.js'
+import { useToast } from 'vue-toastification'
 
 BigNumber.set({
   ROUNDING_MODE: BigNumber.ROUND_FLOOR,
@@ -107,6 +108,11 @@ const BigAmount = defineComponent({
     }
   },
 
+  setup () {
+    const toast = useToast()
+    return { toast }
+  },
+
   computed: {
     numberForDisplay (): string {
       return asBigNumber(this.amount, false)
@@ -120,6 +126,7 @@ const BigAmount = defineComponent({
   methods: {
     copyText () {
       const value = asBigNumber(this.amount, true).replaceAll(',', '')
+      this.toast.success('Copied to Clipboard')
       copyToClipboard(value)
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ const options: PluginOptions = {
   closeButton: false,
   icon: false,
   maxToasts: 3,
+  timeout: 1500,
   hideProgressBar: true
 }
 


### PR DESCRIPTION
https://www.loom.com/share/a5be6bb6e1364c2da76063f4b96de68b

Improvements:

* Don't purge custom vendor styles by avoiding the `@layer` tailwind directive
* Currency amounts should also use a toast
* Toasts should stay on the screen for less time.