### PR TITLE
chore: improve how we handle network selection

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,6 +1,6 @@
 export NODE_TLS_REJECT_UNAUTHORIZED=1
-export VUE_APP_API=https://stokenet.radixdlt.com
-export VUE_APP_EXPLORER=https://stokenet-explorer.radixdlt.com
+export VUE_APP_NETWORK_NAME=mainnet
+export VUE_APP_EXPLORER=https://explorer.radixdlt.com
 export VUE_APP_FAUCET=https://stokenet-faucet.radixdlt.com
 export APPLE_ID=
 export APPLE_ID_PASSWORD=

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -1,9 +1,9 @@
 on:
   push:
     branches:
-      - ledger
+      - main
 
-name: release-ledger
+name: release-latest
 jobs:
   build-release:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release-ledger.yml
+++ b/.github/workflows/release-ledger.yml
@@ -20,26 +20,11 @@ jobs:
           node-version: '15'
           check-latest: true
 
-      - name: Install node-hid Dependencies
-        shell: bash
-        run: |
-          case $RUNNER_OS in
-            Linux)
-              echo "Building node-hid deps for Ubuntu"
-              sudo apt install build-essential git
-              sudo apt install gcc-4.8 g++-4.8 && export CXX=g++-4.8
-              sudo apt install libusb-1.0-0 libusb-1.0-0-dev
-              sudo apt install libudev-dev
-              ;;
-            *)
-              echo "No commands required for this OS"
-          esac
       - name: Build/release Electron app
         uses: samuelmeuli/action-electron-builder@v1
         env:
-          VUE_APP_API: https://sandpitnet.radixdlt.com
-          VUE_APP_EXPLORER: https://sandpitnet-explorer.radixdlt.com
-          VUE_APP_FAUCET: https://sandpitnet-faucet.radixdlt.com/faucet/request
+          VUE_APP_NETWORK_NAME: mainnet
+          VUE_APP_EXPLORER: https://explorer.radixdlt.com
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
         with:

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -46,9 +46,8 @@ jobs:
       - name: Build/release Electron app
         uses: samuelmeuli/action-electron-builder@v1
         env:
-          VUE_APP_API: https://mainnet.radixdlt.com
+          VUE_APP_NETWORK_NAME: mainnet
           VUE_APP_EXPLORER: https://explorer.radixdlt.com
-          VUE_APP_FAUCET: https://stokenet-faucet.radixdlt.com
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
         with:

--- a/src/components/StakeListItem.vue
+++ b/src/components/StakeListItem.vue
@@ -82,6 +82,7 @@ import ClickToCopy from '@/components/ClickToCopy.vue'
 import { Subscription } from 'rxjs'
 import { formatValidatorAddressForDisplay } from '@/helpers/formatter'
 import { Position } from '@/store/_types'
