### PR TITLE
feat: Introduce NativeToken and TokenBalances composables

### DIFF
--- a/src/components/ActionListItemUnstakeTokens.vue
+++ b/src/components/ActionListItemUnstakeTokens.vue
@@ -5,7 +5,7 @@
         <img src="@/assets/unstakeTokens.svg" alt="receive tokens" />
         <span class="ml-2 text-sm">{{ $t('history.unstakeAction') }}</span>
       </div>
-      <div><big-amount :amount="action.amount" class="text-rBlack text-base"/> {{ nativeToken.symbol.toUpperCase() }}</div>
+      <div v-if="action.amount && nativeToken"><big-amount :amount="action.amount" class="text-rBlack text-base"/> {{ nativeToken.symbol.toUpperCase() }}</div>
     </div>
     <div class="flex flex-col items-end">
       <div class="flex flex-row flex-1 min-w-0 items-center">

--- a/src/components/TransactionListItem.vue
+++ b/src/components/TransactionListItem.vue
@@ -24,7 +24,7 @@
     <div v-else class="bg-rGrayLightest text-rGrayDark text-sm pl-3 w-40 flex items-center">
       {{ sentAt }}
     </div>
-    <div class="flex-1">
+    <div class="flex-1" v-if="nativeToken">
       <div class="py-3.5 px-3">
         <div v-for="(action, i) in relatedActions" :key="i">
           <action-list-item-stake-tokens

