### PR TITLE
fix ledger connection stuff

### DIFF
--- a/src/actions/electron/hardware-wallet.ts
+++ b/src/actions/electron/hardware-wallet.ts
@@ -1,9 +1,135 @@
 import TransportNodeHid from '@ledgerhq/hw-transport-node-hid'
 import { IpcMainInvokeEvent } from 'electron/main'
+import { Observable, Subject } from 'rxjs'
+import { RadixAPDU } from '@radixdlt/hardware-ledger'
+
+let performingInstruction = false
 
 export const sendAPDU = async (event: IpcMainInvokeEvent, apdu: { cla: number, ins: number, p1: number, p2: number, data?: string }) => {
+  const devices = await TransportNodeHid.list()
+  if (!devices[0]) { throw new Error('No device found.') }
+
+  
   const transport = await TransportNodeHid.create()
-  const result = await transport.send(apdu.cla, apdu.ins, apdu.p1, apdu.p2, apdu.data ? Buffer.from(apdu.data, 'hex') : undefined)
+  performingInstruction = true
+
+  let result
+
+  try {
+    result = await transport.send(apdu.cla, apdu.ins, apdu.p1, apdu.p2, apdu.data ? Buffer.from(apdu.data, 'hex') : undefined)
+  } catch (e) {
+    performingInstruction = false
+    throw e
+  }
+
+  performingInstruction = false
   transport.close()
+
   return result
 }
+
+const subscribeDeviceConnection = async (next: (isConnected: boolean) => any) =>
+  TransportNodeHid.listen({
+    next: async (obj: any) => {
+      switch (obj.type) {
+        case 'add':
+          next(true)
+          break
+        case 'remove':
+          next(false)
+          break
+      }
+    },
+  } as any)
+
+export enum ConnectionEvent {
+  DEVICE_CONNECTED,
+  DEVICE_DISCONNECTED,
+  APP_OPEN,
+  APP_CLOSED
+}
+
+export enum AppState {
+  APP_OPEN,
+  APP_CLOSED
+}
+
+const appStateObservable = new Observable<AppState>(subscriber => {
+  let connected = false
+  setInterval(async () => {
+    if (performingInstruction) { return }
+    try {
+      const apdu = await RadixAPDU.getVersion()
+
+      // @ts-ignore
+      await sendAPDU(undefined, apdu)
+      if (connected) { return }
+    } catch (e) {
+      if (!connected) { return }
+    }
+    connected = !connected
+    subscriber.next(connected ? AppState.APP_OPEN : AppState.APP_CLOSED)
+  }, 500)
+})
+
+const appStateSubject = new Subject<AppState>()
+appStateObservable.subscribe(appStateSubject)
+
+export const subscribeAppConnection = appStateSubject.subscribe.bind(appStateSubject)
+
+export async function subscribeConnection(next: (value: ConnectionEvent) => void) {
+  let deviceConnected = false
+  let lastResult: ConnectionEvent
+
+  const deviceSubscription = await subscribeDeviceConnection(isConnected => {
+    deviceConnected = isConnected
+
+    // If the radix app is opened/closed, this will trigger device disconnected
+    // and then connected. To ignore that (to help the UI make sense), wait a bit
+    // for an event following immediately, and only signal if there was none. 
+    setTimeout(() => {
+      if (deviceConnected == isConnected) {
+        const result = isConnected ? ConnectionEvent.DEVICE_CONNECTED : ConnectionEvent.DEVICE_DISCONNECTED
+        if(lastResult === result) return
+
+        lastResult = result
+        next(result)
+      }
+    }, 3000)
+  })
+
+  const appSubscription = subscribeAppConnection(state => {
+    next((() => {
+      switch (state) {
+        case AppState.APP_OPEN:
+          return ConnectionEvent.APP_OPEN
+        case AppState.APP_CLOSED:
+          return ConnectionEvent.APP_CLOSED
+      }
+    })())
+  })
+
+  return {
+    unsubscribe: () => {
+      appSubscription.unsubscribe()
+      deviceSubscription.unsubscribe()
+    },
+  }
+}
+
+subscribeConnection(event => {
+  switch (event) {
+    case ConnectionEvent.APP_OPEN:
+      console.log('ledger app is open')
+      break
+    case ConnectionEvent.APP_CLOSED:
+      console.log('ledger app is closed')
+      break
+    case ConnectionEvent.DEVICE_CONNECTED:
+      console.log('device connected')
+      break
+    case ConnectionEvent.DEVICE_DISCONNECTED:
+      console.log('device disconnected')
+      break
+  }
+})

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -117,7 +117,7 @@
 
           <ButtonSubmit class="w-72 mx-auto mt-2" :disabled="disableSubmit">
             {{ $t('transaction.confirmButton') }}
