### PR TITLE
feat: show non xrd tokens in wallet

### DIFF
--- a/src/helpers/explorerLinks.ts
+++ b/src/helpers/explorerLinks.ts
@@ -1,0 +1,3 @@
+export const createRRIUrl = function (rriString: string): string {
+  return `${process.env.VUE_APP_EXPLORER}/#/tokens/${rriString}`
+}

--- a/src/helpers/formatter.ts
+++ b/src/helpers/formatter.ts
@@ -1,4 +1,4 @@
-import { AccountAddressT, ValidatorAddressT } from '@radixdlt/application'
+import { AccountAddressT, HRP, Network, ValidatorAddressT, TokenBalance } from '@radixdlt/application'
 
 export const formatWalletAddressForDisplay = function (address: AccountAddressT): string {
   const s = address.toString()
@@ -8,4 +8,28 @@ export const formatWalletAddressForDisplay = function (address: AccountAddressT)
 export const formatValidatorAddressForDisplay = function (address: ValidatorAddressT): string {
   const s = address.toString()
   return s.substring(0, 2) + '...' + s.substring(s.length - 9)
+}
+
+export const truncateRRIStringForDisplay = function (rriString: string): any {
+  const arrOfValues = []
+  for (const [key, val] of Object.entries(HRP)) {
+    arrOfValues.push(val.RRI_suffix)
+  }
+
+  // Sort by largest -> Smallest since some suffixes have length 3 and some have 2
+  // Avoiding scenarios such as matching '_tr' first when there is a '_tr3'
+  arrOfValues.sort(function (a, b) {
+    return b.length - a.length
+  })
+
+  const correctSuffix = arrOfValues.filter((suffix) => {
+    return rriString.match(suffix)! != null
+  })
+
+  const charsUntilSuffixEnd = correctSuffix.map((suffix) => {
+    return rriString.match(suffix)!.index // suffix.length // + matchDetails[1]
+  })
+
+  const prefixLength = charsUntilSuffixEnd[0]! + 3
+  return rriString.substring(0, prefixLength) + '...' + rriString.substring(rriString.length - 9)
 }

--- a/src/helpers/formatter.ts
+++ b/src/helpers/formatter.ts
@@ -30,6 +30,6 @@ export const truncateRRIStringForDisplay = function (rriString: string): any {
     return rriString.match(suffix)!.index // suffix.length // + matchDetails[1]
   })
 
-  const prefixLength = charsUntilSuffixEnd[0]! + 3
+  const prefixLength = charsUntilSuffixEnd[0]! + correctSuffix[0].length
   return rriString.substring(0, prefixLength) + '...' + rriString.substring(rriString.length - 9)
 }