--- a/src/components/TransactionListItem.vue
+++ b/src/components/TransactionListItem.vue
@@ -119,7 +119,7 @@ export default defineComponent({
     },
     nativeToken: {
       type: Object as PropType<Token>,
-      required: true
+      required: false
     },
     decryptedMessage: {
       type: String as PropType<string>,

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -2,6 +2,7 @@ import useConnectableRadix from './useConnectableRadix'
 import useHomeModal from './useHomeModal'
 import useNativeToken from './useNativeToken'
 import useRadix from './useRadix'
+import useStaking from './useStaking'
 import useSidebar from './useSidebar'
 import useTokenBalances from './useTokenBalances'
 import useWallet from './useWallet'
@@ -11,6 +12,7 @@ export {
   useHomeModal,
   useNativeToken,
   useRadix,
+  useStaking,
   useSidebar,
   useTokenBalances,
   useWallet

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -1,13 +1,17 @@
+import useConnectableRadix from './useConnectableRadix'
 import useHomeModal from './useHomeModal'
+import useNativeToken from './useNativeToken'
 import useRadix from './useRadix'
 import useSidebar from './useSidebar'
+import useTokenBalances from './useTokenBalances'
 import useWallet from './useWallet'
-import useConnectableRadix from './useConnectableRadix'
 
 export {
+  useConnectableRadix,
   useHomeModal,
+  useNativeToken,
   useRadix,
   useSidebar,
-  useWallet,
-  useConnectableRadix
+  useTokenBalances,
+  useWallet
 }

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -4,6 +4,7 @@ import useNativeToken from './useNativeToken'
 import useRadix from './useRadix'
 import useStaking from './useStaking'
 import useSidebar from './useSidebar'
+import useTransactions from './useTransactions'
 import useTokenBalances from './useTokenBalances'
 import useWallet from './useWallet'
 
@@ -14,6 +15,7 @@ export {
   useRadix,
   useStaking,
   useSidebar,
+  useTransactions,
   useTokenBalances,
   useWallet
 }

--- a/src/composables/useNativeToken.ts
+++ b/src/composables/useNativeToken.ts
@@ -1,0 +1,21 @@
+import { ref, Ref } from 'vue'
+import { RadixT, Token } from '@radixdlt/application'
+
+interface useNativeTokenInterface {
+  readonly nativeToken: Ref<Token | null>;
+  nativeTokenUnsub: () => void;
+}
+
+export default function useNativeToken (radix: RadixT): useNativeTokenInterface {
+  const nativeToken: Ref<Token | null> = ref(null)
+  const nativeTokenSub = radix.ledger.nativeToken().subscribe((nativeTokenRes: Token) => {
+    nativeToken.value = nativeTokenRes
+  })
+
+  return {
+    nativeToken,
+    nativeTokenUnsub: () => {
+      nativeTokenSub.unsubscribe()
+    }
+  }
+}

--- a/src/composables/useStaking.ts
+++ b/src/composables/useStaking.ts
@@ -1,0 +1,25 @@
+import { ref, Ref } from 'vue'
+import { RadixT, StakePositions, UnstakePositions } from '@radixdlt/application'
+
+interface useStakingInterface {
+  readonly activeStakes: Ref<StakePositions | null>;
+  readonly activeUnstakes: Ref<UnstakePositions | null>;
+  stakingUnsub: () => void;
+}
+
+export default function useStaking (radix: RadixT): useStakingInterface {
+  const activeStakes: Ref<StakePositions | null> = ref(null)
+  const activeUnstakes: Ref<UnstakePositions | null> = ref(null)
+
+  const activeStakesSub = radix.stakingPositions.subscribe((stakes: StakePositions) => { activeStakes.value = stakes })
+  const activeUnstakesSub = radix.unstakingPositions.subscribe((unstakes: UnstakePositions) => { activeUnstakes.value = unstakes })
+
+  return {
+    activeStakes,
+    activeUnstakes,
+    stakingUnsub: () => {
+      activeStakesSub.unsubscribe()
+      activeUnstakesSub.unsubscribe()
+    }
+  }
+}

--- a/src/composables/useTokenBalances.ts
+++ b/src/composables/useTokenBalances.ts
@@ -1,0 +1,27 @@
+import { ref, Ref } from 'vue'
+import { RadixT, Token, TokenBalance, TokenBalances } from '@radixdlt/application'
+
+interface useTokenBalancesInterface {
+  readonly tokenBalances: Ref<TokenBalances | null>;
+  tokenBalancesUnsub: () => void;
+  tokenBalanceFor: (token: Token) => TokenBalance | null;
+}
+
+export default function useTokenBalances (radix: RadixT): useTokenBalancesInterface {
+  const tokenBalances: Ref<TokenBalances | null> = ref(null)
+  const tokenBalancesSub = radix.tokenBalances.subscribe((tokenBalancesRes: TokenBalances) => {
+    tokenBalances.value = tokenBalancesRes
+  })
+
+  return {
+    tokenBalances,
+    tokenBalancesUnsub: () => {
+      tokenBalancesSub.unsubscribe()
+    },
+
+    tokenBalanceFor: (token: Token) => {
+      if (!tokenBalances.value) return null
+      return tokenBalances.value.tokenBalances.find((tb: TokenBalance) => tb.token.rri.equals(token.rri)) || null
+    }
+  }
+}

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -1,0 +1,385 @@
+import { computed, ComputedRef, ref, Ref } from 'vue'
+import { BehaviorSubject, combineLatest, firstValueFrom, Observable, ReplaySubject, Subject, Subscription } from 'rxjs'
+import { mergeMap, retry, filter } from 'rxjs/operators'
+import {
+  AmountT,
+  ExecutedTransaction,
+  FinalizedTransaction,
+  IntendedAction,
+  ManualUserConfirmTX,
+  MessageInTransaction,
+  RadixT,
+  StakeOptions,
+  StakeTokensInput,
+  TokenBalance,
+  TransactionHistory,
+  TransactionHistoryOfKnownAddressRequestInput,
+  TransactionIntent,
+  TransactionStateError,
+  TransactionStateSuccess,
+  TransactionStateUpdate,
+  TransactionIdentifierT,
+  TransactionTracking,
+  TransferTokensInput,
+  TransferTokensOptions,
+  UnstakeOptions,
+  UnstakeTokensInput,
+  AccountT
+} from '@radixdlt/application'
+import { Router } from 'vue-router'
+
+export interface PendingTransaction extends TransactionStateSuccess {
+  actions: IntendedAction[]
+}
+
+interface useTransactionsInterface {
+  readonly activeMessageInTransaction: Ref<MessageInTransaction | null>;
+  readonly activeTransaction: Ref<TransactionTracking | null>;
+  readonly activeTransactionForm: Ref<string | null>;
+  readonly confirmationMode: Ref<string | null>;
+  readonly decryptedMessages: Ref<{id: string, message: string}[]>;
+  readonly selectedCurrency: Ref<TokenBalance | null>;
+  readonly shouldShowConfirmation: Ref<boolean>;
+  readonly stakeInput: Ref<StakeTokensInput | null>;
+  readonly transactionState: Ref<string>;
+  readonly transferInput: Ref<TransferTokensInput | null>;
+  readonly transactionFee: Ref<AmountT | null>;
+  readonly transactionHistory: Ref<TransactionHistory>;
+  readonly transactionErrorMessage: Ref<string | null>;
+  readonly pendingTransactions: Ref<Array<PendingTransaction>>;
+  readonly canGoBack: ComputedRef<boolean>;
+  readonly canGoNext: Ref<boolean>;
+  readonly loadingHistory: Ref<boolean>;
+
+  cancelTransaction: () => void;
+  confirmTransaction: () => void;
+  decryptMessage: (tx: ExecutedTransaction) => void;
+  nextPage: () => void;
+  previousPage: () => void;
+  refreshHistory: () => void;
+  setActiveTransactionForm: (val: string) => void;
+  stakeTokens: (input: StakeTokensInput) => void;
+  transferTokens: (input: TransferTokensInput, message: MessageInTransaction, sc: TokenBalance) => void;
+  unstakeTokens: (input: UnstakeTokensInput) => void;
+  transactionUnsub: () => void;
+}
+
+const subs = new Subscription()
+
+const PAGE_SIZE = 50
+
+const activeMessage: Ref<string> = ref('')
+const activeMessageInTransaction: Ref<MessageInTransaction | null> = ref(null)
+const activeTransaction: Ref<TransactionTracking | null> = ref(null)
+const activeTransactionForm: Ref<string | null> = ref(null)
+const ledgerTxError: Ref<Error | null> = ref(null)
+const loadingHistory: Ref<boolean> = ref(true)
+const loadingHistoryPage: Ref<boolean> = ref(true)
+
+const selectedCurrency: Ref<TokenBalance | null> = ref(null)
+const shouldShowConfirmation: Ref<boolean> = ref(false)
+const canGoNext: Ref<boolean> = ref(false)
+const confirmationMode: Ref<string | null> = ref(null)
+const cursorStack: Ref<string[]> = ref([])
+const decryptedMessages: Ref<{id: string, message: string}[]> = ref([])
+const draftTransaction: Ref<TransactionIntent | null> = ref(null)
+const pendingTransactions: Ref<Array<PendingTransaction>> = ref([])
+const stakeInput: Ref<StakeTokensInput | null> = ref(null)
+const transactionErrorMessage: Ref<string | null> = ref(null)
+const transactionFee: Ref<AmountT | null> = ref(null)
+const transactionHistory: Ref<TransactionHistory> = ref({ transactions: [], cursor: '' })
+const transactionToConfirm: Ref<ManualUserConfirmTX | null> = ref(null)
+const transferInput: Ref<TransferTokensInput | null> = ref(null)
+const hasCalculatedFee: Ref<boolean> = ref(false)
+
+// can be building, confirm, submitting
+const transactionState: Ref<string> = ref('confirm')
+const userDidConfirm = new Subject<boolean>()
+const userDidCancel = new Subject<boolean>()
+let userConfirmation = new ReplaySubject<ManualUserConfirmTX>()
+const historyPagination = new Subject<TransactionHistoryOfKnownAddressRequestInput>()
+
+export default function useTransactions (radix: RadixT, router: Router, activeAccount: AccountT | null, hardwareAccount: AccountT | null, callbacks: { ledgerSigningError: () => void;}): useTransactionsInterface {
+  const refreshHistory = () => {
+    loadingHistory.value = true
+    historyPagination.next({ size: PAGE_SIZE })
+  }
+
+  const canGoBack = computed(() => cursorStack.value.length > 0)
+
+  const nextPage = () => {
+    loadingHistoryPage.value = true
+    cursorStack.value.push(transactionHistory.value.cursor)
+    historyPagination.next({
+      size: PAGE_SIZE,
+      cursor: cursorStack.value[cursorStack.value.length - 1]
+    })
+  }
+
+  const previousPage = () => {
+    loadingHistoryPage.value = true
+    cursorStack.value.pop()
+    historyPagination.next({
+      size: PAGE_SIZE,
+      cursor: cursorStack.value.length > 0 ? cursorStack.value[cursorStack.value.length - 1] : ''
+    })
+  }
+
+  const decryptMessage = (tx: ExecutedTransaction) => {
+    firstValueFrom(radix.decryptTransaction(tx)).then((val) => {
+      decryptedMessages.value.push({ id: tx.txID.toString(), message: val })
+    })
+  }
+  // Fetch history when user navigates to next page
+  const historySub = historyPagination.asObservable()
+    .pipe(
+      mergeMap((params: TransactionHistoryOfKnownAddressRequestInput) =>
+        radix.transactionHistory(params).pipe(retry())
+      )
+    )
+    .subscribe((history: TransactionHistory) => {
+      loadingHistory.value = false
+      loadingHistoryPage.value = false
+      if (history.cursor && history.transactions.length === PAGE_SIZE) canGoNext.value = true
+      else canGoNext.value = false
+      transactionHistory.value = history
+    })
+
+  const confirmTransaction = () => {
+    if (activeAccount && hardwareAccount && activeAccount === hardwareAccount) {
+      transactionState.value = 'hw-signing'
+    }
+    userDidConfirm.next(true)
+    hasCalculatedFee.value = false
+  }
+
+  const cancelTransaction = () => {
+    userDidCancel.next(true)
+    hasCalculatedFee.value = false
+  }
+
+  const setActiveTransactionForm = (val: string) => {
+    activeTransactionForm.value = val
+  }
+
+  const confirmAndExecuteTransaction = (transactionTracking: TransactionTracking) => {
+    activeTransaction.value = transactionTracking
+    const transactionDidComplete = new BehaviorSubject<boolean>(false)
+    userDidCancel.next(false)
+    transactionState.value = 'building'
+    shouldShowConfirmation.value = true
+    console.log(shouldShowConfirmation.value)
+    // Subscribe to initial userConfirmation and display modal
+    const createUserConfirmation = userConfirmation
+      .subscribe((txnToConfirm: ManualUserConfirmTX) => {
+        transactionToConfirm.value = txnToConfirm
+        userDidConfirm.next(false)
+        transactionState.value = 'confirm'
+        transactionFee.value = txnToConfirm.txToConfirm.fee
+        hasCalculatedFee.value = true
+      })
+    subs.add(createUserConfirmation)
+
+    // Confirm transaction and move user to history view after they press confirm
+    const watchUserDidConfirm = combineLatest<[ManualUserConfirmTX, boolean]>([userConfirmation, userDidConfirm])
+      .subscribe(([txnToConfirm, didConfirm]: [ManualUserConfirmTX, boolean]) => {
+        if (didConfirm) { txnToConfirm.confirm() }
+      })
+    subs.add(watchUserDidConfirm)
+
+    // Catch errors that were silently failing
+    const trackingSubmittedEventErrors = transactionTracking.events
+      .pipe(filter((trackingEvent: TransactionStateUpdate) => {
+        const errorEvent: TransactionStateError = trackingEvent as TransactionStateError
+        return errorEvent && errorEvent.error != null
+      }))
+      .subscribe((event: TransactionStateUpdate) => {
+        const errorEvent: TransactionStateError = event as TransactionStateError
+        userDidCancel.next(true)
+        shouldShowConfirmation.value = false
+        const isLedgerConnectedError = errorEvent.error.message && errorEvent.error.message.includes('Failed to sign tx with Ledger')
+        if (isLedgerConnectedError) {
+          ledgerTxError.value = errorEvent.error
+          callbacks.ledgerSigningError()
+          transactionErrorMessage.value = null
+          return
+        }
+
+        transactionErrorMessage.value = `validations.${activeTransactionForm.value}Failed`
+      })
+
+    subs.add(trackingSubmittedEventErrors)
+
+    // Store draft transaction actions
+    subs.add(transactionTracking.events
+      .pipe(filter((trackingEvent: TransactionStateUpdate) => trackingEvent.eventUpdateType === 'INITIATED'))
+      .subscribe((res: TransactionStateUpdate) => {
+        draftTransaction.value = (res as TransactionStateSuccess).transactionState as TransactionIntent
+      }))
+
+    // Track pending transactions augmented with actions array
+    const trackingSubmittedEvents = transactionTracking.events
+      .pipe(filter((trackingEvent: TransactionStateUpdate) => trackingEvent.eventUpdateType === 'SUBMITTED'))
+      .subscribe((res: TransactionStateUpdate) => {
+        const finalizedTransaction = res as unknown as TransactionStateSuccess
+        pendingTransactions.value = pendingTransactions.value.concat([{
+          ...finalizedTransaction,
+          actions: draftTransaction.value ? draftTransaction.value.actions : []
+        }])
+        draftTransaction.value = null
+        transactionState.value = 'submitting'
+      })
+    subs.add(trackingSubmittedEvents)
+
+    // When a transaction has been completed, remove it from pending transactions
+    subs.add(transactionTracking.completion
+      .subscribe({
+        next: (txnID: TransactionIdentifierT) => {
+          pendingTransactions.value = pendingTransactions.value.filter((pendingTxn: TransactionStateSuccess) => {
+            const transactionState = pendingTxn.transactionState as unknown as FinalizedTransaction
+            return txnID.toString() !== transactionState.txID.toString()
+          })
+          shouldShowConfirmation.value = false
+          router.push('/wallet/history')
+          hasCalculatedFee.value = false
+          transactionDidComplete.next(true)
+        }
+      }))
+
+    // Cleanup subscriptions on cancel and complete
+    const cleanupTransactionSubs = () => {
+      userConfirmation = new ReplaySubject<ManualUserConfirmTX>()
+      createUserConfirmation.unsubscribe()
+      watchUserDidConfirm.unsubscribe()
+      trackingSubmittedEvents.unsubscribe()
+      hasCalculatedFee.value = false
+      transactionErrorMessage.value = null
+    }
+
+    userDidCancel.subscribe((didCancel: boolean) => {
+      if (didCancel) {
+        cleanupTransactionSubs()
+        shouldShowConfirmation.value = false
+        activeMessage.value = ''
+        hasCalculatedFee.value = false
+      }
+    })
+
+    subs.add(transactionDidComplete.subscribe((didComplete: boolean) => {
+      if (didComplete) {
+        cleanupTransactionSubs()
+        activeMessage.value = ''
+        hasCalculatedFee.value = false
+        historyPagination.next({ size: PAGE_SIZE })
+      }
+    }))
+  }
+
+  const cleanupInputs = () => {
+    transferInput.value = null
+    stakeInput.value = null
+  }
+
+  // call transferTokens() with built options and subscribe to confirmation and results
+  const transferTokens = (transferTokensInput: TransferTokensInput, message: MessageInTransaction, sc: TokenBalance) => {
+    let pollTXStatusTrigger: Observable<unknown>
+    cleanupInputs()
+    transferInput.value = transferTokensInput
+    selectedCurrency.value = sc
+    activeMessage.value = message.plaintext
+    activeMessageInTransaction.value = message
+    confirmationMode.value = 'transfer'
+    const buildTransferTokens = (): TransferTokensOptions => ({
+      transferInput: transferTokensInput,
+      userConfirmation: userConfirmation,
+      pollTXStatusTrigger: pollTXStatusTrigger
+    })
+
+    const transactionTracking: TransactionTracking = radix.transferTokens({
+      ...buildTransferTokens(),
+      userConfirmation,
+      message
+    })
+
+    confirmAndExecuteTransaction(transactionTracking)
+  }
+
+  // call unstakeTokens() with built options and subscribe to confirmation and results
+  const unstakeTokens = (unstakeTokensInput: UnstakeTokensInput) => {
+    let pollTXStatusTrigger: Observable<unknown>
+    cleanupInputs()
+    stakeInput.value = unstakeTokensInput
+    confirmationMode.value = 'unstake'
+
+    const buildTransferTokens = (): UnstakeOptions => ({
+      unstakeInput: unstakeTokensInput,
+      userConfirmation: userConfirmation,
+      pollTXStatusTrigger: pollTXStatusTrigger
+    })
+
+    const unstakingTransactionTracking: TransactionTracking = radix.unstakeTokens({
+      ...buildTransferTokens(),
+      userConfirmation
+    })
+
+    confirmAndExecuteTransaction(unstakingTransactionTracking)
+  }
+
+  // call stakeTokens() with built options and subscribe to confirmation and results
+  const stakeTokens = (stakeTokensInput: StakeTokensInput) => {
+    let pollTXStatusTrigger: Observable<unknown>
+    cleanupInputs()
+    stakeInput.value = stakeTokensInput
+    confirmationMode.value = 'stake'
+
+    const buildTransferTokens = (): StakeOptions => ({
+      stakeInput: stakeTokensInput,
+      userConfirmation: userConfirmation,
+      pollTXStatusTrigger: pollTXStatusTrigger
+    })
+
+    const stakingTransactionTracking: TransactionTracking = radix.stakeTokens({
+      ...buildTransferTokens(),
+      userConfirmation
+    })
+
+    confirmAndExecuteTransaction(stakingTransactionTracking)
+  }
+
+  const transactionUnsub = () => {
+    historySub.unsubscribe()
+    cursorStack.value = []
+  }
+
+  return {
+    activeMessageInTransaction,
+    activeTransaction,
+    activeTransactionForm,
+    confirmationMode,
+    decryptedMessages,
+    selectedCurrency,
+    shouldShowConfirmation,
+    stakeInput,
+    transactionState,
+    transferInput,
+    transactionFee,
+    transactionHistory,
+    transactionErrorMessage,
+    pendingTransactions,
+    canGoBack,
+    canGoNext,
+    loadingHistory,
+
+    cancelTransaction,
+    confirmTransaction,
+    decryptMessage,
+    nextPage,
+    previousPage,
+    refreshHistory,
+    setActiveTransactionForm,
+    stakeTokens,
+    transferTokens,
+    transactionUnsub,
+    unstakeTokens
+  }
+}

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -3,43 +3,24 @@ import {
   AccountAddressT,
   AccountsT,
   AccountT,
-  AmountT,
   ErrorT,
   ErrorCategory,
-  ExecutedTransaction,
-  FinalizedTransaction,
   HDPathRadix,
   IntendedAction,
-  ManualUserConfirmTX,
-  MessageInTransaction,
   MnemomicT,
   Network,
   RadixT,
   SigningKeychain,
   SigningKeychainT,
-  StakeOptions,
-  StakeTokensInput,
-  TokenBalance,
-  TransactionHistory,
-  TransactionHistoryOfKnownAddressRequestInput,
-  TransactionIdentifierT,
-  TransactionIntent,
-  TransactionStateError,
   TransactionStateSuccess,
-  TransactionStateUpdate,
-  TransactionTracking,
-  TransferTokensInput,
-  TransferTokensOptions,
-  UnstakeOptions,
-  UnstakeTokensInput,
   WalletErrorCause,
   WalletT,
   walletError
 } from '@radixdlt/application'
 import { AccountName } from '@/actions/electron/data-store'
 import { Router } from 'vue-router'
-import { Subscription, interval, Subject, Observable, combineLatest, BehaviorSubject, ReplaySubject, firstValueFrom, zip, merge, of } from 'rxjs'
-import { filter, mergeMap, retry, switchMap } from 'rxjs/operators'
+import { Subscription, interval, Subject, firstValueFrom, zip, merge } from 'rxjs'
+import { filter, switchMap } from 'rxjs/operators'
 import { touchKeystore, hasKeystore, initWallet, storePin } from '@/actions/vue/create-wallet'
 import {
   deleteHardwareWalletAddress,
@@ -64,62 +45,30 @@ export interface PendingTransaction extends TransactionStateSuccess {
 
 export type WalletError = ErrorT<ErrorCategory.WALLET>
 
-const accounts: Ref<AccountsT | null> = ref(null)
 const accountNames: Ref<AccountName[]> = ref([])
+const accounts: Ref<AccountsT | null> = ref(null)
 const activeAccount: Ref<AccountT | null> = ref(null)
 const activeAddress: Ref<AccountAddressT | null> = ref(null)
-const activeMessage: Ref<string> = ref('')
-const activeMessageInTransaction: Ref<MessageInTransaction | null> = ref(null)
-const activeTransaction: Ref<TransactionTracking | null> = ref(null)
-const activeTransactionForm: Ref<string | null> = ref(null)
-const canGoNext: Ref<boolean> = ref(false)
-const confirmationMode: Ref<string | null> = ref(null)
-const cursorStack: Ref<string[]> = ref([])
-const decryptedMessages: Ref<{id: string, message: string}[]> = ref([])
-const draftTransaction: Ref<TransactionIntent | null> = ref(null)
 const hardwareAccount: Ref<AccountT | null> = ref(null)
-const hasCalculatedFee: Ref<boolean> = ref(false)
-const hasWallet = ref(false)
-const ledgerTxError: Ref<Error | null> = ref(null)
-const ledgerVerifyError: Ref<Error | null> = ref(null)
-const pendingTransactions: Ref<Array<PendingTransaction>> = ref([])
-const selectedCurrency: Ref<TokenBalance | null> = ref(null)
-const shouldShowConfirmation: Ref<boolean> = ref(false)
-const showLedgerVerify: Ref<boolean> = ref(false)
-const sidebar = ref('default')
-const stakeInput: Ref<StakeTokensInput | null> = ref(null)
-const transactionErrorMessage: Ref<string | null> = ref(null)
-const transactionFee: Ref<AmountT | null> = ref(null)
-const transactionHistory: Ref<TransactionHistory> = ref({ transactions: [], cursor: '' })
-const transactionToConfirm: Ref<ManualUserConfirmTX | null> = ref(null)
-const transferInput: Ref<TransferTokensInput | null> = ref(null)
-const wallet: Ref<WalletT | null> = ref(null)
-const nodeUrl: Ref<string | null> = ref(null)
-const signingKeychain: Ref<SigningKeychainT | null> = ref(null)
-
-const loadingHistory: Ref<boolean> = ref(true)
-const loadingHistoryPage: Ref<boolean> = ref(true)
-
-// can be building, confirm, submitting
-const transactionState: Ref<string> = ref('confirm')
-
-const hardwareInteractionState: Ref<string> = ref('')
-
-const userDidConfirm = new Subject<boolean>()
-const userDidCancel = new Subject<boolean>()
-let userConfirmation = new ReplaySubject<ManualUserConfirmTX>()
-const historyPagination = new Subject<TransactionHistoryOfKnownAddressRequestInput>()
-const reloadTrigger = new Subject<number>()
-
 const hardwareAddress: Ref<string> = ref('')
 const hardwareError: Ref<Error | null> = ref(null)
-getHardwareWalletAddress().then(a => { hardwareAddress.value = a })
+const hardwareInteractionState: Ref<string> = ref('')
+const hasWallet = ref(false)
+const ledgerVerifyError: Ref<Error | null> = ref(null)
+const nodeUrl: Ref<string | null> = ref(null)
+const reloadTrigger = new Subject<number>()
+const showLedgerVerify: Ref<boolean> = ref(false)
+const signingKeychain: Ref<SigningKeychainT | null> = ref(null)
+const wallet: Ref<WalletT | null> = ref(null)
+
 const showDeleteHWWalletPrompt: Ref<boolean> = ref(false)
 
 const setWallet = (newWallet: WalletT) => {
   wallet.value = newWallet
   return wallet.value
 }
+
+getHardwareWalletAddress().then(a => { hardwareAddress.value = a })
 
 const subs = new Subscription()
 
@@ -136,65 +85,36 @@ const createWallet = (mnemonic: MnemomicT, pass: string, network: Network) => {
 
 const setPin = (pin: string) => storePin(pin)
 
-const PAGE_SIZE = 50
-
 interface useWalletInterface {
   readonly accounts: Ref<AccountsT | null>;
   readonly activeAccount: Ref<AccountT | null>;
   readonly activeAddress: Ref<AccountAddressT | null>;
-  readonly activeMessageInTransaction: Ref<MessageInTransaction | null>;
-  readonly activeTransaction: Ref<TransactionTracking | null>;
-  readonly activeTransactionForm: Ref<string | null>;
-  readonly confirmationMode: Ref<string | null>;
-  readonly decryptedMessages: Ref<{id: string, message: string}[]>;
   readonly hardwareAccount: Ref<AccountT | null>;
   readonly hardwareAddress: Ref<string | null>;
   readonly hardwareError: Ref<Error | null>;
   readonly hardwareInteractionState: Ref<string>;
   readonly hasWallet: Ref<boolean>;
-  readonly ledgerTxError: Ref<Error | null>;
   readonly ledgerVerifyError: Ref<Error | null>;
   readonly invalidPasswordError: Ref<WalletError | null>;
-  readonly selectedCurrency: Ref<TokenBalance | null>;
-  readonly shouldShowConfirmation: Ref<boolean>;
   readonly showDeleteHWWalletPrompt: Ref<boolean>;
   readonly showLedgerVerify: Ref<boolean>;
-  readonly stakeInput: Ref<StakeTokensInput | null>;
-  readonly transactionState: Ref<string>;
-  readonly transferInput: Ref<TransferTokensInput | null>;
-  readonly transactionFee: Ref<AmountT | null>;
-  readonly transactionHistory: Ref<TransactionHistory>;
-  readonly transactionErrorMessage: Ref<string | null>;
   readonly walletHasLoaded: ComputedRef<boolean>;
-  readonly pendingTransactions: Ref<Array<PendingTransaction>>;
-  readonly canGoBack: ComputedRef<boolean>;
-  readonly canGoNext: Ref<boolean>;
-  readonly loadingHistory: Ref<boolean>;
 
   accountNameFor: (address: AccountAddressT) => string;
   accountRenamed: (newName: string) => void;
   addAccount: () => void;
-  cancelTransaction: () => void;
-  confirmTransaction: () => void;
   connectHardwareWallet: () => void;
   createWallet: (mnemonic: MnemomicT, pass: string, network: Network) => Promise<WalletT>;
+  hardwareAccountFailedToSign: () => void;
   reloadSubscriptions: () => void;
-  decryptMessage: (tx: ExecutedTransaction) => void;
   deleteLocalHardwareAddress: () => void;
   initWallet: () => void;
   loginWithWallet: (password: string) => Promise<RadixT>;
-  nextPage: () => void;
   persistNodeUrl: (url: string) => Promise<void>;
-  previousPage: () => void;
-  refreshHistory: () => void;
   resetWallet: (nextRoute: 'create-wallet' | 'restore-wallet') => void;
   setPin: (pin: string) => Promise<string>;
   setWallet: (newWallet: WalletT) => WalletT;
-  setActiveTransactionForm: (val: string) => void;
-  stakeTokens: (input: StakeTokensInput) => void;
   switchAccount: (account: AccountT) => void;
-  transferTokens: (input: TransferTokensInput, message: MessageInTransaction, sc: TokenBalance) => void;
-  unstakeTokens: (input: UnstakeTokensInput) => void;
   verifyHardwareWalletAddress: () => void;
   walletLoaded: () => void;
   waitUntilAllLoaded: () => Promise<any>;
@@ -224,10 +144,8 @@ export default function useWallet (radix: RadixT, router: Router): useWalletInte
 
   const allLoadedObservable = zip(
     radix.activeAccount,
-    radix.stakingPositions,
     radix.accounts,
-    radix.activeAddress,
-    radix.unstakingPositions
+    radix.activeAddress
   )
 
   const waitUntilAllLoaded = async () => firstValueFrom(allLoadedObservable)
@@ -248,7 +166,6 @@ export default function useWallet (radix: RadixT, router: Router): useWalletInte
       .subscribe((addressRes: AccountAddressT) => { activeAddress.value = addressRes }))
 
     reloadSubscriptions()
-    refreshHistory()
 
     getDerivedAccountsIndex()
       .then((accountsIndex: string) => {
@@ -266,21 +183,6 @@ export default function useWallet (radix: RadixT, router: Router): useWalletInte
     })
   }
 
-  // Fetch history when user navigates to next page
-  subs.add(historyPagination.asObservable()
-    .pipe(
-      mergeMap((params: TransactionHistoryOfKnownAddressRequestInput) =>
-        radix.transactionHistory(params).pipe(retry())
-      )
-    )
-    .subscribe((history: TransactionHistory) => {
-      loadingHistory.value = false
-      loadingHistoryPage.value = false
-      if (history.cursor && history.transactions.length === PAGE_SIZE) canGoNext.value = true
-      else canGoNext.value = false
-      transactionHistory.value = history
-    }))
-
   const addAccount = () => {
     getDerivedAccountsIndex()
       .then((index: string) => {
@@ -290,7 +192,6 @@ export default function useWallet (radix: RadixT, router: Router): useWalletInte
   }
 
   const switchAccount = (account: AccountT) => {
-    decryptedMessages.value = []
     radix.switchAccount({ toAccount: account })
   }
 
@@ -314,239 +215,6 @@ export default function useWallet (radix: RadixT, router: Router): useWalletInte
         return { ...accountName, name: newName }
       }
       return accountName
-    })
-  }
-
-  const confirmTransaction = () => {
-    if (activeAccount.value &&
-    hardwareAccount.value &&
-    activeAccount.value === hardwareAccount.value) {
-      transactionState.value = 'hw-signing'
-    }
-    userDidConfirm.next(true)
-    hasCalculatedFee.value = false
-  }
-
-  const cancelTransaction = () => {
-    userDidCancel.next(true)
-    hasCalculatedFee.value = false
-  }
-
-  const setActiveTransactionForm = (val: string) => {
-    activeTransactionForm.value = val
-  }
-
-  const confirmAndExecuteTransaction = (transactionTracking: TransactionTracking) => {
-    activeTransaction.value = transactionTracking
-    const transactionDidComplete = new BehaviorSubject<boolean>(false)
-    userDidCancel.next(false)
-    transactionState.value = 'building'
-    shouldShowConfirmation.value = true
-    // Subscribe to initial userConfirmation and display modal
-    const createUserConfirmation = userConfirmation
-      .subscribe((txnToConfirm: ManualUserConfirmTX) => {
-        transactionToConfirm.value = txnToConfirm
-        userDidConfirm.next(false)
-        transactionState.value = 'confirm'
-        transactionFee.value = txnToConfirm.txToConfirm.fee
-        hasCalculatedFee.value = true
-      })
-    subs.add(createUserConfirmation)
-
-    // Confirm transaction and move user to history view after they press confirm
-    const watchUserDidConfirm = combineLatest<[ManualUserConfirmTX, boolean]>([userConfirmation, userDidConfirm])
-      .subscribe(([txnToConfirm, didConfirm]: [ManualUserConfirmTX, boolean]) => {
-        if (didConfirm) { txnToConfirm.confirm() }
-      })
-    subs.add(watchUserDidConfirm)
-
-    // Catch errors that were silently failing
-    const trackingSubmittedEventErrors = transactionTracking.events
-      .pipe(filter((trackingEvent: TransactionStateUpdate) => {
-        const errorEvent: TransactionStateError = trackingEvent as TransactionStateError
-        return errorEvent && errorEvent.error != null
-      }))
-      .subscribe((event: TransactionStateUpdate) => {
-        const errorEvent: TransactionStateError = event as TransactionStateError
-        userDidCancel.next(true)
-        shouldShowConfirmation.value = false
-        const isLedgerConnectedError = errorEvent.error.message && errorEvent.error.message.includes('Failed to sign tx with Ledger')
-        if (isLedgerConnectedError) {
-          ledgerTxError.value = errorEvent.error
-          hardwareAccount.value = null
-          hardwareInteractionState.value = 'FAILED_TO_SIGN'
-          hardwareError.value = new Error('validations.failedToSign')
-          transactionErrorMessage.value = null
-          return
-        }
-
-        transactionErrorMessage.value = `validations.${activeTransactionForm.value}Failed`
-      })
-
-    subs.add(trackingSubmittedEventErrors)
-
-    // Store draft transaction actions
-    subs.add(transactionTracking.events
-      .pipe(filter((trackingEvent: TransactionStateUpdate) => trackingEvent.eventUpdateType === 'INITIATED'))
-      .subscribe((res: TransactionStateUpdate) => {
-        draftTransaction.value = (res as TransactionStateSuccess).transactionState as TransactionIntent
-      }))
-
-    // Track pending transactions augmented with actions array
-    const trackingSubmittedEvents = transactionTracking.events
-      .pipe(filter((trackingEvent: TransactionStateUpdate) => trackingEvent.eventUpdateType === 'SUBMITTED'))
-      .subscribe((res: TransactionStateUpdate) => {
-        const finalizedTransaction = res as unknown as TransactionStateSuccess
-        pendingTransactions.value = pendingTransactions.value.concat([{
-          ...finalizedTransaction,
-          actions: draftTransaction.value ? draftTransaction.value.actions : []
-        }])
-        draftTransaction.value = null
-        transactionState.value = 'submitting'
-      })
-    subs.add(trackingSubmittedEvents)
-
-    // When a transaction has been completed, remove it from pending transactions
-    subs.add(transactionTracking.completion
-      .subscribe({
-        next: (txnID: TransactionIdentifierT) => {
-          pendingTransactions.value = pendingTransactions.value.filter((pendingTxn: TransactionStateSuccess) => {
-            const transactionState = pendingTxn.transactionState as unknown as FinalizedTransaction
-            return txnID.toString() !== transactionState.txID.toString()
-          })
-          shouldShowConfirmation.value = false
-          router.push('/wallet/history')
-          hasCalculatedFee.value = false
-          transactionDidComplete.next(true)
-        }
-      }))
-
-    // Cleanup subscriptions on cancel and complete
-    const cleanupTransactionSubs = () => {
-      userConfirmation = new ReplaySubject<ManualUserConfirmTX>()
-      createUserConfirmation.unsubscribe()
-      watchUserDidConfirm.unsubscribe()
-      trackingSubmittedEvents.unsubscribe()
-      hasCalculatedFee.value = false
-      transactionErrorMessage.value = null
-    }
-
-    userDidCancel.subscribe((didCancel: boolean) => {
-      if (didCancel) {
-        cleanupTransactionSubs()
-        shouldShowConfirmation.value = false
-        activeMessage.value = ''
-        hasCalculatedFee.value = false
-      }
-    })
-
-    subs.add(transactionDidComplete.subscribe((didComplete: boolean) => {
-      if (didComplete) {
-        cleanupTransactionSubs()
-        activeMessage.value = ''
-        hasCalculatedFee.value = false
-        historyPagination.next({ size: PAGE_SIZE })
-      }
-    }))
-  }
-
-  const cleanupInputs = () => {
-    transferInput.value = null
-    stakeInput.value = null
-  }
-
-  // call transferTokens() with built options and subscribe to confirmation and results
-  const transferTokens = (transferTokensInput: TransferTokensInput, message: MessageInTransaction, sc: TokenBalance) => {
-    let pollTXStatusTrigger: Observable<unknown>
-    cleanupInputs()
-    transferInput.value = transferTokensInput
-    selectedCurrency.value = sc
-    activeMessage.value = message.plaintext
-    activeMessageInTransaction.value = message
-    confirmationMode.value = 'transfer'
-    const buildTransferTokens = (): TransferTokensOptions => ({
-      transferInput: transferTokensInput,
-      userConfirmation: userConfirmation,
-      pollTXStatusTrigger: pollTXStatusTrigger
-    })
-
-    const transactionTracking: TransactionTracking = radix.transferTokens({
-      ...buildTransferTokens(),
-      userConfirmation,
-      message
-    })
-
-    confirmAndExecuteTransaction(transactionTracking)
-  }
-
-  // call stakeTokens() with built options and subscribe to confirmation and results
-  const stakeTokens = (stakeTokensInput: StakeTokensInput) => {
-    let pollTXStatusTrigger: Observable<unknown>
-    cleanupInputs()
-    stakeInput.value = stakeTokensInput
-    confirmationMode.value = 'stake'
-
-    const buildTransferTokens = (): StakeOptions => ({
-      stakeInput: stakeTokensInput,
-      userConfirmation: userConfirmation,
-      pollTXStatusTrigger: pollTXStatusTrigger
-    })
-
-    const stakingTransactionTracking: TransactionTracking = radix.stakeTokens({
-      ...buildTransferTokens(),
-      userConfirmation
-    })
-
-    confirmAndExecuteTransaction(stakingTransactionTracking)
-  }
-
-  // call unstakeTokens() with built options and subscribe to confirmation and results
-  const unstakeTokens = (unstakeTokensInput: UnstakeTokensInput) => {
-    let pollTXStatusTrigger: Observable<unknown>
-    cleanupInputs()
-    stakeInput.value = unstakeTokensInput
-    confirmationMode.value = 'unstake'
-
-    const buildTransferTokens = (): UnstakeOptions => ({
-      unstakeInput: unstakeTokensInput,
-      userConfirmation: userConfirmation,
-      pollTXStatusTrigger: pollTXStatusTrigger
-    })
-
-    const unstakingTransactionTracking: TransactionTracking = radix.unstakeTokens({
-      ...buildTransferTokens(),
-      userConfirmation
-    })
-
-    confirmAndExecuteTransaction(unstakingTransactionTracking)
-  }
-
-  const refreshHistory = () => {
-    loadingHistory.value = true
-    historyPagination.next({ size: PAGE_SIZE })
-  }
-
-  const nextPage = () => {
-    loadingHistoryPage.value = true
-    cursorStack.value.push(transactionHistory.value.cursor)
-    historyPagination.next({
-      size: PAGE_SIZE,
-      cursor: cursorStack.value[cursorStack.value.length - 1]
-    })
-  }
-
-  const previousPage = () => {
-    loadingHistoryPage.value = true
-    cursorStack.value.pop()
-    historyPagination.next({
-      size: PAGE_SIZE,
-      cursor: cursorStack.value.length > 0 ? cursorStack.value[cursorStack.value.length - 1] : ''
-    })
-  }
-
-  const decryptMessage = (tx: ExecutedTransaction) => {
-    firstValueFrom(radix.decryptTransaction(tx)).then((val) => {
-      decryptedMessages.value.push({ id: tx.txID.toString(), message: val })
     })
   }
 
@@ -575,7 +243,6 @@ export default function useWallet (radix: RadixT, router: Router): useWalletInte
           saveAccountName(hwAccount.address.toString(), 'Hardware Wallet')
           hardwareAddress.value = hwAccount.address.toString()
         }
-        sidebar.value = 'default'
         hardwareInteractionState.value = ''
       },
       error: (err) => { hardwareError.value = err }
@@ -625,41 +292,29 @@ export default function useWallet (radix: RadixT, router: Router): useWalletInte
     return selectedNode
   }
 
