### PR TITLE
feat: add proper verify address modals everywhere

### DIFF
--- a/src/components/AccountListItem.vue
+++ b/src/components/AccountListItem.vue
@@ -23,7 +23,12 @@
     <div class="text-xs text-white relative z-20 flex justify-between">
       <span class="mr-2">{{ $t('wallet.addressLabel') }}</span>
       <span class="flex-1 w-full truncate font-mono">{{ displayAddress }}</span>
-      <click-to-copy :text="address" class="hover:text-rGreen active:text-rGreenDark" />
+      <click-to-copy
+        :address="address"
+        :checkForHardwareAddress=true
+        class="hover:text-rGreen active:text-rGreenDark"
+        @verifyHardwareAddress="$emit('verifyHardwareAddress')"
+      />
     </div>
   </div>
 </template>
@@ -97,7 +102,7 @@ const AccountListItem = defineComponent({
     }
   },
 
-  emits: ['edit']
+  emits: ['edit', 'verifyHardwareAddress']
 })
 
 export default AccountListItem

--- a/src/components/ActionListItemStakeTokens.vue
+++ b/src/components/ActionListItemStakeTokens.vue
@@ -10,7 +10,7 @@
     <div class="flex flex-col items-end">
       <div class="flex flex-row flex-1 min-w-0">
         <span>{{ $t('history.validatorLabel') }}:</span> <span class="ml-2 mr-1 min-w-0 font-mono">{{ displayAddress }}</span>
-        <click-to-copy :text="action.validator.toString()" />
+        <click-to-copy :address="action.validator.toString()" />
       </div>
     </div>
   </div>

--- a/src/components/ActionListItemTransferTokens.vue
+++ b/src/components/ActionListItemTransferTokens.vue
@@ -14,11 +14,11 @@
     <div class="flex flex-col items-end">
       <div v-if="!isRecipient" class="flex flex-row flex-1 min-w-0">
         <span>{{ $t('history.toLabel') }}:</span> <span class="ml-2 mr-1 min-w-0 font-mono">{{ displayAddress(action.to) }}</span>
-        <click-to-copy :text="action.to.toString()" />
+        <click-to-copy :address="action.to.toString()" />
       </div>
       <div v-if="isRecipient" class="flex flex-row flex-1 min-w-0">
         <span>{{ $t('history.fromLabel') }}:</span> <span class="ml-2 mr-1 min-w-0 font-mono">{{displayAddress(action.from) }}</span>
-        <click-to-copy :text="action.from.toString()" />
+        <click-to-copy :address="action.from.toString()" />
       </div>
     </div>
   </div>

--- a/src/components/ActionListItemUnstakeTokens.vue
+++ b/src/components/ActionListItemUnstakeTokens.vue
@@ -10,7 +10,7 @@
     <div class="flex flex-col items-end">
       <div class="flex flex-row flex-1 min-w-0 items-center">
         <span>{{ $t('history.validatorLabel') }}:</span> <span class="ml-2 mr-1 min-w-0 font-mono">{{ displayAddress }}</span>
-        <click-to-copy :text="action.validator.toString()" />
+        <click-to-copy :address="action.validator.toString()" />
       </div>
     </div>
   </div>

--- a/src/components/ClickToCopy.vue
+++ b/src/components/ClickToCopy.vue
@@ -11,12 +11,19 @@
 import { defineComponent } from 'vue'
 import { copyToClipboard } from '@/actions/vue/create-wallet'
 import { useToast } from 'vue-toastification'
