### PR TITLE
fix: Transaction Error Handling Regression

### DIFF
--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -458,7 +458,7 @@ const WalletIndex = defineComponent({
           const errorEvent: TransactionStateError = event as TransactionStateError
           userDidCancel.next(true)
           shouldShowConfirmation.value = false
-          const isLedgerConnectedError = errorEvent.error.message.includes('Failed to sign tx with Ledger')
+          const isLedgerConnectedError = errorEvent.error.message && errorEvent.error.message.includes('Failed to sign tx with Ledger')
           if (isLedgerConnectedError) {
             ledgerTxError.value = errorEvent.error
             hardwareAccount.value = null
@@ -467,11 +467,11 @@ const WalletIndex = defineComponent({
             walletTransactionComponent.value.setErrors({
               amount: null
             })
-          } else if (view.value === 'transaction' && !ledgerTxError) {
+          } else if (view.value === 'transaction') {
             walletTransactionComponent.value.setErrors({
               amount: t('validations.transactionFailed')
             })
-          } else if (walletStakingComponent.value.$data.activeForm === 'stake') {
+          } else if (walletStakingComponent.value && walletStakingComponent.value.$data.activeForm === 'stake') {
             walletStakingComponent.value.setErrors({
               amount: t('validations.stakeFailed')
             })

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -520,11 +520,11 @@ const WalletIndex = defineComponent({
           error: () => {
             userDidCancel.next(true)
             shouldShowConfirmation.value = false
-            if (view.value === 'transaction' && !ledgerTxError) {
+            if (view.value === 'transaction') {
               walletTransactionComponent.value.setErrors({
                 amount: t('validations.transactionFailed')
               })
-            } else if (walletStakingComponent.value.$data.activeForm === 'stake') {
+            } else if (walletStakingComponent.value && walletStakingComponent.value.$data.activeForm === 'stake') {
               walletStakingComponent.value.setErrors({
                 amount: t('validations.stakeFailed')
               })


### PR DESCRIPTION
This PR fixes a regression in the error handling caused by the addition of ledger errors.

The error handling subscriptions have been updated for the following fixes:

- Errors that originate from the API do not have the expected shape as described by typescript
- Referenced staking components do not have values if they're not currently rendered.