### PR TITLE
Feat: The confirmation modal should submit on Enter, and Cancel on Escape.

### DIFF
--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -113,12 +113,12 @@
             />
           </div>
           <div class="flex justify-end items-center">
-            <button
-              class="text-rGrayDark py-3 px-4 text-base mx-auto mr-4"
+            <div
+              class="text-rGrayDark py-3 px-4 text-base mx-auto mr-4 cursor-pointer"
               @click="canCancel && $emit('cancel')"
             >
               {{ $t('transaction.cancelButton') }}
-            </button>
+            </div>
 
             <ButtonSubmit class="w-44 py-3" :disabled="disableSubmit" :small="true" >
               {{ $t('transaction.confirmButton') }}

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -203,6 +203,14 @@ const WalletConfirmTransactionModal = defineComponent({
     }
   },
 
+  mounted () {
+    window.addEventListener('keydown', this.escapeListener)
+  },
+
+  unmounted () {
+    window.removeEventListener('keydown', this.escapeListener)
+  },
+
   computed: {
     toContent (): string {
       if (this.stakeInput) {
@@ -256,6 +264,11 @@ const WalletConfirmTransactionModal = defineComponent({
     },
     handleUnfinishedPin () {
       this.isValidPin = false
+    },
+    escapeListener (event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        this.$emit('cancel')
+      }
     }
   },
 


### PR DESCRIPTION
This PR contains one fix and one new feature:

- The confirmation modal form previously contained two `button` elements. This was preventing the form from submitting successfully and closing the modal. Changing the cancel `button` to an anchor tag corrected the issue.

- Adds functionality to close the confirmation modal when the escape key is pressed.