+import { getHardwareWalletAddress } from '@/actions/vue/data-store'
 
 const ClickToCopy = defineComponent({
+
   props: {
-    text: {
+    address: {
       type: String,
       required: true
+    },
+    checkForHardwareAddress: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
 
@@ -27,10 +34,24 @@ const ClickToCopy = defineComponent({
 
   methods: {
     copyText () {
-      copyToClipboard(this.text)
-      this.toast.success('Copied to Clipboard')
+      if (this.checkForHardwareAddress) {
+        getHardwareWalletAddress().then(a => {
+          const hardwareAddress = a
+          if (hardwareAddress && this.address === hardwareAddress) {
+            this.$emit('verifyHardwareAddress')
+          } else {
+            copyToClipboard(this.address)
+            this.toast.success('Copied to Clipboard')
+          }
+        })
+      } else {
+        copyToClipboard(this.address)
+        this.toast.success('Copied to Clipboard')
+      }
     }
-  }
+  },
+
+  emits: ['verifyHardwareAddress']
 })
 
 export default ClickToCopy

--- a/src/components/StakeListItem.vue
+++ b/src/components/StakeListItem.vue
@@ -11,7 +11,7 @@
         </div>
         <div class="text-sm flex items-center text-rGrayMed font-mono">
           {{ validatorAddress }}
-          <click-to-copy :text="stake.validator.toString()" class="hover:text-rGreen active:text-rGreenDark" />
+          <click-to-copy :address="stake.validator.toString()" class="hover:text-rGreen active:text-rGreenDark" />
         </div>
         <div class="text-sm text-rBlack flex flex-row items-center justify-between mr-4">
           <span><big-amount :amount="stake.amount" /> <span class="text-rGrayDark ml-1 uppercase">{{ nativeToken.symbol }}</span></span>

--- a/src/views/Wallet/WalletHistory.vue
+++ b/src/views/Wallet/WalletHistory.vue
@@ -6,8 +6,11 @@
         <div class="flex items-center text-rBlack text-sm">
           <span class="text-rGrayDark mr-2">{{ $t('wallet.currentAddress') }}</span> <span class="font-mono text-rBlack">{{ activeAddress.toString() }}</span>
           <div class="hover:text-rGreen flex flex-row items-center cursor-pointer transition-colors">
-            <click-to-copy :text="activeAddress.toString()">
-            </click-to-copy>
+            <click-to-copy
+              :address="activeAddress.toString()"
+              :checkForHardwareAddress=true
+              @verifyHardwareAddress="$emit('verifyHardwareAddress')"
+            />
           </div>
         </div>
       </div>
@@ -125,7 +128,7 @@ const WalletHistory = defineComponent({
     }
   },
 
-  emits: ['next', 'previous', 'decryptMessage'],
+  emits: ['next', 'previous', 'decryptMessage', 'verifyHardwareAddress'],
 
   computed: {
     transactionsWithMessages (): {tx: ExecutedTransaction, decryptedMessage?: string}[] {

--- a/src/views/Wallet/WalletLedgerVerifyAddressModal.vue
+++ b/src/views/Wallet/WalletLedgerVerifyAddressModal.vue
@@ -11,7 +11,7 @@
             <div class="w-20 text-right text-rGrayDark mr-4">Address</div>
             <div class="flex-1 flex">
               {{ hardwareAddress }}
-              <click-to-copy :text="hardwareAddress" class="hover:text-rGreen active:text-rGreenDark ml-1" />
+              <click-to-copy :address="hardwareAddress" class="hover:text-rGreen active:text-rGreenDark ml-1" />
             </div>
           </div>
         </div>
@@ -29,17 +29,31 @@
 import { defineComponent } from 'vue'
 import ClickToCopy from '@/components/ClickToCopy.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
+import { copyToClipboard } from '@/actions/vue/create-wallet'
+import { useToast } from 'vue-toastification'
 
 const WalletLedgerVerifyAddressModal = defineComponent({
   components: {
-    ClickToCopy,
-    ButtonSubmit
+    ButtonSubmit,
+    ClickToCopy
   },
 
   props: {
     hardwareAddress: {
       type: String,
-      required: false
+      required: true
+    }
+  },
+
+  setup () {
+    const toast = useToast()
+    return { toast }
+  },
+
+  methods: {
+    copyText () {
+      copyToClipboard(this.hardwareAddress)
+      this.toast.success('Copied to Clipboard')
     }
   },
 

--- a/src/views/Wallet/WalletOverview.vue
+++ b/src/views/Wallet/WalletOverview.vue
@@ -6,8 +6,11 @@
         <div class="flex items-center text-rBlack text-sm">
           <span class="text-rGrayDark mr-2">{{ $t('wallet.currentAddress') }}</span> <span class="font-mono text-rBlack">{{ activeAddress.toString() }}</span>
           <div class="hover:text-rGreen flex flex-row items-center cursor-pointer transition-colors">
-            <click-to-copy :text="activeAddress.toString()">
-            </click-to-copy>
+            <click-to-copy
+              :address="activeAddress.toString()"
+              :checkForHardwareAddress=true
+              @verifyHardwareAddress="$emit('verifyHardwareAddress')"
+            />
           </div>
         </div>
       </div>
@@ -166,7 +169,7 @@ const WalletOverview = defineComponent({
     }
   },
 
-  emits: ['requestFreeTokens']
+  emits: ['requestFreeTokens', 'verifyHardwareAddress']
 })
 
 export default WalletOverview

--- a/src/views/Wallet/WalletSidebarAccounts.vue
+++ b/src/views/Wallet/WalletSidebarAccounts.vue
@@ -45,12 +45,11 @@
         <div class="text-xs text-white relative z-20 flex justify-between mt-4">
           <span class="mr-2">{{ $t('wallet.addressLabel') }}</span>
           <span class="flex-1 w-full truncate">{{ displayHardwareAddress }}</span>
-          <button @click="showLedgerVerify = true; $emit('verifyHardwareAddress')" class="cursor-pointer flex items-center active:text-rBlack outline-none focus:outline-none hover:text-rGreen active:text-rGreenDark">
-            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <rect x="7.5" y="7.5" width="7" height="7" class="stroke-current"/>
-              <path d="M13 5H5V13" class="stroke-current"/>
-            </svg>
-          </button>
+          <click-to-copy
+              :address="hardwareAddress"
+              :checkForHardwareAddress=true
+              @verifyHardwareAddress="$emit('verifyHardwareAddress')"
+            />
         </div>
       </div>
 
@@ -67,11 +66,6 @@
         </div>
       </div>
     </div>
-    <wallet-ledger-verify-address-modal
-      v-if="showLedgerVerify"
-      :hardwareAddress="hardwareAddress"
-      @close="showLedgerVerify = false"
-    />
   </div>
 </template>
 
@@ -79,12 +73,12 @@
 import { defineComponent, PropType } from 'vue'
 import { AccountsT, AccountT } from '@radixdlt/application'
 import AccountListItem from '@/components/AccountListItem.vue'
-import WalletLedgerVerifyAddressModal from '@/views/Wallet/WalletLedgerVerifyAddressModal.vue'
+import ClickToCopy from '@/components/ClickToCopy.vue'
 
 const WalletSidebarAccounts = defineComponent({
   components: {
     AccountListItem,
-    WalletLedgerVerifyAddressModal
+    ClickToCopy
   },
 
   props: {
@@ -104,7 +98,7 @@ const WalletSidebarAccounts = defineComponent({
 
   data () {
     return {
-      showLedgerVerify: false
+      showHardwareHelper: false
     }
   },
 

--- a/src/views/Wallet/WalletSidebarDefault.vue
+++ b/src/views/Wallet/WalletSidebarDefault.vue
@@ -10,6 +10,7 @@
           :account="activeAccount"
           :activeAccount="activeAccount"
           :nameIndex="nameIndex"
+          @verifyHardwareAddress="$emit('verifyHardwareAddress')"
         />
         <div class="absolute bg-gradient-to-r from-blueEnd to-transparent inset-0 w-full h-full z-10 -mx-8 opacity-40">
         </div>
@@ -134,7 +135,7 @@ const WalletSidebarDefault = defineComponent({
     }
   },
 
-  emits: ['open', 'setView', 'openHelp', 'connectHW']
+  emits: ['open', 'setView', 'openHelp', 'connectHW', 'verifyHardwareAddress']
 })
 
 export default WalletSidebarDefault

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -6,8 +6,11 @@
         <div class="flex items-center text-rBlack text-sm">
           <span class="text-rGrayDark mr-2">{{ $t('wallet.currentAddress') }}</span> <span class="font-mono text-rBlack">{{ activeAddress.toString() }}</span>
           <div class="hover:text-rGreen flex flex-row items-center cursor-pointer transition-colors">
-            <click-to-copy :text="activeAddress.toString()">
-            </click-to-copy>
+            <click-to-copy
+              :address="activeAddress.toString()"
+              :checkForHardwareAddress=true
+              @verifyHardwareAddress="$emit('verifyHardwareAddress')"
+            />
           </div>
         </div>
       </div>
@@ -256,7 +259,7 @@ const WalletTransaction = defineComponent({
     }
   },
 
-  emits: ['transferTokens']
+  emits: ['transferTokens', 'verifyHardwareAddress']
 })
 
 export default WalletTransaction

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -6,6 +6,7 @@
       :nameIndex="accountNameIndex"
       @open="sidebar = 'accounts'"
       @setView="setView"
+      @verifyHardwareAddress="verifyHardwareWalletAddress"
     />
     <transition
       enter-active-class="transition ease-out duration-100 transform"
@@ -41,6 +42,7 @@
           :nativeToken="nativeToken"
           :nativeTokenBalance="nativeTokenBalance"
           @requestFreeTokens="requestFreeTokens"
+          @verifyHardwareAddress="verifyHardwareWalletAddress"
         />
         <wallet-loading v-else />
       </template>
@@ -53,6 +55,7 @@
           :nativeToken="nativeToken"
           @transferTokens="transferTokens"
           ref="walletTransactionComponent"
+          @verifyHardwareAddress="verifyHardwareWalletAddress"
         />
         <wallet-loading v-else />
       </template>
@@ -88,6 +91,7 @@
           @next="nextPage"
           @previous="previousPage"
           @decryptMessage="decryptMessage"
+          @verifyHardwareAddress="verifyHardwareWalletAddress"
         />
         <wallet-loading v-else />
       </template>
@@ -112,6 +116,12 @@
         :activeAddress="activeAddress"
         @saved="accountRenamed"
       />
+
+      <wallet-ledger-verify-address-modal
+      v-if="showLedgerVerify"
+      :hardwareAddress="hardwareAddress"
+      @dismissVerify="showLedgerVerify = false"
+    />
 
       <settings-index v-if="view == 'settings' && !loading" />
       <wallet-ledger-interaction-modal
@@ -187,6 +197,7 @@ import {
 import { useI18n } from 'vue-i18n'
 import { sendAPDU } from '@/actions/vue/hardware-wallet'
 import { HardwareWalletLedger } from '@radixdlt/hardware-ledger'
+import WalletLedgerVerifyAddressModal from '@/views/Wallet/WalletLedgerVerifyAddressModal.vue'
 
 const PAGE_SIZE = 50
 
@@ -206,7 +217,8 @@ const WalletIndex = defineComponent({
     WalletStaking,
     WalletTransaction,
     WalletLoading,
-    WalletLedgerInteractionModal
+    WalletLedgerInteractionModal,
+    WalletLedgerVerifyAddressModal
   },
 
   props: {
@@ -247,6 +259,7 @@ const WalletIndex = defineComponent({
     const selectedCurrency: Ref<TokenBalance | null> = ref(null)
     const nativeTokenBalance: Ref<TokenBalance | null> = ref(null)
     const activeMessage: Ref<string> = ref('')
+    const showLedgerVerify: Ref<boolean> = ref(false)
 
     // a dirty trick to get the account list item in the default wallet sidebar when the name changes
     const accountNameIndex: Ref<number> = ref(0)
@@ -669,6 +682,8 @@ const WalletIndex = defineComponent({
 
     const verifyHardwareWalletAddress = () => {
       radix.displayAddressForActiveHWAccountOnHWDeviceForVerification()
+        .subscribe()
+      showLedgerVerify.value = true
     }
 
     onUnmounted(() => subs.unsubscribe())
@@ -704,6 +719,7 @@ const WalletIndex = defineComponent({
       hardwareInteractionState,
       decryptedMessages,
       accountNameIndex,
+      showLedgerVerify,
 
       // view flags
       view,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1560,6 +1560,11 @@
     open-rpc-utils "^1.1.1"
     uuid "^8.3.2"
 
+"@radixdlt/open-rpc-spec@1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@radixdlt/open-rpc-spec/-/open-rpc-spec-1.0.13.tgz#5b58ed3febbbcf04196b9fa1b8a57ef241b74c81"
+  integrity sha512-gcmcCkcLePZS2fWrAtB2Z0yEz/a9saWaJ76yngjVoHwk0bXjQLjYuPklGJVbo6a0Il0B4JXdOKzadBD/46TzRg==
+
 "@radixdlt/open-rpc-spec@^1.0.15":
   version "1.0.15"
   resolved "https://registry.yarnpkg.com/@radixdlt/open-rpc-spec/-/open-rpc-spec-1.0.15.tgz#d52bb10e8faa0cabebf0f726e9b4d4955858a932"


### PR DESCRIPTION
This PR adds the verify address modal functionality to all relevant copy icons. When a hardware wallet is the active account, it will show the verify modal and cue the Ledger to verify the address before copying.