+import { radixConnection } from '@/helpers/network'
 
 const StakeListItem = defineComponent({
   components: {
@@ -102,11 +103,7 @@ const StakeListItem = defineComponent({
 
   setup (props) {
     const validator: Ref<Validator | null> = ref(null)
-
-    const radix = Radix
-      .create({ network: Network.MAINNET })
-      .connect(process.env.VUE_APP_API || 'https://mainnet.radixdlt.com')
-
+    const radix = radixConnection()
     const subs = new Subscription()
 
     subs

--- a/src/helpers/network.ts
+++ b/src/helpers/network.ts
@@ -1,0 +1,32 @@
+import { Network, Radix } from '@radixdlt/application'
+
+type ChosenNetworkT = {
+  network: Network
+  networkURL: string
+}
+
+export const network = (): ChosenNetworkT => {
+  let response: ChosenNetworkT
+  const networkName = process.env.VUE_APP_NETWORK_NAME
+  if (networkName === 'stokenet') {
+    response = {
+      network: Network.STOKENET,
+      networkURL: 'https://stokenet.radixdlt.com'
+    }
+  } else if (networkName === 'mainnet') {
+    response = {
+      network: Network.MAINNET,
+      networkURL: 'https://mainnet.radixdlt.com'
+    }
+  } else {
+    throw new Error('Invalid Network Name Provided')
+  }
+  return response
+}
+
+export const radixConnection = () => {
+  const activeNetwork = network()
+  return Radix
+    .create({ network: activeNetwork.network })
+    .connect(activeNetwork.networkURL)
+}

--- a/src/views/CreateWallet/index.vue
+++ b/src/views/CreateWallet/index.vue
@@ -98,6 +98,7 @@ import { initWallet, storePin } from '@/actions/vue/create-wallet'
 import { useStore } from '@/store'
 import { ref } from '@nopr3d/vue-next-rx'
 import { saveDerivedAccountsIndex } from '@/actions/vue/data-store'
+import { network } from '@/helpers/network'
 
 const CreateWallet = defineComponent({
   components: {
@@ -113,10 +114,11 @@ const CreateWallet = defineComponent({
     const mnemonic: MnemomicT = Mnemonic.generateNew()
     const step = ref(0)
     const passcode = ref('')
+    const activeNetwork = network()
 
     // Create wallet with password and path to keystore
     const createWallet = (pass: string) => {
-      initWallet(mnemonic, pass, Network.MAINNET)
+      initWallet(mnemonic, pass, activeNetwork.network)
         .then((wallet: WalletT) => {
           store.commit('setWallet', wallet)
           saveDerivedAccountsIndex(0)

--- a/src/views/Home/index.vue
+++ b/src/views/Home/index.vue
@@ -59,6 +59,7 @@ import { useI18n } from 'vue-i18n'
 import { ref } from '@nopr3d/vue-next-rx'
 import { filter } from 'rxjs/operators'
 import { resetStore } from '@/actions/vue/data-store'
+import { radixConnection } from '@/helpers/network'
 
 const CreateWallet = defineComponent({
   components: {
@@ -84,9 +85,7 @@ const CreateWallet = defineComponent({
 
     const enterPasscodeComponent = ref(null)
 
-    const radix = Radix
-      .create({ network: Network.MAINNET })
-      .connect(process.env.VUE_APP_API || 'https://mainnet.radixdlt.com')
+    const radix = radixConnection()
     const subs = new Subscription()
 
     radix.errors

--- a/src/views/Settings/SettingsResetPassword.vue
+++ b/src/views/Settings/SettingsResetPassword.vue
@@ -64,6 +64,7 @@ import { touchKeystore, initWallet } from '@/actions/vue/create-wallet'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
 import FormField from '@/components/FormField.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
+import { radixConnection } from '@/helpers/network'
 
 interface PasswordForm {
   currentPassword: string;
@@ -85,9 +86,7 @@ const SettingsResetPassword = defineComponent({
     const isLoading = ref(false)
     const updatedPassword: Ref<boolean> = ref(false)
 
-    const radix = Radix
-      .create({ network: Network.MAINNET })
-      .connect(process.env.VUE_APP_API || 'https://mainnet.radixdlt.com')
+    const radix = radixConnection()
       .withWallet(store.state.wallet)
 
     const handleResetPassword = (newPassword: string) => {

--- a/src/views/Settings/index.vue
+++ b/src/views/Settings/index.vue
@@ -34,6 +34,7 @@ import SettingsRevealMnemonic from './SettingsRevealMnemonic.vue'
 import SettingsResetPassword from './SettingsResetPassword.vue'
 import { useStore } from '@/store'
 import { ref } from '@nopr3d/vue-next-rx'
+import { radixConnection } from '@/helpers/network'
 
 const SettingsIndex = defineComponent({
   components: {
@@ -46,9 +47,7 @@ const SettingsIndex = defineComponent({
 
   setup () {
     const store = useStore()
-    const radix = Radix
-      .create({ network: Network.MAINNET })
-      .connect(process.env.VUE_APP_API || 'https://mainnet.radixdlt.com')
+    const radix = radixConnection()
       .withWallet(store.state.wallet)
 
     const mnemonic = ref(null)

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -207,6 +207,7 @@ import { sendAPDU } from '@/actions/vue/hardware-wallet'
 import { HardwareWalletLedger } from '@radixdlt/hardware-ledger'
 import WalletLedgerVerifyAddressModal from '@/views/Wallet/WalletLedgerVerifyAddressModal.vue'
 import WalletLedgerDeleteModal from '@/views/Wallet/WalletLedgerDeleteModal.vue'
+import { radixConnection } from '@/helpers/network'
 
 const PAGE_SIZE = 50
 
@@ -312,9 +313,7 @@ const WalletIndex = defineComponent({
     // Return home if wallet is undefined
     if (!store.state.wallet) router.push('/')
 
-    const radix = Radix
-      .create({ network: Network.MAINNET })
-      .connect(process.env.VUE_APP_API || 'https://mainnet.radixdlt.com')
+    const radix = radixConnection()
       .withWallet(store.state.wallet)
       .withTokenBalanceFetchTrigger(interval(5 * 1_000))
       .withStakingFetchTrigger(interval(5 * 1_000))


### PR DESCRIPTION
This PR improves how we manage network selection in environment variables, and should help improve our Github build process long term.

We now expect an `VUE_APP_NETWORK_NAME` environment variable. Currently, we only support values of `stokenet` or `mainnet`. If we don't receive one of those two values, we throw an error. Choosing a network implictly has burned us in the past, I'd prefer we just bomb out.