### PR TITLE
fix: correct pin change button title

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -199,7 +199,8 @@ const messages = {
       nodeAddressLabel: 'Archive Node Address',
       nodeNetworkLabel: 'Network',
       addCustomNodeLabel: 'Add Custom Node Address:',
-      addNodeButton: 'add node'
+      addNodeButton: 'add node',
+      confirm: 'Confirm'
     },
     errors: {
       hardwareMismatchTitle: 'Hardware Wallet Account Mismatch',

--- a/src/views/Settings/SettingsResetPin.vue
+++ b/src/views/Settings/SettingsResetPin.vue
@@ -49,7 +49,7 @@
     </pin-input>
 
     <ButtonSubmit class="w-72 mx-auto mt-8" :disabled="disableSubmit">
-      {{ $t('transaction.confirmButton') }}
+      {{ $t('settings.confirm') }}
     </ButtonSubmit>
     <div v-if="updatedPin" class="text-rGrayDark text-sm mt-4">
       {{ $t('settings.updatedPIN') }}


### PR DESCRIPTION
This PR updates the title of the confirmation button to `Confirm` on the Change PIN screen.
<img width="1312" alt="Screen Shot 2021-09-21 at 9 54 18 AM" src="https://user-images.githubusercontent.com/102228/134183838-784a0424-ba49-4460-83d6-b7f1de5184cb.png">


