### PR TITLE
fix: Show Word Numbers when revealing the seed phrase in settings

### DIFF
--- a/src/components/MnemonicDisplay.vue
+++ b/src/components/MnemonicDisplay.vue
@@ -3,7 +3,7 @@
     class="w-40 border rounded-full border-rGray leading-tight h-16 justify-center inline-flex items-center"
   >
     <div :class="{ 'filter-blur': obfuscate }">
-      {{ word }}
+      {{index + 1}}. {{ word }}
     </div>
   </div>
 </template>
@@ -20,6 +20,10 @@ const MnemonicDisplay = defineComponent({
     word: {
       type: String,
       required: false
+    },
+    index: {
+      type: Number,
+      required: true
     }
   }
 })

--- a/src/views/Settings/SettingsRevealMnemonic.vue
+++ b/src/views/Settings/SettingsRevealMnemonic.vue
@@ -15,6 +15,7 @@
       >
         <mnemonic-display
           :word="word"
+          :index="i"
           :obfuscate="!this.mnemonic"
         >
         </mnemonic-display>


### PR DESCRIPTION
<img width="1212" alt="Screen Shot 2021-08-19 at 1 30 25 PM" src="https://user-images.githubusercontent.com/2738409/130116477-7e50db45-4771-454c-b181-a756268a69e8.png">
