### PR TITLE
fix: Stake reducers need an initial value for empty lists

### DIFF
--- a/src/components/StakeListItem.vue
+++ b/src/components/StakeListItem.vue
@@ -122,13 +122,15 @@ const StakeListItem = defineComponent({
     },
 
     stakeAmount (): AmountT {
-      if (this.position.stakes.length === 0) { Amount.fromUnsafe(0)._unsafeUnwrap() }
-      return this.position.stakes.map((el: StakePosition) => el.amount).reduce((prev: AmountT, curr: AmountT) => prev.add(curr))
+      const zero = Amount.fromUnsafe(0)._unsafeUnwrap()
+      if (this.position.stakes.length === 0) { return zero }
+      return this.position.stakes.map((el: StakePosition) => el.amount).reduce((prev: AmountT, curr: AmountT) => prev.add(curr), zero)
     },
 
     unstakeAmount (): AmountT | null {
+      const zero = Amount.fromUnsafe(0)._unsafeUnwrap()
       if (this.position.unstakes.length === 0) { return null }
-      return this.position.unstakes.map((el: UnstakePosition) => el.amount).reduce((prev: AmountT, curr: AmountT) => prev.add(curr))
+      return this.position.unstakes.map((el: UnstakePosition) => el.amount).reduce((prev: AmountT, curr: AmountT) => prev.add(curr), zero)
     }
   },
 

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -200,8 +200,9 @@ const WalletStaking = defineComponent({
       })
 
       return positions.sort((a: Position, b: Position) => {
-        const aTotal = a.stakes.map((el: StakePosition) => el.amount).reduce((prev: AmountT, curr: AmountT) => prev.add(curr))
-        const bTotal = b.stakes.map((el: StakePosition) => el.amount).reduce((prev: AmountT, curr: AmountT) => prev.add(curr))
+        const zero = Amount.fromUnsafe(0)._unsafeUnwrap()
+        const aTotal = a.stakes.map((el: StakePosition) => el.amount).reduce((prev: AmountT, curr: AmountT) => prev.add(curr), zero)
+        const bTotal = b.stakes.map((el: StakePosition) => el.amount).reduce((prev: AmountT, curr: AmountT) => prev.add(curr), zero)
         if (aTotal > bTotal) return -1
         if (bTotal > aTotal) return 1
         return 0


### PR DESCRIPTION
> Nasty bug here. Apparently unstaking sometimes causes the Stake & Unstake screen to become inaccessible, like this. Details in thread.

If you want to test, I think it should be replicatable by:
Stake to tv1qguchws4ewpt98uwwkrpyat6jz5kdd7cvddsd7me22c2ncscyny7j5qvv05
Wait 30 minutes to make sure an epoch has elapsed, allowing you to unstake
Unstake all of your tokens again from that validator.
Try to load the Stake & Unstake screen again.

Exception was being thrown due to reducing over empty lists.
