### PR TITLE
use high level method for unstakes

### DIFF
--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -281,11 +281,9 @@ const WalletIndex = defineComponent({
     subs.add(radix.accounts.subscribe((accountsRes: AccountsT) => { accounts.value = accountsRes }))
     subs.add(radix.activeAddress.subscribe((addressRes: AccountAddressT) => { activeAddress.value = addressRes }))
 
-    subs.add(radix.activeAddress.pipe(
-      switchMap((res: AccountAddressT) => radix.ledger.unstakesForAddress(res))
-    ).subscribe((unstakes: UnstakePositions) => {
+    radix.unstakingPositions.subscribe(unstakes => {
       activeUnstakes.value = unstakes
-    }))
+    })
 
     subs.add(radix.ledger.nativeToken().subscribe((nativeTokenRes: Token) => { nativeToken.value = nativeTokenRes }))
 


### PR DESCRIPTION
Depending on `radix.activeAddress()` to update unstakes does not work as expected, since the active address stream will only push new values when changing account (or when starting the app). 

Using the helper method `radix.unstakingPositions()` however, periodically pushes values and therefore will keep triggering the `subscribe` logic, updating the state as expected.