### PR TITLE
chore: Various design enhancements

### DIFF
--- a/src/components/ActionListItemStakeTokens.vue
+++ b/src/components/ActionListItemStakeTokens.vue
@@ -5,7 +5,7 @@
         <img src="@/assets/stakeTokens.svg" alt="receive tokens" />
         <span class="ml-2 text-sm">{{ $t('history.stakeAction') }}</span>
       </div>
-      <div><big-amount :amount="action.amount" class="text-rBlack"/> {{ nativeToken.symbol.toUpperCase() }}</div>
+      <div><big-amount :amount="action.amount" class="text-rBlack text-base"/> {{ nativeToken.symbol.toUpperCase() }}</div>
     </div>
     <div class="flex flex-col items-end">
       <div class="flex flex-row flex-1 min-w-0">

--- a/src/components/ActionListItemTransferTokens.vue
+++ b/src/components/ActionListItemTransferTokens.vue
@@ -9,7 +9,7 @@
         <img src="@/assets/sendTokens.svg" alt="send tokens" class="w-6 h-auto" />
         <span class="ml-2 text-sm">{{ $t('history.sentAction') }}</span>
       </div>
-      <div><big-amount :amount="action.amount" class="text-rBlack"/> {{ this.action.rri.name.toUpperCase() }}</div>
+      <div><big-amount :amount="action.amount" class="text-rBlack text-base"/> {{ this.action.rri.name.toUpperCase() }}</div>
     </div>
     <div class="flex flex-col items-end">
       <div v-if="!isRecipient" class="flex flex-row flex-1 min-w-0">

--- a/src/components/ActionListItemUnstakeTokens.vue
+++ b/src/components/ActionListItemUnstakeTokens.vue
@@ -5,7 +5,7 @@
         <img src="@/assets/unstakeTokens.svg" alt="receive tokens" />
         <span class="ml-2 text-sm">{{ $t('history.unstakeAction') }}</span>
       </div>
-      <div><big-amount :amount="action.amount" class="text-rBlack"/> {{ nativeToken.symbol.toUpperCase() }}</div>
+      <div><big-amount :amount="action.amount" class="text-rBlack text-base"/> {{ nativeToken.symbol.toUpperCase() }}</div>
     </div>
     <div class="flex flex-col items-end">
       <div class="flex flex-row flex-1 min-w-0 items-center">

--- a/src/components/TransactionListItem.vue
+++ b/src/components/TransactionListItem.vue
@@ -68,8 +68,8 @@
         </div>
 
         <span v-if="messageState == 'plaintext'">{{ transaction.message }}</span>
