### PR TITLE
WIP: enable switching networks

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@babel/core": "^7.13.10",
     "@ledgerhq/hw-transport-node-hid": "^6.0.2",
     "@nopr3d/vue-next-rx": "^1.0.6",
-    "@radixdlt/application": "^2.1.15",
+    "@radixdlt/application": "^3.0.5",
     "@radixdlt/hardware-ledger": "^2.1.15",
     "@headlessui/vue": "^1.3.0",
     "@tailwindcss/forms": "^0.2.1",

--- a/src/helpers/network.ts
+++ b/src/helpers/network.ts
@@ -1,4 +1,4 @@
-import { Network, Radix, HRP } from '@radixdlt/application'
+import { Network, Radix, HRP, RadixT } from '@radixdlt/application'
 
 type ChosenNetworkT = {
   network: Network
@@ -6,9 +6,10 @@ type ChosenNetworkT = {
   preamble: string
 }
 
-export const network = (): ChosenNetworkT => {
+let currentNetwork: ChosenNetworkT
+
+export const network = (networkName: 'stokenet' | 'mainnet'): ChosenNetworkT => {
   let response: ChosenNetworkT
-  const networkName = process.env.VUE_APP_NETWORK_NAME
   if (networkName === 'stokenet') {
     response = {
       network: Network.STOKENET,
@@ -22,14 +23,21 @@ export const network = (): ChosenNetworkT => {
       preamble: HRP.MAINNET.account
     }
   } else {
-    throw new Error('Invalid Network Name Provided')
+    throw new Error(`Invalid Network Name ${networkName} Provided`)
   }
+  currentNetwork = response
   return response
 }
 
-export const radixConnection = () => {
-  const activeNetwork = network()
-  return Radix
-    .create({ network: activeNetwork.network })
-    .connect(activeNetwork.networkURL)
+const radix = Radix.create()
+
+export const radixConnection = () => radix
+
+export const getCurrentNetwork = () => currentNetwork
+
+export const setNetwork = async (name: 'stokenet' | 'mainnet') => {
+  await radix.connect(network(name).networkURL)
+  return radix
 }
+
+setNetwork(process.env.VUE_APP_NETWORK_NAME)

--- a/src/helpers/validateRadixTypes.ts
+++ b/src/helpers/validateRadixTypes.ts
@@ -1,10 +1,10 @@
 import { AccountAddress, AccountAddressT, Amount, AmountT, Token, ValidatorAddress, ValidatorAddressT } from '@radixdlt/application'
 import BigNumber from 'bignumber.js'
-import { network } from '@/helpers/network'
+import { getCurrentNetwork, network } from '@/helpers/network'
 
 export const safelyUnwrapAddress = (addressString: string): AccountAddressT | null => {
   const recipientAddressResult = AccountAddress.fromUnsafe(addressString)
-  const activeNetwork = network()
+  const activeNetwork = getCurrentNetwork()
   const validAddressForActiveNetwork = addressString.startsWith(activeNetwork.preamble)
 
   if (recipientAddressResult.isErr() || !validAddressForActiveNetwork) {

--- a/src/views/CreateWallet/index.vue
+++ b/src/views/CreateWallet/index.vue
@@ -98,7 +98,7 @@ import { initWallet, storePin } from '@/actions/vue/create-wallet'
 import { useStore } from '@/store'
 import { ref } from '@nopr3d/vue-next-rx'
 import { saveDerivedAccountsIndex } from '@/actions/vue/data-store'
-import { network } from '@/helpers/network'
+import { getCurrentNetwork, network } from '@/helpers/network'
 
 const CreateWallet = defineComponent({
   components: {
@@ -114,7 +114,7 @@ const CreateWallet = defineComponent({
     const mnemonic: MnemomicT = Mnemonic.generateNew()
     const step = ref(0)
     const passcode = ref('')
-    const activeNetwork = network()
+    const activeNetwork = getCurrentNetwork()
 
     // Create wallet with password and path to keystore
     const createWallet = (pass: string) => {

--- a/src/views/Home/index.vue
+++ b/src/views/Home/index.vue
@@ -45,7 +45,7 @@
 
 <script lang="ts">
 import { defineComponent, reactive } from 'vue'
-import { Radix, ErrorNotification, WalletErrorCause, WalletT, Network } from '@radixdlt/application'
+import { Radix, WalletErrorCause, WalletT, Network } from '@radixdlt/application'
 import { hasKeystore, touchKeystore } from '@/actions/vue/create-wallet'
 import { useStore } from '@/store'
 import HomeCreateAndRestore from './HomeCreateAndRestore.vue'
@@ -89,7 +89,7 @@ const CreateWallet = defineComponent({
     const subs = new Subscription()
 
     radix.errors
-      .pipe(filter((errorNotification: ErrorNotification) => errorNotification.cause === WalletErrorCause.LOAD_KEYSTORE_FAILED))
+      .pipe(filter(errorNotification => errorNotification.cause === WalletErrorCause.LOAD_KEYSTORE_FAILED))
       .subscribe(
         () => {
           enterPasscodeComponent.value.setErrors({

--- a/src/views/Settings/SettingsResetPassword.vue
+++ b/src/views/Settings/SettingsResetPassword.vue
@@ -90,7 +90,6 @@ const SettingsResetPassword = defineComponent({
     const updatedPassword: Ref<boolean> = ref(false)
 
     const radix = radixConnection()
-      .withWallet(store.state.wallet)
 
     const handleResetPassword = (newPassword: string) => {
       const getMnemonicForPassword = radix.revealMnemonic()

--- a/src/views/Settings/index.vue
+++ b/src/views/Settings/index.vue
@@ -48,7 +48,6 @@ const SettingsIndex = defineComponent({
   setup () {
     const store = useStore()
     const radix = radixConnection()
-      .withWallet(store.state.wallet)
 
     const mnemonic = ref(null)
     const userRequestedMnemonic = new Subject<boolean>()

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -207,7 +207,7 @@ import { sendAPDU } from '@/actions/vue/hardware-wallet'
 import { HardwareWalletLedger } from '@radixdlt/hardware-ledger'
 import WalletLedgerVerifyAddressModal from '@/views/Wallet/WalletLedgerVerifyAddressModal.vue'
 import WalletLedgerDeleteModal from '@/views/Wallet/WalletLedgerDeleteModal.vue'
-import { radixConnection } from '@/helpers/network'
+import { radixConnection, setNetwork } from '@/helpers/network'
 
 const PAGE_SIZE = 50
 
@@ -315,7 +315,6 @@ const WalletIndex = defineComponent({
     if (!store.state.wallet) router.push('/')
 
     const radix = radixConnection()
-      .withWallet(store.state.wallet)
       .withTokenBalanceFetchTrigger(interval(5 * 1_000))
       .withStakingFetchTrigger(interval(5 * 1_000))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1526,19 +1526,38 @@
     prelude-ts "^1.0.2"
     rxjs "7.0.0"
 
-"@radixdlt/application@^2.1.15":
-  version "2.1.15"
-  resolved "https://registry.yarnpkg.com/@radixdlt/application/-/application-2.1.15.tgz#c63db8e0ffc269f44d90686a00f1452a4b519001"
-  integrity sha512-WauhZEOP9nfkFWeKvwLztvBeqiST5kqTYwcOukIbR15rqxuvG0QAGUx47YA8dq78qJrAch5Rr1Nr8UI2CSFpaQ==
+"@radixdlt/account@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@radixdlt/account/-/account-3.0.0.tgz#8e966395b5585ca575102372c41f339926c23738"
+  integrity sha512-lNFOGTTaABE8PRyQc4/COFVhvV4ZcqkyindiQi80omcpmY5Ug6t1/frju05AZmYItTRFlaUDcLZ5tisF66+8mQ==
+  dependencies:
+    "@radixdlt/crypto" "^2.1.4"
+    "@radixdlt/data-formats" "1.0.30"
+    "@radixdlt/hardware-wallet" "^2.1.7"
+    "@radixdlt/primitives" "^3.0.0"
+    "@radixdlt/uint256" "1.1.0"
+    "@radixdlt/util" "1.0.29"
+    bech32 "^2.0.0"
+    bip39 "^3.0.3"
+    hdkey "^2.0.1"
+    long "^4.0.0"
+    neverthrow "^4.0.1"
+    prelude-ts "^1.0.2"
+    rxjs "7.0.0"
+
+"@radixdlt/application@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@radixdlt/application/-/application-3.0.5.tgz#4e00a8dbf26b228dc4e86c3f234167130246cf37"
+  integrity sha512-Pamw6khmdzhO8Gsf1sFt7qEZN1jOvHUwJljzBMEPYg+dlHgEIir8Qz0KezCVyJr4mNdi3+xCXYZRDjay+IDJLA==
   dependencies:
     "@open-rpc/mock-server" "1.7.2"
     "@open-rpc/schema-utils-js" "1.14.3"
-    "@radixdlt/account" "^2.1.6"
-    "@radixdlt/crypto" "^2.1.3"
+    "@radixdlt/account" "^3.0.0"
+    "@radixdlt/crypto" "^2.1.4"
     "@radixdlt/data-formats" "1.0.30"
     "@radixdlt/networking" "^2.1.4"
     "@radixdlt/open-rpc-spec" "^1.0.19"
-    "@radixdlt/primitives" "^2.1.3"
+    "@radixdlt/primitives" "^3.0.0"
     "@radixdlt/util" "1.0.29"
     jest "^26.6.3"
     json-schema-faker "^0.5.0-rcv.34"
@@ -1554,6 +1573,22 @@
   dependencies:
     "@radixdlt/data-formats" "1.0.30"
     "@radixdlt/primitives" "^2.1.3"
+    "@radixdlt/uint256" "1.1.0"
+    "@radixdlt/util" "1.0.29"
+    base-x "^3.0.8"
+    elliptic "^6.5.3"
+    neverthrow "^4.0.1"
+    node-forge "^0.10.0"
+    scrypt-js "^3.0.1"
+    uuid "^8.3.2"
+
+"@radixdlt/crypto@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@radixdlt/crypto/-/crypto-2.1.4.tgz#2fd2e01d865e0dacb3e381e9b8f25df33dea97cb"
+  integrity sha512-zlH5C/VQWmrzpF2GuWMO95X3h2cxZIGh9uDBt48K7DKXHvMlapjJLTJlnrhW0dZ6PfFnK2FbvUB5eCOXh67BJg==
+  dependencies:
+    "@radixdlt/data-formats" "1.0.30"
+    "@radixdlt/primitives" "^3.0.0"
     "@radixdlt/uint256" "1.1.0"
     "@radixdlt/util" "1.0.29"
     base-x "^3.0.8"
@@ -1601,6 +1636,19 @@
     rxjs "7.0.0"
     uuid "^8.3.2"
 
+"@radixdlt/hardware-wallet@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@radixdlt/hardware-wallet/-/hardware-wallet-2.1.7.tgz#862bf3aa8acfd6b20fe9aa826b3fc086aaee7abb"
+  integrity sha512-hm4m1ie+cdc9tpIJ16EslyFS1cK81JsYyi17Nzktv47L3joqXpPbqQOZbxwcxamn9Hbsg4hU3byIPXBqCmxRYA==
+  dependencies:
+    "@radixdlt/crypto" "^2.1.4"
+    "@radixdlt/primitives" "^3.0.0"
+    "@radixdlt/util" "1.0.29"
+    neverthrow "4.0.1"
+    prelude-ts "^1.0.2"
+    rxjs "7.0.0"
+    uuid "^8.3.2"
+
 "@radixdlt/networking@^2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@radixdlt/networking/-/networking-2.1.4.tgz#cff339140b912f926a3d515dda08ba538a800dab"
@@ -1624,6 +1672,18 @@
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@radixdlt/primitives/-/primitives-2.1.3.tgz#bc80d974cd0a363b03291f36bef1369bd8c291b8"
   integrity sha512-132/NJQMaHK0JtAPki2vjYCvPEFcVc9+oOsrU/7ydag63oYmWWe7HRAEwAoYQeTvY4eFmWGdU+mw9QtGWn7cvQ==
+  dependencies:
+    "@radixdlt/data-formats" "1.0.30"
+    "@radixdlt/uint256" "1.1.0"
+    "@radixdlt/util" "1.0.29"
+    bn.js "^5.1.3"
+    long "^4.0.0"
+    neverthrow "^4.0.1"
+
+"@radixdlt/primitives@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@radixdlt/primitives/-/primitives-3.0.0.tgz#fb52cda2578c66fc395099db7e57a512045bf8f0"
+  integrity sha512-sfekbjFNm8/WzZiBBM7EPniLJWCcTTGOcRuRdtFGp6eiojtN3UZAaBe/RFhYlrZLPXniIzic2xn64SE1jUrNCw==
   dependencies:
     "@radixdlt/data-formats" "1.0.30"
     "@radixdlt/uint256" "1.1.0"


### PR DESCRIPTION
This is work in progress. More changes and testing is needed, as some things need to be re-initialized after switching networks, such as the native token for example. 

I removed the `__withWallet()` calls, since I don't think that should be needed. You have access to the `radix` object, and the wallet is created internally when you `radix.login()`. Maybe I missed something?

I also made sure that there is only one `radix` object created - instead of creating a new one every time you call `radixConnection()`.