### PR TITLE
Fix: Network specific account indexes and hardware addresses

### DIFF
--- a/src/actions/electron/data-store.ts
+++ b/src/actions/electron/data-store.ts
@@ -34,16 +34,17 @@ export const getDerivedAccountsIndex = (event: IpcMainInvokeEvent, network: stri
   return store.get(`wallets.${network}.derivedAccountsIndex`)
 }
 
-export const saveHardwareAddress = (event: IpcMainInvokeEvent, address: string) => {
-  return store.set('hardwareAddress', address)
+export const saveHardwareAddress = (event: IpcMainInvokeEvent, data: string) => {
+  const { address, network } = JSON.parse(data)
+  return store.set(`wallets.${network}.hardwareAddress`, address)
 }
 
-export const getHardwareAddress = (event: IpcMainInvokeEvent) => {
-  return store.get('hardwareAddress')
+export const getHardwareAddress = (event: IpcMainInvokeEvent, network: string) => {
+  return store.get(`wallets.${network}.hardwareAddress`)
 }
 
-export const deleteHardwareAddress = (event: IpcMainInvokeEvent) => {
-  return store.delete('hardwareAddress')
+export const deleteHardwareAddress = (event: IpcMainInvokeEvent, network: string) => {
+  return store.delete(`wallets.${network}.hardwareAddress`)
 }
 
 export const resetStore = (event: IpcMainInvokeEvent) => {

--- a/src/actions/electron/data-store.ts
+++ b/src/actions/electron/data-store.ts
@@ -25,12 +25,13 @@ export const getAccountNames = (): AccountName[] => {
   return asAccounts
 }
 
-export const saveDerivedAccountsIndex = (event: IpcMainInvokeEvent, num: string) => {
-  return store.set('derivedAccountsIndex', num)
+export const saveDerivedAccountsIndex = (event: IpcMainInvokeEvent, data: string): void => {
+  const { num, network } = JSON.parse(data)
+  store.set(`wallets.${network}.derivedAccountsIndex`, num)
 }
 
-export const getDerivedAccountsIndex = (event: IpcMainInvokeEvent) => {
-  return store.get('derivedAccountsIndex')
+export const getDerivedAccountsIndex = (event: IpcMainInvokeEvent, network: string) => {
+  return store.get(`wallets.${network}.derivedAccountsIndex`)
 }
 
 export const saveHardwareAddress = (event: IpcMainInvokeEvent, address: string) => {

--- a/src/actions/vue/data-store.ts
+++ b/src/actions/vue/data-store.ts
@@ -13,20 +13,19 @@ export const saveDerivedAccountsIndex = (num: number, network: Network): Promise
 })
 
 export const getDerivedAccountsIndex = (network: Network): Promise<string> => new Promise((resolve) => {
-  console.log(network)
   resolve(window.ipcRenderer.invoke('get-num-accounts', String(network)))
 })
 
-export const saveHardwareWalletAddress = (address: string): Promise<string> => new Promise((resolve) => {
-  resolve(window.ipcRenderer.invoke('save-hw-address', address))
+export const saveHardwareWalletAddress = (address: string, network: Network): Promise<string> => new Promise((resolve) => {
+  resolve(window.ipcRenderer.invoke('save-hw-address', JSON.stringify({ address, network })))
 })
 
-export const getHardwareWalletAddress = (): Promise<string> => new Promise((resolve) => {
-  resolve(window.ipcRenderer.invoke('get-hw-address'))
+export const getHardwareWalletAddress = (network: Network): Promise<string> => new Promise((resolve) => {
+  resolve(window.ipcRenderer.invoke('get-hw-address', String(network)))
 })
 
-export const deleteHardwareWalletAddress = (): Promise<string> => new Promise((resolve) => {
-  resolve(window.ipcRenderer.invoke('delete-hw-address'))
+export const deleteHardwareWalletAddress = (network: Network): Promise<string> => new Promise((resolve) => {
+  resolve(window.ipcRenderer.invoke('delete-hw-address', String(network)))
 })
 
 export const resetStore = (): Promise<string> => new Promise((resolve) => {

--- a/src/actions/vue/data-store.ts
+++ b/src/actions/vue/data-store.ts
@@ -1,5 +1,5 @@
 import { AccountName, SelectedNode } from '../electron/data-store'
-
+import { Network } from '@radixdlt/application'
 export const saveAccountName = (accountAddress: string, prettyName: string): Promise<string> => new Promise((resolve) => {
   resolve(window.ipcRenderer.invoke('save-account-name', JSON.stringify({ accountAddress, prettyName })))
 })
@@ -8,12 +8,13 @@ export const getAccountNames = (): Promise<AccountName[]> => new Promise((resolv
   resolve(window.ipcRenderer.invoke('get-account-names'))
 })
 
-export const saveDerivedAccountsIndex = (numAccounts: number): Promise<string> => new Promise((resolve) => {
-  resolve(window.ipcRenderer.invoke('save-num-accounts', String(numAccounts)))
+export const saveDerivedAccountsIndex = (num: number, network: Network): Promise<string> => new Promise((resolve) => {
+  resolve(window.ipcRenderer.invoke('save-num-accounts', JSON.stringify({ num, network })))
 })
 
-export const getDerivedAccountsIndex = (): Promise<string> => new Promise((resolve) => {
-  resolve(window.ipcRenderer.invoke('get-num-accounts'))
+export const getDerivedAccountsIndex = (network: Network): Promise<string> => new Promise((resolve) => {
+  console.log(network)
+  resolve(window.ipcRenderer.invoke('get-num-accounts', String(network)))
 })
 
 export const saveHardwareWalletAddress = (address: string): Promise<string> => new Promise((resolve) => {

--- a/src/components/ClickToCopy.vue
+++ b/src/components/ClickToCopy.vue
@@ -8,11 +8,11 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, toRefs } from 'vue'
 import { copyToClipboard } from '@/actions/vue/create-wallet'
 import { useToast } from 'vue-toastification'
-import { getHardwareWalletAddress } from '@/actions/vue/data-store'
-
+import { useRadix, useWallet } from '@/composables'
+import { useRouter } from 'vue-router'
 const ClickToCopy = defineComponent({
 
   props: {
@@ -27,31 +27,24 @@ const ClickToCopy = defineComponent({
     }
   },
 
-  setup () {
+  setup (props) {
     const toast = useToast()
-    return { toast }
-  },
-
-  methods: {
-    copyText () {
-      if (this.checkForHardwareAddress) {
-        getHardwareWalletAddress().then(a => {
-          const hardwareAddress = a
-          if (hardwareAddress && this.address === hardwareAddress) {
-            this.$emit('verifyHardwareAddress')
-          } else {
-            copyToClipboard(this.address)
-            this.toast.success('Copied to Clipboard')
-          }
-        })
-      } else {
-        copyToClipboard(this.address)
-        this.toast.success('Copied to Clipboard')
+    const { radix } = useRadix()
+    const router = useRouter()
+    const { hardwareAddress, verifyHardwareWalletAddress } = useWallet(radix, router)
+    const { address, checkForHardwareAddress } = toRefs(props)
+    const copyText = () => {
+      if (checkForHardwareAddress) {
+        if (hardwareAddress.value && address.value === hardwareAddress.value) {
+          verifyHardwareWalletAddress()
+        } else {
+          copyToClipboard(address.value)
+          toast.success('Copied to Clipboard')
+        }
       }
     }
-  },
-
-  emits: ['verifyHardwareAddress']
+    return { copyText }
+  }
 })
 
 export default ClickToCopy

--- a/src/composables/useRadix.ts
+++ b/src/composables/useRadix.ts
@@ -1,7 +1,6 @@
 import { ref, computed, ComputedRef } from 'vue'
 import { Network, Radix, RadixT, HRP, ErrorT } from '@radixdlt/application'
 import { firstValueFrom } from 'rxjs'
-import { filter } from 'rxjs/operators'
 
 const radix: RadixT = Radix.create()
 

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -191,7 +191,6 @@ export default function useTransactions (radix: RadixT, router: Router, activeAc
     userDidCancel.next(false)
     transactionState.value = 'building'
     shouldShowConfirmation.value = true
-    console.log(shouldShowConfirmation.value)
     // Subscribe to initial userConfirmation and display modal
     const createUserConfirmation = userConfirmation
       .subscribe((txnToConfirm: ManualUserConfirmTX) => {

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -60,7 +60,8 @@ const reloadTrigger = new Subject<number>()
 const showLedgerVerify: Ref<boolean> = ref(false)
 const signingKeychain: Ref<SigningKeychainT | null> = ref(null)
 const wallet: Ref<WalletT | null> = ref(null)
-
+const activeNetwork: Ref<Network | null> = ref(null)
+const derivedAccountIndex: Ref<number> = ref(0)
 const showDeleteHWWalletPrompt: Ref<boolean> = ref(false)
 
 const setWallet = (newWallet: WalletT) => {
@@ -77,7 +78,7 @@ const createWallet = (mnemonic: MnemomicT, pass: string, network: Network) => {
 
   newWalletPromise.then((newWallet: WalletT) => {
     setWallet(newWallet)
-    saveDerivedAccountsIndex(0)
+    saveDerivedAccountsIndex(0, network)
   })
 
   return newWalletPromise
@@ -89,6 +90,7 @@ interface useWalletInterface {
   readonly accounts: Ref<AccountsT | null>;
   readonly activeAccount: Ref<AccountT | null>;
   readonly activeAddress: Ref<AccountAddressT | null>;
+  readonly activeNetwork: Ref<Network | null>;
   readonly hardwareAccount: Ref<AccountT | null>;
   readonly hardwareAddress: Ref<string | null>;
   readonly hardwareError: Ref<Error | null>;
@@ -99,6 +101,7 @@ interface useWalletInterface {
   readonly showDeleteHWWalletPrompt: Ref<boolean>;
   readonly showLedgerVerify: Ref<boolean>;
   readonly walletHasLoaded: ComputedRef<boolean>;
+  readonly derivedAccountIndex: Ref<number>;
 
   accountNameFor: (address: AccountAddressT) => string;
   accountRenamed: (newName: string) => void;
@@ -148,6 +151,19 @@ export default function useWallet (radix: RadixT, router: Router): useWalletInte
     radix.activeAddress
   )
 
+  const fetchAccountsForNetwork = (network: Network) => {
+    getDerivedAccountsIndex(network)
+      .then((accountsIndex: string) => {
+        derivedAccountIndex.value = Number(accountsIndex)
+        if (accountsIndex) {
+          firstValueFrom(radix.restoreLocalHDAccountsToIndex(Number(accountsIndex) + 1))
+            .then((accountsRes: AccountsT) => { accounts.value = accountsRes })
+        } else {
+          saveDerivedAccountsIndex(0, network)
+        }
+      })
+  }
+
   const waitUntilAllLoaded = async () => firstValueFrom(allLoadedObservable)
 
   const reloadSubscriptions = () => reloadTrigger.next(Math.random())
@@ -165,34 +181,37 @@ export default function useWallet (radix: RadixT, router: Router): useWalletInte
       .pipe(switchMap(() => radix.activeAddress))
       .subscribe((addressRes: AccountAddressT) => { activeAddress.value = addressRes }))
 
-    reloadSubscriptions()
-
-    getDerivedAccountsIndex()
-      .then((accountsIndex: string) => {
-        if ((Number(accountsIndex)) > 0) {
-          radix.restoreLocalHDAccountsToIndex(Number(accountsIndex) + 1)
-            .subscribe(
-              (accountsRes: AccountsT) => { accounts.value = accountsRes })
-        } else {
-          saveDerivedAccountsIndex(0)
-        }
+    const networkObserver = reloadTrigger.asObservable()
+      .pipe(switchMap(() => radix.ledger.networkId()))
+      .subscribe((network: Network) => {
+        activeNetwork.value = network
+        fetchAccountsForNetwork(network)
       })
 
+    subs.add(networkObserver)
+
+    reloadSubscriptions()
     getAccountNames().then((names) => {
       accountNames.value = names
     })
   }
 
   const addAccount = () => {
-    getDerivedAccountsIndex()
+    if (!activeNetwork.value) return
+    getDerivedAccountsIndex(activeNetwork.value)
       .then((index: string) => {
-        saveDerivedAccountsIndex(Number(index) + 1)
+        if (!activeNetwork.value) return
+        saveDerivedAccountsIndex(Number(index) + 1, activeNetwork.value)
         radix.deriveNextAccount({ alsoSwitchTo: true })
       })
   }
 
   const switchAccount = (account: AccountT) => {
     radix.switchAccount({ toAccount: account })
+    if (activeNetwork.value) {
+      fetchAccountsForNetwork(activeNetwork.value)
+    }
+    reloadSubscriptions()
   }
 
   const accountNameFor = (accountAddress: AccountAddressT): string => {
@@ -302,6 +321,8 @@ export default function useWallet (radix: RadixT, router: Router): useWalletInte
     accounts,
     activeAccount,
     activeAddress,
+    activeNetwork,
+    derivedAccountIndex,
     hardwareAccount,
     hardwareAddress,
     hardwareError,

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -69,8 +69,6 @@ const setWallet = (newWallet: WalletT) => {
   return wallet.value
 }
 
-getHardwareWalletAddress().then(a => { hardwareAddress.value = a })
-
 const subs = new Subscription()
 
 const createWallet = (mnemonic: MnemomicT, pass: string, network: Network) => {
@@ -162,6 +160,7 @@ export default function useWallet (radix: RadixT, router: Router): useWalletInte
           saveDerivedAccountsIndex(0, network)
         }
       })
+    getHardwareWalletAddress(network).then(a => { hardwareAddress.value = a; console.log(a, network) })
   }
 
   const waitUntilAllLoaded = async () => firstValueFrom(allLoadedObservable)
@@ -257,8 +256,8 @@ export default function useWallet (radix: RadixT, router: Router): useWalletInte
       next: (hwAccount: AccountT) => {
         activeAccount.value = hwAccount
         hardwareAccount.value = hwAccount
-        if (!hardwareAddress.value) {
-          saveHardwareWalletAddress(hwAccount.address.toString())
+        if (!hardwareAddress.value && activeNetwork.value) {
+          saveHardwareWalletAddress(hwAccount.address.toString(), activeNetwork.value)
           saveAccountName(hwAccount.address.toString(), 'Hardware Wallet')
           hardwareAddress.value = hwAccount.address.toString()
         }
@@ -277,7 +276,9 @@ export default function useWallet (radix: RadixT, router: Router): useWalletInte
   }
 
   const deleteLocalHardwareAddress = () => {
-    deleteHardwareWalletAddress()
+    if (activeNetwork.value) {
+      deleteHardwareWalletAddress(activeNetwork.value)
+    }
     hardwareAddress.value = ''
     showDeleteHWWalletPrompt.value = false
     hardwareAccount.value = null

--- a/src/electron-store/migrations.ts
+++ b/src/electron-store/migrations.ts
@@ -16,10 +16,10 @@ const migrations = {
 
     // Nest derivedAccountsIndex and hardwareAddress values under current network
     store.set(`wallets.${currentNetwork}.derivedAccountsIndex`, derivedAccountsIndex)
-    store.set(`wallets.${currentNetwork}.handwareAddress`, hardwareAddress)
+    store.set(`wallets.${currentNetwork}.hardwareAddress`, hardwareAddress)
 
     // Set other network to have an index of 0
-    store.set(`wallets.${otherNetwork}.derivedAccountsIndex`, "0")
+    store.set(`wallets.${otherNetwork}.derivedAccountsIndex`, 0)
 
     // Remove old configuration
     store.delete('derivedAccountsIndex')

--- a/src/views/RestoreWallet/index.vue
+++ b/src/views/RestoreWallet/index.vue
@@ -103,7 +103,7 @@ const RestoreWallet = defineComponent({
     const createWallet = (pass: string) => {
       initWallet(mnemonic.value, pass, Network.MAINNET)
         .then(() => {
-          saveDerivedAccountsIndex(0)
+          saveDerivedAccountsIndex(0, Network.MAINNET)
           step.value = 2
           passcode.value = pass
         })

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -154,7 +154,6 @@ const WalletConfirmTransactionModal = defineComponent({
   },
 
   setup () {
-    console.log('load form')
     const { errors, meta, values, setErrors, resetForm } = useForm<ConfirmationForm>()
     const { setModal } = useHomeModal()
     const router = useRouter()

--- a/src/views/Wallet/WalletSidebarAccounts.vue
+++ b/src/views/Wallet/WalletSidebarAccounts.vue
@@ -115,6 +115,7 @@ const WalletSidebarAccounts = defineComponent({
     const showHardwareHelper = ref(false)
 
     const displayHardwareAddress: ComputedRef<string> = computed(() => {
+      console.log(hardwareAddress.value)
       if (!hardwareAddress.value) return ''
       const add: string = hardwareAddress.value
       return add.substring(0, 3) + '...' + add.substring(add.length - 9)

--- a/src/views/Wallet/WalletSidebarAccounts.vue
+++ b/src/views/Wallet/WalletSidebarAccounts.vue
@@ -13,8 +13,8 @@
     </div>
 
     <account-list-item
-      v-for="(account, i) in localAccounts"
-      :key="i"
+      v-for="account in localAccounts"
+      :key="account.address.toString()"
       :account="account"
       :activeAccount="activeAccount"
       :shouldShowEdit="true"
@@ -107,6 +107,8 @@ const WalletSidebarAccounts = defineComponent({
       connectHardwareWallet,
       hardwareAccount,
       hardwareAddress,
+      derivedAccountIndex,
+      activeNetwork,
       verifyHardwareWalletAddress
     } = useWallet(radix, router)
     const { setState } = useSidebar()
@@ -128,6 +130,8 @@ const WalletSidebarAccounts = defineComponent({
     return {
       accounts,
       activeAccount,
+      derivedAccountIndex,
+      activeNetwork,
       hardwareAccount,
       hardwareAddress,
       showHardwareHelper,
@@ -137,7 +141,6 @@ const WalletSidebarAccounts = defineComponent({
       addAccount,
       switchAccount,
       debugSwitch (account: AccountT) {
-        console.log(account)
         switchAccount(account)
       },
       editName (account: AccountT) {

--- a/src/views/Wallet/WalletSidebarDefault.vue
+++ b/src/views/Wallet/WalletSidebarDefault.vue
@@ -99,7 +99,7 @@ const WalletSidebarDefault = defineComponent({
   },
 
   setup () {
-    const { radix } = useRadix()
+    const { radix, network } = useRadix()
     const router = useRouter()
     const { activeAccount } = useWallet(radix, router)
     const { open, setState } = useSidebar()
@@ -109,7 +109,8 @@ const WalletSidebarDefault = defineComponent({
       activeAccount,
       open,
       route,
-      setState
+      setState,
+      network
     }
   },
 

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -167,8 +167,6 @@ const WalletTransaction = defineComponent({
     const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
     const { tokenBalances, tokenBalanceFor, tokenBalancesUnsub } = useTokenBalances(radix)
 
-    console.log(tokenBalances.value?.tokenBalances)
-
     onBeforeRouteLeave(() => {
       nativeTokenUnsub()
       tokenBalancesUnsub()
@@ -212,7 +210,6 @@ const WalletTransaction = defineComponent({
 
     const hasTokenBalances = computed(() => {
       if (!tokenBalances.value?.tokenBalances) return false
-      console.log(tokenBalances.value?.tokenBalances.length > 0)
       return tokenBalances.value?.tokenBalances.length > 0
     })
 


### PR DESCRIPTION
Looks like the migration misspelled `hardware`, users who have updated to the unreleased alpha will need to replace `handware` with `hardware` in `wallet.json`