+  const hardwareAccountFailedToSign = () => {
+    hardwareAccount.value = null
+    hardwareInteractionState.value = 'FAILED_TO_SIGN'
+    hardwareError.value = new Error('validations.failedToSign')
+  }
+
   return {
     accounts,
     activeAccount,
     activeAddress,
-    activeMessageInTransaction,
-    activeTransactionForm,
-    activeTransaction,
-    confirmationMode,
-    decryptedMessages,
     hardwareAccount,
     hardwareAddress,
     hardwareError,
     hardwareInteractionState,
     hasWallet,
     invalidPasswordError,
-    ledgerTxError,
     ledgerVerifyError,
-    selectedCurrency,
-    shouldShowConfirmation,
     showDeleteHWWalletPrompt,
     showLedgerVerify,
-    stakeInput,
-    transactionErrorMessage,
-    transactionFee,
-    transactionHistory,
-    transactionState,
-    transferInput,
-    pendingTransactions,
-    canGoNext,
-    loadingHistory,
     reloadSubscriptions,
     walletHasLoaded: computed(() => {
       return activeAddress.value != null
     }),
-    canGoBack: computed(() => cursorStack.value.length > 0),
 
     async loginWithWallet (password: string) {
       const signingKeychainResult = await SigningKeychain.byLoadingAndDecryptingKeystore({
@@ -690,24 +345,15 @@ export default function useWallet (radix: RadixT, router: Router): useWalletInte
     accountNameFor,
     accountRenamed,
     addAccount,
-    cancelTransaction,
-    confirmTransaction,
     connectHardwareWallet,
     createWallet,
-    decryptMessage,
     deleteLocalHardwareAddress,
+    hardwareAccountFailedToSign,
     initWallet,
-    nextPage,
     persistNodeUrl,
-    previousPage,
-    refreshHistory,
-    setActiveTransactionForm,
     setPin,
     setWallet,
-    stakeTokens,
     switchAccount,
-    transferTokens,
-    unstakeTokens,
     verifyHardwareWalletAddress,
     waitUntilAllLoaded,
     walletLoaded

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -89,7 +89,7 @@
 
           <div class="py-4 flex items-center">
             <div class="w-26 text-right text-rGrayDark mr-8">{{ $t('transaction.feeLabel') }}</div>
-            <div class="flex-1 flex flex-row items-center">
+            <div class="flex-1 flex flex-row items-center" v-if="transactionFee">
               <big-amount :amount="transactionFee"  class="mr-1" />
               <span class="uppercase">{{ nativeToken.symbol }}</span>
             </div>
@@ -139,7 +139,7 @@ import PinInput from '@/components/PinInput.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
 import { validatePin } from '@/actions/vue/create-wallet'
 import { useRouter } from 'vue-router'
-import { useNativeToken, useHomeModal, useRadix, useWallet } from '@/composables'
+import { useNativeToken, useHomeModal, useRadix, useTransactions, useWallet } from '@/composables'
 import { useI18n } from 'vue-i18n'
 
 interface ConfirmationForm {
@@ -154,6 +154,7 @@ const WalletConfirmTransactionModal = defineComponent({
   },
 
   setup () {
+    console.log('load form')
     const { errors, meta, values, setErrors, resetForm } = useForm<ConfirmationForm>()
     const { setModal } = useHomeModal()
     const router = useRouter()
@@ -166,6 +167,13 @@ const WalletConfirmTransactionModal = defineComponent({
     const { radix, reset } = useRadix()
     const {
       activeAddress,
+      activeAccount,
+      hardwareAccount,
+      hardwareAccountFailedToSign
+    } = useWallet(radix, router)
+    const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
+
+    const {
       activeMessageInTransaction,
       cancelTransaction,
       confirmationMode,
@@ -174,9 +182,13 @@ const WalletConfirmTransactionModal = defineComponent({
       stakeInput,
       transactionFee,
       transactionState,
-      transferInput
-    } = useWallet(radix, router)
-    const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
+      transferInput,
+      transactionUnsub
+    } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value, {
+      ledgerSigningError: () => {
+        hardwareAccountFailedToSign()
+      }
+    })
 
     const escapeListener = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -190,6 +202,7 @@ const WalletConfirmTransactionModal = defineComponent({
 
     onUnmounted(() => {
       nativeTokenUnsub()
+      transactionUnsub()
       window.removeEventListener('keydown', escapeListener)
     })
 

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -139,7 +139,7 @@ import PinInput from '@/components/PinInput.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
 import { validatePin } from '@/actions/vue/create-wallet'
 import { useRouter } from 'vue-router'
-import { useHomeModal, useRadix, useWallet } from '@/composables'
+import { useNativeToken, useHomeModal, useRadix, useWallet } from '@/composables'
 import { useI18n } from 'vue-i18n'
 
 interface ConfirmationForm {
@@ -170,13 +170,13 @@ const WalletConfirmTransactionModal = defineComponent({
       cancelTransaction,
       confirmationMode,
       confirmTransaction,
-      nativeToken,
       selectedCurrency,
       stakeInput,
       transactionFee,
       transactionState,
       transferInput
     } = useWallet(radix, router)
+    const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
 
     const escapeListener = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -189,6 +189,7 @@ const WalletConfirmTransactionModal = defineComponent({
     })
 
     onUnmounted(() => {
+      nativeTokenUnsub()
       window.removeEventListener('keydown', escapeListener)
     })
 

--- a/src/views/Wallet/WalletHistory.vue
+++ b/src/views/Wallet/WalletHistory.vue
@@ -90,7 +90,7 @@ import { computed, ComputedRef, defineComponent, onMounted, watch } from 'vue'
 import TransactionListItem from '@/components/TransactionListItem.vue'
 import LoadingIcon from '@/components/LoadingIcon.vue'
 import ClickToCopy from '@/components/ClickToCopy.vue'
-import { useNativeToken, useRadix, useWallet } from '@/composables'
+import { useNativeToken, useRadix, useTransactions, useWallet } from '@/composables'
 import { useRouter, onBeforeRouteLeave } from 'vue-router'
 
 const WalletHistory = defineComponent({
@@ -104,20 +104,30 @@ const WalletHistory = defineComponent({
     const router = useRouter()
     const { radix } = useRadix()
     const {
-      transactionHistory,
-      decryptedMessages,
       activeAddress,
-      pendingTransactions,
+      hardwareAccount,
+      hardwareAccountFailedToSign,
+      verifyHardwareWalletAddress,
+      activeAccount
+    } = useWallet(radix, router)
+
+    const {
       canGoBack,
       canGoNext,
+      decryptedMessages,
       loadingHistory,
+      pendingTransactions,
+      transactionHistory,
       previousPage,
       nextPage,
       decryptMessage,
-      verifyHardwareWalletAddress,
       refreshHistory,
-      activeAccount
-    } = useWallet(radix, router)
+      transactionUnsub
+    } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value, {
+      ledgerSigningError: () => {
+        hardwareAccountFailedToSign()
+      }
+    })
 
     const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
 
@@ -141,6 +151,7 @@ const WalletHistory = defineComponent({
 
     onBeforeRouteLeave(() => {
       nativeTokenUnsub()
+      transactionUnsub()
     })
 
     const loading: ComputedRef<boolean> = computed(() => {

--- a/src/views/Wallet/WalletHistory.vue
+++ b/src/views/Wallet/WalletHistory.vue
@@ -17,7 +17,7 @@
     </div>
 
     <div class="text-rBlack py-6 min-h-full text-sm">
-      <div v-if="loadingHistory" class="p-4 flex items-center justify-center">
+      <div v-if="loading" class="p-4 flex items-center justify-center">
         <loading-icon class="text-rGrayDark" />
       </div>
       <template v-else-if="pendingTransactions.length > 0 || transactionsWithMessages.length > 0">
@@ -86,7 +86,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, watch } from 'vue'
+import { computed, ComputedRef, defineComponent, onMounted, watch } from 'vue'
 import TransactionListItem from '@/components/TransactionListItem.vue'
 import LoadingIcon from '@/components/LoadingIcon.vue'
 import ClickToCopy from '@/components/ClickToCopy.vue'
@@ -143,6 +143,10 @@ const WalletHistory = defineComponent({
       nativeTokenUnsub()
     })
 
+    const loading: ComputedRef<boolean> = computed(() => {
+      return !nativeToken.value && loadingHistory.value
+    })
+
     return {
       activeAccount,
       transactionHistory,
@@ -151,7 +155,7 @@ const WalletHistory = defineComponent({
       pendingTransactions,
       canGoBack,
       canGoNext,
-      loadingHistory,
+      loading,
       nativeToken,
       previousPage,
       nextPage,

--- a/src/views/Wallet/WalletHistory.vue
+++ b/src/views/Wallet/WalletHistory.vue
@@ -90,9 +90,8 @@ import { computed, defineComponent, onMounted, watch } from 'vue'
 import TransactionListItem from '@/components/TransactionListItem.vue'
 import LoadingIcon from '@/components/LoadingIcon.vue'
 import ClickToCopy from '@/components/ClickToCopy.vue'
-import useWallet from '@/composables/useWallet'
-import { useRouter } from 'vue-router'
-import { useRadix } from '@/composables'
+import { useNativeToken, useRadix, useWallet } from '@/composables'
+import { useRouter, onBeforeRouteLeave } from 'vue-router'
 
 const WalletHistory = defineComponent({
   components: {
@@ -112,7 +111,6 @@ const WalletHistory = defineComponent({
       canGoBack,
       canGoNext,
       loadingHistory,
-      nativeToken,
       previousPage,
       nextPage,
       decryptMessage,
@@ -120,6 +118,8 @@ const WalletHistory = defineComponent({
       refreshHistory,
       activeAccount
     } = useWallet(radix, router)
+
+    const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
 
     const transactionsWithMessages = computed(() => {
       return transactionHistory.value.transactions.map((tx) => {
@@ -137,6 +137,10 @@ const WalletHistory = defineComponent({
     // Fetch initial history on route load
     onMounted(() => {
       refreshHistory()
+    })
+
+    onBeforeRouteLeave(() => {
+      nativeTokenUnsub()
     })
 
     return {

--- a/src/views/Wallet/WalletOverview.vue
+++ b/src/views/Wallet/WalletOverview.vue
@@ -93,7 +93,7 @@ import { createRRIUrl } from '@/helpers/explorerLinks'
 import { truncateRRIStringForDisplay } from '@/helpers/formatter'
 import { sumAmounts, add } from '@/helpers/arithmetic'
 import { useRouter, onBeforeRouteLeave } from 'vue-router'
-import { useNativeToken, useRadix, useWallet, useTokenBalances } from '@/composables'
+import { useNativeToken, useRadix, useStaking, useWallet, useTokenBalances } from '@/composables'
 
 const WalletOverview = defineComponent({
   components: {
@@ -107,18 +107,18 @@ const WalletOverview = defineComponent({
     const { radix } = useRadix()
     const {
       activeAddress,
-      activeStakes,
-      activeUnstakes,
       verifyHardwareWalletAddress,
       hasWallet
     } = useWallet(radix, router)
 
     const { tokenBalances, tokenBalancesUnsub, tokenBalanceFor } = useTokenBalances(radix)
     const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
+    const { activeStakes, activeUnstakes, stakingUnsub } = useStaking(radix)
 
     onBeforeRouteLeave(() => {
       tokenBalancesUnsub()
       nativeTokenUnsub()
+      stakingUnsub()
     })
 
     if (!hasWallet) {

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -109,7 +109,7 @@ import FormField from '@/components/FormField.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
 import { asBigNumber } from '@/components/BigAmount.vue'
 import { Position } from '@/services/_types'
-import { useNativeToken, useRadix, useTokenBalances, useWallet } from '@/composables'
+import { useNativeToken, useRadix, useStaking, useTokenBalances, useWallet } from '@/composables'
 import { useRouter, onBeforeRouteLeave } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 
@@ -136,18 +136,18 @@ const WalletStaking = defineComponent({
     const router = useRouter()
     const {
       activeAddress,
-      activeStakes,
-      activeUnstakes,
       stakeTokens,
       unstakeTokens
     } = useWallet(radix, router)
 
     const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
     const { tokenBalances, tokenBalanceFor, tokenBalancesUnsub } = useTokenBalances(radix)
+    const { activeStakes, activeUnstakes, stakingUnsub } = useStaking(radix)
 
     onBeforeRouteLeave(() => {
       nativeTokenUnsub()
       tokenBalancesUnsub()
+      stakingUnsub()
     })
 
     const setForm = (form: string) => {

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -109,7 +109,7 @@ import FormField from '@/components/FormField.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
 import { asBigNumber } from '@/components/BigAmount.vue'
 import { Position } from '@/services/_types'
-import { useNativeToken, useRadix, useStaking, useTokenBalances, useWallet } from '@/composables'
+import { useNativeToken, useRadix, useStaking, useTransactions, useTokenBalances, useWallet } from '@/composables'
 import { useRouter, onBeforeRouteLeave } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 
@@ -136,9 +136,16 @@ const WalletStaking = defineComponent({
     const router = useRouter()
     const {
       activeAddress,
-      stakeTokens,
-      unstakeTokens
+      activeAccount,
+      hardwareAccount,
+      hardwareAccountFailedToSign
     } = useWallet(radix, router)
+
+    const { stakeTokens, unstakeTokens, transactionUnsub } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value, {
+      ledgerSigningError: () => {
+        hardwareAccountFailedToSign()
+      }
+    })
 
     const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
     const { tokenBalances, tokenBalanceFor, tokenBalancesUnsub } = useTokenBalances(radix)
@@ -148,6 +155,7 @@ const WalletStaking = defineComponent({
       nativeTokenUnsub()
       tokenBalancesUnsub()
       stakingUnsub()
+      transactionUnsub()
     })
 
     const setForm = (form: string) => {

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -109,8 +109,8 @@ import FormField from '@/components/FormField.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
 import { asBigNumber } from '@/components/BigAmount.vue'
 import { Position } from '@/services/_types'
-import { useRadix, useWallet } from '@/composables'
-import { useRouter } from 'vue-router'
+import { useNativeToken, useRadix, useTokenBalances, useWallet } from '@/composables'
+import { useRouter, onBeforeRouteLeave } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 
 interface StakeForm {
@@ -136,14 +136,19 @@ const WalletStaking = defineComponent({
     const router = useRouter()
     const {
       activeAddress,
-      tokenBalances,
-      nativeToken,
       activeStakes,
       activeUnstakes,
-      nativeTokenBalance,
       stakeTokens,
       unstakeTokens
     } = useWallet(radix, router)
+
+    const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
+    const { tokenBalances, tokenBalanceFor, tokenBalancesUnsub } = useTokenBalances(radix)
+
+    onBeforeRouteLeave(() => {
+      nativeTokenUnsub()
+      tokenBalancesUnsub()
+    })
 
     const setForm = (form: string) => {
       activeForm.value = form
@@ -151,8 +156,11 @@ const WalletStaking = defineComponent({
     }
 
     // Computed Values
-    const xrdBalance: ComputedRef<AmountT> = computed(() =>
-      nativeTokenBalance.value ? nativeTokenBalance.value.amount : Amount.fromUnsafe(0)._unsafeUnwrap())
+    const xrdBalance: ComputedRef<AmountT> = computed(() => {
+      if (!tokenBalances.value || !nativeToken.value) return Amount.fromUnsafe(0)._unsafeUnwrap()
+      const nativeTokenBalance = tokenBalanceFor(nativeToken.value)
+      return nativeTokenBalance ? nativeTokenBalance.amount : Amount.fromUnsafe(0)._unsafeUnwrap()
+    })
 
     const sortedPositions: ComputedRef<Array<Position>> = computed(() => {
       if (!activeStakes.value || !activeUnstakes.value) return []
@@ -216,33 +224,32 @@ const WalletStaking = defineComponent({
     }
 
     const handleSubmitStake = () => {
-      if (meta.value.valid && nativeTokenBalance.value) {
-        const safeAddress = safelyUnwrapValidator(values.validator)
-        const safeAmount = safelyUnwrapAmount(Number(values.amount))
-        const greaterThanZero = safeAmount && validateGreaterThanZero(safeAmount)
-        const validAmount = safeAmount && validateAmountOfType(safeAmount, nativeTokenBalance.value.token)
+      if (!tokenBalances.value || !nativeToken.value) return
+      const nativeTokenBalance = tokenBalanceFor(nativeToken.value)
+      if (!meta.value.valid || !nativeTokenBalance) return
+      const safeAddress = safelyUnwrapValidator(values.validator)
+      const safeAmount = safelyUnwrapAmount(Number(values.amount))
+      const greaterThanZero = safeAmount && validateGreaterThanZero(safeAmount)
+      const validAmount = safeAmount && validateAmountOfType(safeAmount, nativeTokenBalance.token)
 
-        if (!greaterThanZero) {
-          setErrors({
-            amount: t('validations.greaterThanZero')
-          })
-        } else if (!validAmount) {
-          setErrors({
-            amount: t('validations.amountOfType', { granularity: nativeTokenBalance.value.token.granularity.toString() })
-          })
-        } else {
-          if (!safeAddress || !safeAmount) return
-          activeForm.value === 'stake'
-            ? stakeTokens({
-              validator: safeAddress,
-              amount: safeAmount
-            })
-            : unstakeTokens({
-              validator: safeAddress,
-              amount: safeAmount
-            })
-        }
+      if (!greaterThanZero) {
+        setErrors({ amount: t('validations.greaterThanZero') })
+        return
       }
+      if (!validAmount) {
+        setErrors({ amount: t('validations.amountOfType', { granularity: nativeTokenBalance.token.granularity.toString() }) })
+        return
+      }
+      if (!safeAddress || !safeAmount) return
+      activeForm.value === 'stake'
+        ? stakeTokens({
+          validator: safeAddress,
+          amount: safeAmount
+        })
+        : unstakeTokens({
+          validator: safeAddress,
+          amount: safeAmount
+        })
     }
 
     return {

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, watchEffect } from 'vue'
+import { defineComponent } from 'vue'
 
 import WalletConfirmTransactionModal from './WalletConfirmTransactionModal.vue'
 import WalletSidebar from './WalletSidebar.vue'
@@ -71,10 +71,6 @@ const WalletIndex = defineComponent({
     window.ipcRenderer.on('resetToHome', () => {
       radix.__reset()
       router.push({ name: 'Home', query: { modal: '' } })
-    })
-
-    watchEffect(() => {
-      console.log('confirm', shouldShowConfirmation.value)
     })
 
     return {


### PR DESCRIPTION
Now that we've done all the hard work of moving _all_ of the logic from the `Wallet/index.vue` component into a few composables (is that the right word?), let's take it one step forward.

This PR separates out two major concerns of the `useWallet` composition api into separate, independent composables.

Doing this allows for each _route_ in the view tree to handle it's own subscriptions.  Each route that needs the token balances or native token associated with the authenticated wallet, can subscribe to that data independently, and then _unsubscribe_ when it's done.  This simplifies the API, increases separation of concerns, and also completely solves the problem of the `WalletOverview` and other views breaking on network change.

We should do this for:
- [x] TransactionHistory
- [x] Staking
- [x] Unstaking

If we continue down this path, this also means that each wallet will only subscribe to the data it needs to display _right now_, rather than all subs all the time.

There are probably some places contained in these changes that created regressions due to the inter-dependent nature of some of these subscriptions that we should clean up.  (native tokens in staking, transaction workflow comes to mind as well as account switching).

I think given the complexity of the transaction workflow, it might make sense to leave that contained in the `useWallet` composable for now, but we should validate that expectation.