--- a/src/helpers/formatter.ts
+++ b/src/helpers/formatter.ts
@@ -1,4 +1,4 @@
-import { AccountAddressT, HRP, Network, ValidatorAddressT, TokenBalance } from '@radixdlt/application'
+import { AccountAddressT, HRP, ValidatorAddressT } from '@radixdlt/application'
 
 export const formatWalletAddressForDisplay = function (address: AccountAddressT): string {
   const s = address.toString()
@@ -10,26 +10,44 @@ export const formatValidatorAddressForDisplay = function (address: ValidatorAddr
   return s.substring(0, 2) + '...' + s.substring(s.length - 9)
 }
 
-export const truncateRRIStringForDisplay = function (rriString: string): any {
-  const arrOfValues = []
-  for (const [key, val] of Object.entries(HRP)) {
-    arrOfValues.push(val.RRI_suffix)
-  }
-
-  // Sort by largest -> Smallest since some suffixes have length 3 and some have 2
+export const truncateRRIStringForDisplay = function (rriString: string): string {
+  // Sort by largest -> Smallest since some suffixes have length 4 and some have 3
   // Avoiding scenarios such as matching '_tr' first when there is a '_tr3'
-  arrOfValues.sort(function (a, b) {
+  // If no RRI suffix match, will return regular string
+  // Return original RRI String if <= 21, following Wireframe design examples
+  if (rriString.length <= 21) {
+    return rriString
+  }
+  const sortedHRPKeys = getSortedHRPKeys()
+  const correctRRISuffix = getCorrectRRISuffixFromHRP(sortedHRPKeys, rriString)
+  // Catch in case no RRI Suffix was found in Networks/HRP
+  if (correctRRISuffix === '') {
+    return rriString
+  }
+  const prefixLength = getRRIPrefixLength(correctRRISuffix, rriString)
+  return rriString.substring(0, prefixLength) + '...' + rriString.substring(rriString.length - 9)
+}
+
+const getSortedHRPKeys = function (): string[] {
+  const allHRPKeys = []
+  for (const [key, val] of Object.entries(HRP)) {
+    allHRPKeys.push(val.RRI_suffix)
+  }
+  allHRPKeys.sort(function (a, b) {
     return b.length - a.length
   })
+  return allHRPKeys
+}
 
-  const correctSuffix = arrOfValues.filter((suffix) => {
+const getCorrectRRISuffixFromHRP = function (hrpKeys: string[], rriString: string): string {
+  // Using regex /${suffix}/.exec(rriString) to return the right suffix
+  const rriStringMatchHRPKey = hrpKeys.filter((suffix) => {
     return rriString.match(suffix)! != null
   })
+  return rriStringMatchHRPKey[0]
+}
 
-  const charsUntilSuffixEnd = correctSuffix.map((suffix) => {
-    return rriString.match(suffix)!.index // suffix.length // + matchDetails[1]
-  })
-
-  const prefixLength = charsUntilSuffixEnd[0]! + correctSuffix[0].length
-  return rriString.substring(0, prefixLength) + '...' + rriString.substring(rriString.length - 9)
+const getRRIPrefixLength = function (rriSuffix: string, rriString: string): number {
+  const match = rriString.match(rriSuffix)!
+  return match.index! + rriSuffix.length
 }

--- a/src/views/Wallet/WalletOverview.vue
+++ b/src/views/Wallet/WalletOverview.vue
@@ -63,6 +63,13 @@
           </a>
           </div>
         </div>
+        <div class="flex flex-row">
+          <div class="flex-1 flex flex-row items-center px-6 pt-3 overflow-x-auto">
+            <span class="text-sm text-rGrayDark">{{ truncateOtherToken(tokenBalance.token.rri.toString()) }}</span>
+            <click-to-copy :address="tokenBalance.token.rri.toString()">
+            </click-to-copy>
+          </div>
+        </div>
           <div class="flex flex-row py-1">
             <div class="flex-1 flex flex-row items-center px-6 py-3 overflow-x-auto">
               <big-amount :amount="tokenBalance.amount" class="text-5xl font-light mr-4 text-rBlack" />
@@ -83,6 +90,7 @@ import TokenSymbol from '@/components/TokenSymbol.vue'
 import ClickToCopy from '@/components/ClickToCopy.vue'
 import { ref } from '@nopr3d/vue-next-rx'
 import { sumAmounts, subtract, add } from '@/helpers/arithmetic'
+import { truncateRRIStringForDisplay } from '@/helpers/formatter'
 import { createRRIUrl } from '@/helpers/explorerLinks'
 
 const WalletOverview = defineComponent({
@@ -94,7 +102,8 @@ const WalletOverview = defineComponent({
 
   setup () {
     return {
-      createOtherTokenUrl: createRRIUrl
+      createOtherTokenUrl: createRRIUrl,
+      truncateOtherToken: truncateRRIStringForDisplay
     }
   },
 

--- a/src/views/Wallet/WalletOverview.vue
+++ b/src/views/Wallet/WalletOverview.vue
@@ -66,8 +66,9 @@
         <div class="flex flex-row">
           <div class="flex-1 flex flex-row items-center px-6 pt-3 overflow-x-auto">
             <span class="text-sm text-rGrayDark">{{ truncateOtherToken(tokenBalance.token.rri.toString()) }}</span>
-            <click-to-copy :address="tokenBalance.token.rri.toString()">
-            </click-to-copy>
+            <div class="hover:text-rGreen flex flex-row items-center cursor-pointer transition-colors">
+              <click-to-copy :address="tokenBalance.token.rri.toString()"/>
+            </div>
           </div>
         </div>
           <div class="flex flex-row py-1">

--- a/src/views/Wallet/WalletOverview.vue
+++ b/src/views/Wallet/WalletOverview.vue
@@ -46,8 +46,18 @@
         <div
           v-for="(tokenBalance, i) in otherTokenBalances"
           :key="i"
-          class="border border-rGray rounded-md divide-x divide-rGray"
+          class="border border-rGray rounded-md  divide-rGray"
         >
+        <div class="flex justify-end">
+          <a :href="createOtherTokenUrl(tokenBalance.token.rri.toString())" target="_blank" class="hover:text-rGreen transition-colors text-rGrayMed">
+            <div class="rounded-full border border-solid border-rGray w-6 h-6 flex items-center justify-center">
+              <svg width="8" height="8" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M1.08789 1H11.1344V11.0465" class="stroke-current" stroke-miterlimit="10"/>
+                <path d="M11.1339 1L1 11.134" class="stroke-current" stroke-miterlimit="10"/>
+              </svg>
+            </div>
+          </a>
+        </div>
           <div class="flex flex-row py-1">
             <div class="flex-1 flex flex-row items-center px-6 py-7 overflow-x-auto">
               <big-amount :amount="tokenBalance.amount" class="text-2xl font-light mr-4 text-rBlack" />
@@ -68,12 +78,19 @@ import TokenSymbol from '@/components/TokenSymbol.vue'
 import ClickToCopy from '@/components/ClickToCopy.vue'
 import { ref } from '@nopr3d/vue-next-rx'
 import { sumAmounts, subtract, add } from '@/helpers/arithmetic'
+import { createRRIUrl } from '@/helpers/explorerLinks'
 
 const WalletOverview = defineComponent({
   components: {
     BigAmount,
     TokenSymbol,
     ClickToCopy
+  },
+
+  setup () {
+    return {
+      createOtherTokenUrl: createRRIUrl
+    }
   },
 
   props: {

--- a/src/views/Wallet/WalletOverview.vue
+++ b/src/views/Wallet/WalletOverview.vue
@@ -48,7 +48,11 @@
           :key="i"
           class="border border-rGray rounded-md  divide-rGray"
         >
-        <div class="flex justify-end">
+        <div class="flex flex-row py-1">
+          <div class="flex-1 flex flex-row items-center px-6 pt-3 overflow-x-auto">
+            <span class="text-sm text-rGrayDark">{{ tokenBalance.token.name }}</span>
+          </div>
+          <div>
           <a :href="createOtherTokenUrl(tokenBalance.token.rri.toString())" target="_blank" class="hover:text-rGreen transition-colors text-rGrayMed">
             <div class="rounded-full border border-solid border-rGray w-6 h-6 flex items-center justify-center">
               <svg width="8" height="8" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -57,11 +61,12 @@
               </svg>
             </div>
           </a>
+          </div>
         </div>
           <div class="flex flex-row py-1">
-            <div class="flex-1 flex flex-row items-center px-6 py-7 overflow-x-auto">
-              <big-amount :amount="tokenBalance.amount" class="text-2xl font-light mr-4 text-rBlack" />
-              <token-symbol>{{ tokenBalance.token.symbol.toUpperCase() }}</token-symbol>
+            <div class="flex-1 flex flex-row items-center px-6 py-3 overflow-x-auto">
+              <big-amount :amount="tokenBalance.amount" class="text-5xl font-light mr-4 text-rBlack" />
+              <token-symbol class="mt-3">{{ tokenBalance.token.symbol.toUpperCase() }}</token-symbol>
             </div>
           </div>
         </div>

--- a/src/views/Wallet/WalletOverview.vue
+++ b/src/views/Wallet/WalletOverview.vue
@@ -54,7 +54,7 @@
           </div>
           <div>
           <a :href="createOtherTokenUrl(tokenBalance.token.rri.toString())" target="_blank" class="hover:text-rGreen transition-colors text-rGrayMed">
-            <div class="rounded-full border border-solid border-rGray w-6 h-6 flex items-center justify-center">
+            <div class="rounded-full border border-solid border-rGray w-6 h-6 flex items-center justify-center mr-1">
               <svg width="8" height="8" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M1.08789 1H11.1344V11.0465" class="stroke-current" stroke-miterlimit="10"/>
                 <path d="M11.1339 1L1 11.134" class="stroke-current" stroke-miterlimit="10"/>


### PR DESCRIPTION
This PR matches the design style and rearranges other token balance divs. Link in corner leads to token RRI page in Explorer.

[Part of RDX-69](https://linear.app/township/issue/RDX-69/feat-token-rris)

[UPDATED Demo w/ RRI String truncation](https://www.loom.com/share/96704d766dfa44378e273b63676a9311)

[Previous Demo no RRI String truncation](https://www.loom.com/share/65c2cc327d7b4fbdbb76e01c6d806ed9)