### PR TITLE
fix: Stake List was using an unpredicatable key

### DIFF
--- a/src/components/StakeListItem.vue
+++ b/src/components/StakeListItem.vue
@@ -18,7 +18,7 @@
           </div>
           <div class="text-xs flex items-center text-rGrayDark font-mono group">
             {{ validatorAddress }}
-            <click-to-copy :text="position.validator.toString()" class="group-hover:text-rGreen active:text-rGreenDark" />
+            <click-to-copy :address="position.address" class="group-hover:text-rGreen active:text-rGreenDark" />
           </div>
         </div>
         <div class="flex-grow-0">

--- a/src/store/_types.ts
+++ b/src/store/_types.ts
@@ -1,6 +1,7 @@
 import { ValidatorAddressT, StakePosition, UnstakePosition } from '@radixdlt/application'
 
 export declare type Position = Readonly<{
+  address: string;
   validator: ValidatorAddressT;
   stakes: Array<StakePosition>;
   unstakes: Array<UnstakePosition>;

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -84,8 +84,8 @@
       </div>
 
       <stake-list-item
-        v-for="(position, i) in sortedPositions"
-        :key="i"
+        v-for="(position) in sortedPositions"
+        :key="position.address"
         :position="position"
         :nativeToken="nativeToken"
         @addToValidator="handleAddToValidator"
@@ -183,17 +183,19 @@ const WalletStaking = defineComponent({
 
       this.activeStakes.forEach((stake: StakePosition) => {
         const existingPositionIndex = positions.findIndex((pos: Position) => pos.validator.equals(stake.validator))
+        const address = stake.validator.toString()
         if (existingPositionIndex === -1) {
-          positions = [...positions, { validator: stake.validator, stakes: [stake], unstakes: [] }]
+          positions = [...positions, { address, validator: stake.validator, stakes: [stake], unstakes: [] }]
         } else {
           positions[existingPositionIndex] = { ...positions[existingPositionIndex], stakes: [...positions[existingPositionIndex].stakes, stake] }
         }
       })
 
       this.activeUnstakes.forEach((unstake: UnstakePosition) => {
+        const address = unstake.validator.toString()
         const existingPositionIndex = positions.findIndex((pos: Position) => pos.validator.equals(unstake.validator))
         if (existingPositionIndex === -1) {
-          positions = [...positions, { validator: unstake.validator, unstakes: [unstake], stakes: [] }]
+          positions = [...positions, { address, validator: unstake.validator, unstakes: [unstake], stakes: [] }]
         } else {
           positions[existingPositionIndex] = { ...positions[existingPositionIndex], unstakes: [...positions[existingPositionIndex].unstakes, unstake] }
         }


### PR DESCRIPTION
The list of current positions displayed on the stake page was depending
on the index of the stake in the sorted list as a key.  Over time, the
index of a position can change on the sorted list as a user interacts
with the positions and as the values of the positions change from
polling.

This commit fixes these inconsistencies by depending on the address of
the valdiator as a key, extending the `Position` type by adding the
address as a string.

This PR also fixes an out of date `CopyToClipboard` call that was
sending a `text` prop rather then the updated `address` prop.