-        <span v-if="messageState == 'decrypted'" class="underline">{{decryptedMessage}}</span>
-        <button v-if="messageState == 'encrypted'" class="rGrayDark" @click="decrypt">Encrypted message, click to decrypt.</button>
+        <span v-if="messageState == 'decrypted'">{{decryptedMessage}}</span>
+        <button v-if="messageState == 'encrypted'" class="text-rGreen underline hover:text-rGreenDark transition-colors" @click="decrypt">{{ $t('history.clickToDecryptLabel') }}</button>
       </div>
      </div>
     <div class="bg-rGrayLightest flex items-center justify-center px-3">

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -103,6 +103,7 @@ const messages = {
       sentAction: 'Sent',
       toLabel: 'To',
       fromLabel: 'From',
+      clickToDecryptLabel: 'Encrypted message, click to decrypt.',
       stakeAction: 'Stake',
       otherAction: 'Other',
       previous: 'Previous',

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -79,6 +79,7 @@ const messages = {
       addressLabel: 'Address:',
       back: 'back',
       addAccount: '+ Add Account',
+      chooseAnAccount: 'Choose an account:',
       balancesHeading: 'XRD Balances',
       additionalBalancesHeading: 'Additional Balances',
       currentAddress: 'Current Address:',

--- a/src/views/Home/HomeEnterPasscode.vue
+++ b/src/views/Home/HomeEnterPasscode.vue
@@ -17,7 +17,6 @@
           data-ci="create-wallet-passcode-input"
           id="password"
         />
-        <FormErrorMessage name="password" class="text-sm text-red-400" />
       </div>
 
       <ButtonSubmit class="w-96" :disabled="disableSubmit">
@@ -33,7 +32,6 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import { useForm } from 'vee-validate'
-import FormErrorMessage from '@/components/FormErrorMessage.vue'
 import FormField from '@/components/FormField.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
 
@@ -44,8 +42,7 @@ interface PasswordForm {
 const HomeEnterPasscode = defineComponent({
   components: {
     ButtonSubmit,
-    FormField,
-    FormErrorMessage
+    FormField
   },
 
   setup () {

--- a/src/views/Settings/SettingsRevealMnemonic.vue
+++ b/src/views/Settings/SettingsRevealMnemonic.vue
@@ -46,7 +46,7 @@
           <FormErrorMessage name="password" />
           <ButtonSubmit
             :disabled="disableSubmit"
-            class="mb-9 mt-9"
+            class="mb-2 mt-9"
           >
             {{ $t('settings.accessMnemonicButton') }}
           </ButtonSubmit>

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -64,8 +64,8 @@
           <div class="border-b border-rGray py-3.5 flex items-center">
             <div class="w-26 text-right text-rGrayDark mr-6">{{ $t('transaction.amountLabel') }}</div>
             <div class="flex-1 flex flex-row items-center">
-              <big-amount :amount="amount" class="mr-4" />
-              <token-symbol>{{ selectedCurrency.token.symbol }}</token-symbol>
+              <big-amount :amount="amount" class="mr-1" />
+              <span class="uppercase">{{ selectedCurrency.token.symbol }}</span>
             </div>
           </div>
 
@@ -90,8 +90,8 @@
           <div class="py-4 flex items-center">
             <div class="w-26 text-right text-rGrayDark mr-8">{{ $t('transaction.feeLabel') }}</div>
             <div class="flex-1 flex flex-row items-center">
-              <big-amount :amount="transactionFee" class="mr-4" />
-              <token-symbol>{{ nativeToken.symbol }}</token-symbol>
+              <big-amount :amount="transactionFee"  class="mr-1" />
+              <span class="uppercase">{{ nativeToken.symbol }}</span>
             </div>
           </div>
         </div>
@@ -132,7 +132,6 @@ import BigAmount from '@/components/BigAmount.vue'
 import PinInput from '@/components/PinInput.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
 import { validatePin } from '@/actions/vue/create-wallet'
-import TokenSymbol from '@/components/TokenSymbol.vue'
 
 interface ConfirmationForm {
   pin: string;
@@ -142,8 +141,7 @@ const WalletConfirmTransactionModal = defineComponent({
   components: {
     BigAmount,
     ButtonSubmit,
-    PinInput,
-    TokenSymbol
+    PinInput
   },
 
   setup () {

--- a/src/views/Wallet/WalletHistory.vue
+++ b/src/views/Wallet/WalletHistory.vue
@@ -16,7 +16,7 @@
       </div>
     </div>
 
-    <div class="text-rBlack py-6 min-h-full">
+    <div class="text-rBlack py-6 min-h-full text-sm">
       <div v-if="!loadingHistoryPage">
         <transaction-list-item
           v-for="(txn, i) in pendingTransactions"

--- a/src/views/Wallet/WalletSidebarAccounts.vue
+++ b/src/views/Wallet/WalletSidebarAccounts.vue
@@ -1,11 +1,15 @@
 <template>
   <div class="w-54 px-5 py-8 text-white overflow-y-auto fixed left-0 h-full bg-rBlueDark z-30 overflow-x-hidden">
-    <div @click="$emit('back')" class="hover:text-rGreen cursor-pointer transition-colors inline-flex flex-row items-center mb-12">
+    <div @click="$emit('back')" class="hover:text-rGreen cursor-pointer transition-colors inline-flex flex-row items-center mb-4">
       <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="mr-2">
         <circle cx="10" cy="10" r="9.5" transform="rotate(90 10 10)" fill="none" class="stroke-current" />
         <path d="M12 15L7 10L12 5" class="stroke-current" stroke-miterlimit="10"/>
       </svg>
       {{ $t('wallet.back') }}
+    </div>
+
+    <div class="mt-3 mb-6">
+      {{ $t('wallet.chooseAnAccount') }}
     </div>
 
     <account-list-item

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -76,7 +76,7 @@
         <h3 class="font-medium text-rBlack">{{ $t('staking.currentStakesHeading') }}</h3>
         <a :href="explorerUrl" target="_blank" class="text-rBlue text-sm inline-flex items-center">
           {{ $t('staking.viewAllValidators') }}
-          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" class="ml-3">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" class="ml-1">
             <path d="M1.08789 1H11.1344V11.0465" stroke="#7A99AC" stroke-miterlimit="10"/>
             <path d="M11.1339 1L1 11.134" stroke="#7A99AC" stroke-miterlimit="10"/>
           </svg>


### PR DESCRIPTION
- chore: Add Choose Accounts copy to sidebar menu
- chore: Cancel button was too low
- fix: Show token label as text in confirmation modal
- chore: Validators arrow was too far away
- chore: Consistent font size in transaction list items
- chore: Click to decrypt should look clickable
- chore: Remove password required copy from login

This addresses most of the issues in the linear story. The last remaining one
includes work for updating the PIN UI which is outlined in https://linear.app/township/issue/RDX-152/change-pin-entry-bubble-presentation

It also closes https://linear.app/township/issue/RDX-170/remove-password-error-message