-          </ButtonSUbmit>
+          </ButtonSubmit>
         </div>
       </form>
     </div>

--- a/src/views/Wallet/WalletLedgerVerifyAddressModal.vue
+++ b/src/views/Wallet/WalletLedgerVerifyAddressModal.vue
@@ -2,7 +2,10 @@
   <div class="fixed w-screen h-screen z-20 flex items-center justify-center bg-translucent-black left-0 top-0">
     <div class="h-modalSmall bg-white rounded-md py-7 px-7 w-full max-w-3xl absolute top-1/2 left-1/2 transform -translate-x-1/3 -translate-y-1/2">
       <h3 class="font-medium text-rBlack mb-2 w-full">Verify Hardware Wallet Address</h3>
-      <div class="text-rBlack">
+      <div v-if="shouldShowError" class="text-rRed">
+        Your Ledger device was not detected. Please attach it you would like to verify your address.
+      </div>
+      <div v-else class="text-rBlack">
         Please verify this address matches the one currently shown on your Ledger.
       </div>
       <div class="mt-4">
@@ -42,12 +45,23 @@ const WalletLedgerVerifyAddressModal = defineComponent({
     hardwareAddress: {
       type: String,
       required: true
+    },
+    hardwareError: {
+      type: Error,
+      required: false
     }
   },
 
   setup () {
     const toast = useToast()
     return { toast }
+  },
+
+  computed: {
+    shouldShowError (): boolean {
+      if (!this.hardwareError) { return false }
+      return this.hardwareError.message.includes('No device found')
+    }
   },
 
   methods: {

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -106,6 +106,9 @@
         <ButtonSubmit :disabled="disableSubmit" class="w-52 ml-full">
           {{ $t('transaction.sendButton') }}
         </ButtonSubmit>
+        <div v-if="ledgerError" class="text-rRed">
+          Your Transaction could not be finalized because your Ledger device could not be found.
+        </div>
       </form>
 
       <div v-else>
@@ -184,6 +187,10 @@ const WalletTransaction = defineComponent({
     },
     nativeToken: {
       type: Object as PropType<Token>,
+      required: false
+    },
+    ledgerError: {
+      type: Error,
       required: false
     }
   },

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -672,7 +672,8 @@ const WalletIndex = defineComponent({
         hardwareWalletConnection: HardwareWalletLedger.create({
           send: sendAPDU
         }),
-        alsoSwitchTo: true
+        alsoSwitchTo: true,
+        verificationPrompt: !hardwareAddress.value
       }).subscribe((hwAccount: AccountT) => {
         activeAccount.value = hwAccount
         hardwareAccount.value = hwAccount

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -54,7 +54,6 @@
           :tokenBalances="tokenBalances.tokenBalances"
           :nativeToken="nativeToken"
           @transferTokens="transferTokens"
-          :ledgerError="ledgerTxError"
           ref="walletTransactionComponent"
           @verifyHardwareAddress="verifyHardwareWalletAddress"
         />


### PR DESCRIPTION
- Throw error when device is disconnected while trying to communicate with a ledger device.
- Subscribe to ledger device events: device disconnected, device connected, app open, app closed.

I have only added logging as a reaction to these events. Please handle the events in any way you deem suitable, for example setting some shared state to be used in components. 

NOTE: Due to some inconsistent behavior with the usb events, I had to hardcode a timer in order to prevent multiple device connection events from firing when opening/closing the ledger app. This might be a bit unreliable between different machines ... but this timer can be increased to increase the reliability. The downside of increasing the timer is that we then introduce a longer delay for the device connection events to fire. This might be something we have to experiment with.