### PR TITLE
fix: Regressions in password error messages and forgot password submission

### DIFF
--- a/src/components/FormField.vue
+++ b/src/components/FormField.vue
@@ -8,6 +8,7 @@
     :rules="rules"
     :data-ci="dataCi"
     :validateOnInput="validateOnInput"
+    :validateOnBlur="validateOnBlur"
   ></Field>
 </template>
 
@@ -49,6 +50,11 @@ const FormField = defineComponent({
       type: Boolean,
       required: false,
       default: false
+    },
+    validateOnBlur: {
+      type: Boolean,
+      required: false,
+      default: true
     }
   }
 })

--- a/src/views/Home/HomeEnterPasscode.vue
+++ b/src/views/Home/HomeEnterPasscode.vue
@@ -17,6 +17,7 @@
           data-ci="create-wallet-passcode-input"
           id="password"
           :validateOnInput="false"
+          :validateOnBlur="false"
         />
         <FormErrorMessage name="password" class="text-sm text-red-400" />
       </div>

--- a/src/views/Home/HomeEnterPasscode.vue
+++ b/src/views/Home/HomeEnterPasscode.vue
@@ -16,17 +16,18 @@
           rules="required"
           data-ci="create-wallet-passcode-input"
           id="password"
-          :validateOnInput="true"
+          :validateOnInput="false"
         />
+        <FormErrorMessage name="password" class="text-sm text-red-400" />
       </div>
 
       <ButtonSubmit class="w-96" :disabled="disableSubmit">
         {{ $t('home.passwordButton') }}
       </ButtonSubmit>
-      <div>
-        <a @click="this.$emit('forgotPassword')" class="w-96 text-rGrayMed text-sm text-center py-4 block">{{ $t('home.forgotPassword')}}</a>
-      </div>
     </form>
+    <div>
+      <button @click.prevent="forgotPassword" role="button" type="button" class="w-96 text-rGrayMed text-sm text-center py-4 block cursor-pointer focus:ring-0">{{ $t('home.forgotPassword')}}</button>
+    </div>
   </div>
 </template>
 
@@ -34,6 +35,8 @@
 import { defineComponent } from 'vue'
 import { useForm } from 'vee-validate'
 import FormField from '@/components/FormField.vue'
+import FormErrorMessage from '@/components/FormErrorMessage.vue'
+
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
 
 interface PasswordForm {
@@ -43,7 +46,8 @@ interface PasswordForm {
 const HomeEnterPasscode = defineComponent({
   components: {
     ButtonSubmit,
-    FormField
+    FormField,
+    FormErrorMessage
   },
 
   setup () {
@@ -68,7 +72,13 @@ const HomeEnterPasscode = defineComponent({
     if (passEl) passEl.focus()
   },
 
-  emits: ['submit', 'forgotPassword']
+  emits: ['submit', 'forgotPassword'],
+
+  methods: {
+    forgotPassword () {
+      this.$emit('forgotPassword')
+    }
+  }
 })
 
 export default HomeEnterPasscode

--- a/src/views/Home/index.vue
+++ b/src/views/Home/index.vue
@@ -32,9 +32,9 @@
           ref="enterPasscodeComponent"
         />
       </div>
-      <home-locked-modal :open="modal === 'locked-out'" @close="closeModal"/>
+      <home-locked-modal :open="uiModal === 'locked-out'" @close="closeModal"/>
       <home-forgot-password
-        :open="modal === 'forgot-password'"
+        :open="uiModal === 'forgot-password'"
         @close="closeModal"
         @resetAndCreate="resetAndCreate"
         @resetAndRestore="resetAndRestore"
@@ -44,7 +44,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive } from 'vue'
+import { defineComponent, reactive, ref, onBeforeMount } from 'vue'
 import { ErrorNotification, WalletErrorCause, WalletT } from '@radixdlt/application'
 import { hasKeystore, touchKeystore } from '@/actions/vue/create-wallet'
 import { useStore } from '@/store'
@@ -56,7 +56,7 @@ import LoadingIcon from '@/components/LoadingIcon.vue'
 import { Subscription } from 'rxjs'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { ref } from '@nopr3d/vue-next-rx'
+import { ref as rxRef } from '@nopr3d/vue-next-rx'
 import { filter } from 'rxjs/operators'
 import { resetStore } from '@/actions/vue/data-store'
 import { radixConnection } from '@/helpers/network'
@@ -77,13 +77,19 @@ const CreateWallet = defineComponent({
     }
   },
 
-  async setup () {
+  async setup (props) {
+    const uiModal = ref('')
+
+    onBeforeMount(() => {
+      if (props.modal) { uiModal.value = props.modal }
+    })
+
     const hasWallet = reactive({ value: null as boolean | null })
     const store = useStore()
     const router = useRouter()
     const { t } = useI18n({ useScope: 'global' })
 
-    const enterPasscodeComponent = ref(null)
+    const enterPasscodeComponent = rxRef(null)
 
     const radix = await radixConnection()
     const subs = new Subscription()
@@ -115,16 +121,17 @@ const CreateWallet = defineComponent({
     return {
       // state
       hasWallet,
+      uiModal,
       // methods
       loginWithWallet,
       // component refs
       enterPasscodeComponent,
       closeModal () {
-        router.push({ name: 'Home', query: { modal: '' } })
+        uiModal.value = ''
       },
 
       forgotPassword () {
-        router.push({ name: 'Home', query: { modal: 'forgot-password' } })
+        uiModal.value = 'forgot-password'
       },
 
       resetAndCreate () {


### PR DESCRIPTION
This PR fixes:

### [Regression: No error on incorrect password](https://linear.app/township/issue/RDX-222/regression-no-error-on-incorrect-password)

> At some point entering an incorrect password stopped showing an error message.

At some point in time, we removed the Error message component from the home page.

and

### [Regression: "I forgot my password" link no longer words](https://linear.app/township/issue/RDX-223/regression-i-forgot-my-password-link-no-longer-works)

> At least not reliably. Some users manage to get it to work by "clicking around", but I confirmed that in general it's just a dead link.

The home routes 'modal' was driven by a prop that once initialized was not tracked.  This PR fixes that by introducing a `ref` for the value rather than relying on the initial prop.
