### PR TITLE
chore: temporarily, latest builds target stokenet

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Build/release Electron app
         uses: samuelmeuli/action-electron-builder@v1
         env:
-          VUE_APP_NETWORK_NAME: mainnet
-          VUE_APP_EXPLORER: https://explorer.radixdlt.com
+          VUE_APP_NETWORK_NAME: stokenet
+          VUE_APP_EXPLORER: https://stokenet-explorer.radixdlt.com
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
         with:


### PR DESCRIPTION
There's a need to deliver stokenet builds for testing purposes. We'd like those stokenet builds to be produced as similarly as possible to our mainnet builds. So, temporarily, all builds on the latest channel will target stokenet.

This work will be undone when the imminent Network Selection work is complete.