### PR TITLE
chore: correct unstaking label size

### DIFF
--- a/src/components/StakeListItem.vue
+++ b/src/components/StakeListItem.vue
@@ -53,7 +53,7 @@
             <div class="mb-1 flex-1 text-rBlack"><big-amount :amount="stakeAmount" /> <span class="text-rGrayDark ml-1 uppercase">{{ nativeToken.symbol }}</span></div>
           </div>
           <div class="flex items-center flex-wrap">
-            <div v-if="unstakeAmount" class="mb-1 w-26 flex-grow-0 text-rGrayMed">{{ $t('staking.unstakingLabel') }}:</div>
+            <div v-if="unstakeAmount" class="mb-1 w-26 flex-grow-0 text-rGrayMed text-xs">{{ $t('staking.unstakingLabel') }}:</div>
             <div v-if="unstakeAmount" class="mb-1 flex-1 text-rBlack"><big-amount :amount="unstakeAmount" /> <span class="text-rGrayDark ml-1 uppercase">{{ nativeToken.symbol }}</span></div>
           </div>
         </dl>


### PR DESCRIPTION
This PR updates the size of the `Unstaking` label on the Stake & Unstake screen to be the same size as the `Staked` label.
<img width="1312" alt="Screen Shot 2021-09-20 at 8 40 48 PM" src="https://user-images.githubusercontent.com/102228/134095671-babc9cdc-96d6-4749-9e9c-1050c2a38d0a.png">

