### PR TITLE
fix: validate network addresses for active network

### DIFF
--- a/src/helpers/network.ts
+++ b/src/helpers/network.ts
@@ -1,8 +1,9 @@
-import { Network, Radix } from '@radixdlt/application'
+import { Network, Radix, HRP } from '@radixdlt/application'
 
 type ChosenNetworkT = {
   network: Network
   networkURL: string
+  preamble: string
 }
 
 export const network = (): ChosenNetworkT => {
@@ -11,12 +12,14 @@ export const network = (): ChosenNetworkT => {
   if (networkName === 'stokenet') {
     response = {
       network: Network.STOKENET,
-      networkURL: 'https://stokenet.radixdlt.com'
+      networkURL: 'https://stokenet.radixdlt.com',
+      preamble: HRP.STOKENET.account
     }
   } else if (networkName === 'mainnet') {
     response = {
       network: Network.MAINNET,
-      networkURL: 'https://mainnet.radixdlt.com'
+      networkURL: 'https://mainnet.radixdlt.com',
+      preamble: HRP.MAINNET.account
     }
   } else {
     throw new Error('Invalid Network Name Provided')

--- a/src/helpers/validateRadixTypes.ts
+++ b/src/helpers/validateRadixTypes.ts
@@ -1,9 +1,13 @@
 import { AccountAddress, AccountAddressT, Amount, AmountT, Token, ValidatorAddress, ValidatorAddressT } from '@radixdlt/application'
 import BigNumber from 'bignumber.js'
+import { network } from '@/helpers/network'
 
 export const safelyUnwrapAddress = (addressString: string): AccountAddressT | null => {
   const recipientAddressResult = AccountAddress.fromUnsafe(addressString)
-  if (recipientAddressResult.isErr()) {
+  const activeNetwork = network()
+  const validAddressForActiveNetwork = addressString.startsWith(activeNetwork.preamble)
+
+  if (recipientAddressResult.isErr() || !validAddressForActiveNetwork) {
     return null
   }
   return recipientAddressResult.value


### PR DESCRIPTION
This PR introduces a lightweight check to verify that user input addresses can both be safely unwrapped and also have valid preambles (`rdx` for mainnet, `tdx` for stokenet, etc) for the wallet's current network. 