### PR TITLE
Fix: Hardware Wallet account derivation

### DIFF
--- a/src/views/Wallet/WalletSidebarAccounts.vue
+++ b/src/views/Wallet/WalletSidebarAccounts.vue
@@ -13,7 +13,7 @@
     </div>
 
     <account-list-item
-      v-for="(account, i) in accounts.all"
+      v-for="(account, i) in localAccounts"
       :key="i"
       :account="account"
       :activeAccount="activeAccount"
@@ -121,6 +121,12 @@ const WalletSidebarAccounts = defineComponent({
 
       const add:string = this.hardwareAddress
       return add.substring(0, 3) + '...' + add.substring(add.length - 9)
+    },
+
+    localAccounts (): AccountT[] {
+      return this.accounts.all.filter((account: AccountT) => {
+        return account.signingKey.isLocalHDSigningKey
+      })
     }
   },
 

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -175,8 +175,8 @@ import {
   TokenBalance,
   MessageInTransaction,
   ExecutedTransaction,
-  Network,
-  TransactionStateError
+  TransactionStateError,
+  HDPathRadix
 } from '@radixdlt/application'
 import { safelyUnwrapAmount } from '@/helpers/validateRadixTypes'
 import { ref } from '@nopr3d/vue-next-rx'
@@ -661,7 +661,9 @@ const WalletIndex = defineComponent({
       hardwareWalletError.value = null
       hardwareInteractionState.value = 'DERIVING'
       radix.deriveHWAccount({
-        keyDerivation: 'next',
+        keyDerivation: HDPathRadix.create({
+          address: { index: 0, isHardened: true }
+        }),
         hardwareWalletConnection: HardwareWalletLedger.create({
           send: sendAPDU
         }),


### PR DESCRIPTION
With the (temporary) release of v1.1.0 a bug was introduced due to the wallet's lagging implementation of new SDK functionality. To allow for multiple derived hardware wallets, the SDK allow hardware wallet accounts to be stacked on the general accounts list. Without proper wallet changes this resulted in two undesirable behaviors:

- As hardware wallet accounts were derived in a single Radix SDK object session, each account was pushed on the general stack of accounts. Meaning, those accounts now began to display in our primary account list, which should only show Local HD Wallet accounts. The fix in this PR is to filter accounts shown there, displaying only those where `account.signingKey.isLocalHDSigningKey` is true.

- Secondly, this also meant that using the `next` option to derive new Hardware Wallet accounts would always derive the next account from the Hardware Wallet based on what's on the account stack. So, if three accounts had been derived in that session, and another was derived, we'd derive the fourth. The fix in this PR is to _always_ derive the 0th index account.