### PR TITLE
fix: Addresses without XRD should be able to send transactions

### DIFF
--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -154,7 +154,7 @@ const WalletTransaction = defineComponent({
     // Set XRD as default and move to top of list of options. Ensure native token subscription has returned before doing so
     const setXRDByDefault = (nativeToken: Token) => {
       const nativeTokenBalance: TokenBalance | undefined = props.tokenBalances.find((tb: TokenBalance) => tb.token.rri.equals(nativeToken.rri))
-      if (nativeTokenBalance) currency.value = nativeTokenBalance.token.name
+      currency.value = nativeTokenBalance ? nativeTokenBalance.token.name : props.tokenBalances[0].token.name
 
       tokenOptions.value = props.tokenBalances
         .reduce((acc: TokenBalance[], tb: TokenBalance) => {


### PR DESCRIPTION
When an address has no native (XRD) tokens but does have alt tokens, a user should still be able to send a transaction.  
Previously the 'currency' value would never be set, resulting in a loader that never disappeared. 