### PR TITLE
fix: correctly present build errors on Transaction and Stake/Unstake screens

### DIFF
--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -191,6 +191,7 @@ export default function useTransactions (radix: RadixT, router: Router, activeAc
     userDidCancel.next(false)
     transactionState.value = 'building'
     shouldShowConfirmation.value = true
+    transactionErrorMessage.value = null
     // Subscribe to initial userConfirmation and display modal
     const createUserConfirmation = userConfirmation
       .subscribe((txnToConfirm: ManualUserConfirmTX) => {

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -101,7 +101,7 @@
 
 <script lang="ts">
 import { StakePosition, UnstakePosition, AccountAddressT, Amount, AmountT } from '@radixdlt/application'
-import { computed, defineComponent, Ref, ref, ComputedRef } from 'vue'
+import { computed, defineComponent, Ref, ref, ComputedRef, watch } from 'vue'
 import { useForm } from 'vee-validate'
 import StakeListItem from '@/components/StakeListItem.vue'
 import { safelyUnwrapAmount, safelyUnwrapValidator, validateAmountOfType, validateGreaterThanZero } from '@/helpers/validateRadixTypes'
@@ -145,7 +145,7 @@ const WalletStaking = defineComponent({
       radix
     } = useWallet(router)
 
-    const { stakeTokens, unstakeTokens, transactionUnsub } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value, {
+    const { stakeTokens, unstakeTokens, transactionUnsub, setActiveTransactionForm, transactionErrorMessage } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value, {
       ledgerSigningError: () => {
         hardwareAccountFailedToSign()
       }
@@ -162,10 +162,20 @@ const WalletStaking = defineComponent({
       transactionUnsub()
     })
 
+    // default active form is stake
+    setActiveTransactionForm('stake')
+
     const setForm = (form: string) => {
       activeForm.value = form
+      setActiveTransactionForm(form)
       resetForm()
     }
+
+    watch(transactionErrorMessage, (val) => {
+      if (val) {
+        setErrors({ amount: t(val) })
+      }
+    })
 
     // Computed Values
     const xrdBalance: ComputedRef<AmountT> = computed(() => {

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -237,11 +237,13 @@ const WalletStaking = defineComponent({
     // Methods
     const handleAddToValidator = (validator: AccountAddressT) => {
       activeForm.value = 'stake'
+      setActiveTransactionForm('stake')
       values.validator = validator.toString()
     }
 
     const handleReduceFromValidator = (validator: AccountAddressT) => {
       activeForm.value = 'unstake'
+      setActiveTransactionForm('unstake')
       values.validator = validator.toString()
     }
 

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -156,11 +156,13 @@ const WalletTransaction = defineComponent({
     const router = useRouter()
     const { activeAddress, activeAccount, hardwareAccount, hardwareAccountFailedToSign, networkPreamble, radix, verifyHardwareWalletAddress } = useWallet(router)
 
-    const { transactionErrorMessage, transferTokens, transactionUnsub } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value, {
+    const { transactionErrorMessage, transferTokens, transactionUnsub, setActiveTransactionForm } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value, {
       ledgerSigningError: () => {
         hardwareAccountFailedToSign()
       }
     })
+
+    setActiveTransactionForm('transaction')
 
     const { t } = useI18n({ useScope: 'global' })
     const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)


### PR DESCRIPTION
This PR sets up the the transaction and stake/unstake views to correctly watch the `transactionErrorMessage` value from the `useTransaction` composable to watch for any potential errors, and displays them appropriately.

It also resets the value of `transactionErrorMessage` to null in `useTransaction` when any new transaction is created, so that repeated failures are reported to views watching `transactionErrorMessage`.
<img width="1312" alt="Screen Shot 2021-09-21 at 9 36 32 PM" src="https://user-images.githubusercontent.com/102228/134269709-ad655777-8b2b-472a-8bf6-83f63312ee98.png">

