### PR TITLE
fix: Include zip file in mac electron-builder targets

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -49,8 +49,7 @@ module.exports = {
           hardenedRuntime: true,
           entitlements: 'build/entitlements.mac.plist',
           entitlementsInherit: 'build/entitlements.mac.plist',
-          gatekeeperAssess: false,
-          target: ['dmg']
+          gatekeeperAssess: false
         },
         dmg: {
           sign: false


### PR DESCRIPTION
The auto-updater needs the zip files for downloading new releases.