### PR TITLE
fix: Refactor old  from the wallet views linked to ledger integrations

### DIFF
--- a/src/views/Wallet/WalletLedgerInteractionModal.vue
+++ b/src/views/Wallet/WalletLedgerInteractionModal.vue
@@ -9,7 +9,7 @@
           <div class="text-center mt-4 text-rBlack text-sm px-8">
             We were unable to derive your wallet. Please ensure your Ledger is connected and the Radix application is open.
           </div>
-          <ButtonSubmit @click="$emit('retryLedgerAccountDerivation')" class="w-72 mx-auto mt-4" :disabled=false>
+          <ButtonSubmit @click="connectHardwareWallet()" class="w-72 mx-auto mt-4" :disabled=false>
             Retry
           </ButtonSubmit>
 
@@ -49,17 +49,17 @@ const WalletLedgerInteractionModal = defineComponent({
   setup () {
     const router = useRouter()
     const {
+      connectHardwareWallet,
       hardwareError,
       hideLedgerInteraction
     } = useWallet(router)
 
     return {
+      connectHardwareWallet,
       hardwareError,
       hideLedgerInteraction
     }
-  },
-
-  emits: ['retryLedgerAccountDerivation']
+  }
 })
 
 export default WalletLedgerInteractionModal

--- a/src/views/Wallet/WalletSidebarDefault.vue
+++ b/src/views/Wallet/WalletSidebarDefault.vue
@@ -117,9 +117,7 @@ const WalletSidebarDefault = defineComponent({
     isOverview: function (): boolean {
       return this.route.path === '/wallet'
     }
-  },
-
-  emits: ['setView', 'openHelp', 'connectHW']
+  }
 })
 
 export default WalletSidebarDefault

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -9,7 +9,7 @@
             <click-to-copy
               :address="activeAddress.toString()"
               :checkForHardwareAddress=true
-              @verifyHardwareAddress="$emit('verifyHardwareAddress')"
+              @verifyHardwareAddress="verifyHardwareAddress()"
             />
           </div>
         </div>
@@ -154,7 +154,7 @@ const WalletTransaction = defineComponent({
   setup () {
     const { errors, values, meta, setErrors, resetForm } = useForm<TransactionForm>()
     const router = useRouter()
-    const { activeAddress, activeAccount, hardwareAccount, hardwareAccountFailedToSign, networkPreamble, radix } = useWallet(router)
+    const { activeAddress, activeAccount, hardwareAccount, hardwareAccountFailedToSign, networkPreamble, radix, verifyHardwareWalletAddress } = useWallet(router)
 
     const { transactionErrorMessage, transferTokens, transactionUnsub } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value, {
       ledgerSigningError: () => {
@@ -250,6 +250,7 @@ const WalletTransaction = defineComponent({
       activeAddress,
       disableSubmit,
       loadedAllData,
+      verifyHardwareWalletAddress,
       handleSubmit () {
         if (!meta.value.valid || !selectedCurrency.value) return false
         const safeAddress = safelyUnwrapAddress(values.recipient, networkPreamble.value)
@@ -291,9 +292,7 @@ const WalletTransaction = defineComponent({
         }
       }
     }
-  },
-
-  emits: ['verifyHardwareAddress']
+  }
 })
 
 export default WalletTransaction


### PR DESCRIPTION
There were several remaining ledger integrations points that utilized the vue-2
style `$emit` events that had been removed in the refactor.
