### PR TITLE
chore: update styling of non-xrd balances

### DIFF
--- a/src/components/OtherTokenBalanceListItem.vue
+++ b/src/components/OtherTokenBalanceListItem.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="border border-rGray rounded-md  divide-rGray">
+  <div class="border border-rGray rounded-md divide-rGray">
     <div class="flex flex-row py-1">
       <div class="flex-1 flex flex-row items-center px-6 pt-3 overflow-x-auto justify-between">
-        <span class="text-sm text-rGrayDark">{{ tokenBalance.token.name }}</span>
+        <span class="text-md text-rGrayDark">{{ tokenBalance.token.name }}</span>
         <div>
           <a :href="rriUrl" target="_blank" class="hover:text-rGreen transition-colors text-rGrayMed">
             <div class="rounded-full border border-solid border-rGray w-6 h-6 flex items-center justify-center ">
@@ -17,17 +17,17 @@
     </div>
     <div class="overflow-x-scroll">
       <div class="flex flex-row absolute">
-        <div class="flex-1 flex flex-row items-center px-6 pt-3 overflow-x-auto">
+        <div class="flex-1 flex flex-row items-center px-6 overflow-x-auto">
           <span class="text-sm font-mono text-rGrayDark">{{ truncateRRIStringForDisplay(tokenBalance.token.rri.toString()) }}</span>
           <div class="hover:text-rGreen flex flex-row items-center cursor-pointer transition-colors">
             <click-to-copy :address="tokenBalance.token.rri.toString()"/>
           </div>
         </div>
       </div>
-      <div class="flex flex-row py-1 mt-8">
+      <div class="flex flex-row py-1 mt-6">
         <div class="flex-1 flex flex-row items-center px-6 py-3">
-          <big-amount :amount="tokenBalance.amount" class="text-5xl font-light mr-4 text-rBlack" />
-          <token-symbol class="mt-3">{{ tokenBalance.token.symbol.toUpperCase() }}</token-symbol>
+          <big-amount :amount="tokenBalance.amount" class="text-2xl font-light mr-4 text-rBlack" />
+          <token-symbol>{{ tokenBalance.token.symbol.toUpperCase() }}</token-symbol>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR updates non-XRD balances to have smaller type sizes, so they don't dominate the balances page.

Before
<img width="1312" alt="Screen Shot 2021-09-21 at 2 17 19 PM" src="https://user-images.githubusercontent.com/102228/134232132-9030c8ba-72ac-428d-aa99-8e3c04f76334.png">


After
<img width="1312" alt="Screen Shot 2021-09-21 at 2 11 21 PM" src="https://user-images.githubusercontent.com/102228/134232155-5c00daa7-a3ab-4896-86b5-92555afeb7c1.png">


