### PR TITLE
chore: Show error when new hw address added

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -190,6 +190,11 @@ const messages = {
       accessSettingsButton: 'Access Settings',
       updatedPassword: 'You\'ve successfully updated your password.',
       updatedPIN: 'You\'ve successfully updated your PIN.'
+    },
+    errors: {
+      hardwareMismatchTitle: 'Hardware Wallet Account Mismatch',
+      hardwareMismatchCopyOne: 'The account provided by the connected hardware wallet device does not match your current hardware wallet account address. Ensure you are using the same hardware wallet device.',
+      hardwareMismatchCopyTwo: 'If you would like to use a different hardware wallet device, please remove the existing hardware wallet account and add a new one with the desired device connected. You can always re-add a previous hardware wallet device account later.'
     }
   }
 }

--- a/src/views/Wallet/WalletErrorModal.vue
+++ b/src/views/Wallet/WalletErrorModal.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="fixed w-screen h-screen z-20 flex items-center justify-center bg-translucent-black">
+    <div class="h-modalSmall bg-white rounded-md py-2 px-7 w-full max-w-lg absolute top-1/2 left-1/2 transform -translate-x-1/3 -translate-y-1/2">
+      <div class="text-center">
+        <div class="text-center mt-8 text-rRed text-lg">
+          {{ title }}
+        </div>
+        <div class="text-center mt-4 text-rBlack text-sm px-6">
+          <p> {{ copyOne }} </p>
+          <p v-if="copyTwo" class="mt-4"> {{ copyTwo }} </p>
+        </div>
+
+        <button @click="$emit('closeErrorModal')" class="block m-auto pt-4"> Close this </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue'
+
+const WalletErrorModal = defineComponent({
+
+  props: {
+    title: {
+      type: String,
+      required: true
+    },
+    copyOne: {
+      type: String,
+      required: true
+    },
+    copyTwo: {
+      type: String,
+      required: false
+    }
+  },
+
+  emits: ['closeErrorModal']
+})
+
+export default WalletErrorModal
+</script>


### PR DESCRIPTION
This PR adds functionality to present users with an error modal when they attempt to derive a new Radix address with one already loaded. In the current build, this is only possible by using multiple ledger devices. Users are required instead to explicitly remove a hardware wallet before adding another.

It also adds a reusable error component for future use. :)