### PR TITLE
fix: correctly highlight active account

### DIFF
--- a/src/components/AccountListItem.vue
+++ b/src/components/AccountListItem.vue
@@ -75,9 +75,7 @@ const AccountListItem = defineComponent({
     const displayAddress: ComputedRef<string> = computed(() => formatWalletAddressForDisplay(account.value.address))
 
     const isActiveAccount: ComputedRef<boolean> = computed(() => {
-      const activeAccountKey: string = activeAccount.value?.hdPath ? activeAccount.value?.hdPath.toString() : 'active'
-      const accountKey: string = props.account.hdPath ? props.account.hdPath.toString() : 'account'
-      return activeAccountKey === accountKey
+      return props.account.address.toString() === activeAccount.value?.address.toString()
     })
 
     return {

--- a/src/views/Wallet/WalletSidebarAccounts.vue
+++ b/src/views/Wallet/WalletSidebarAccounts.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="w-54 px-5 py-8 text-white overflow-y-auto fixed top-0 left-0 h-full bg-rBlueDark z-30 overflow-x-hidden">
     <div @click="setState(false)" class="hover:text-rGreen cursor-pointer transition-colors inline-flex flex-row items-center mb-4">
-      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="mr-2">
-        <circle cx="10" cy="10" r="9.5" transform="rotate(90 10 10)" fill="none" class="stroke-current" />
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="mr-2" >
+        <circle cx="10" cy="10" r="9.5" transform="rotate(90 10 10)" fill="none" class="stroke-current"  />
         <path d="M12 15L7 10L12 5" class="stroke-current" stroke-miterlimit="10"/>
       </svg>
       {{ $t('wallet.back') }}
@@ -37,9 +37,9 @@
             @click="connectHardwareWallet"
             @mouseover="showHardwareHelper = true"
             @mouseleave="showHardwareHelper = false">
-            <svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M18.7382 10.6172H7.26074V19H18.7382V10.6172Z" stroke="white" stroke-width="1.5" stroke-miterlimit="10"/>
-              <path d="M10.6592 12.7317V16.8855" stroke="white" stroke-width="1.5" stroke-miterlimit="10"/>
+            <svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg" class="text-rGreen" :class="{'fill-current': isHardwareWalletActive}">
+              <path d="M18.7382 10.6172H7.26074V19H18.7382V10.6172Z" stroke="white" stroke-width="1.5" stroke-miterlimit="10" />
+              <path d="M10.6592 12.7317V16.8855" stroke="white" stroke-width="1.5" stroke-miterlimit="10" />
               <path d="M15.3405 12.7317V16.8855" stroke="white" stroke-width="1.5" stroke-miterlimit="10"/>
               <path d="M1.45471 18.9997H24.5453V21.4505C24.5453 23.4596 22.9165 25.0883 20.9074 25.0883H5.09253C3.08342 25.0883 1.45471 23.4596 1.45471 21.4505V18.9997Z" stroke="white" stroke-width="1.5" stroke-miterlimit="10"/>
               <path d="M24.5449 7L1.45438 7V4.54926C1.45438 2.54016 3.08309 0.91145 5.09219 0.91145L20.9071 0.91145C22.9162 0.91145 24.5449 2.54016 24.5449 4.54926V7Z" stroke="white" stroke-width="1.5" stroke-miterlimit="10"/>
@@ -48,7 +48,7 @@
             <span class="text-white ml-2"> {{ $t('wallet.hardwareWalletHeading') }} </span>
           </a>
           <div class="text-white hover:text-rGreen transition-colors cursor-pointer flex items-center justify-center w-5 h-5" @click="showDeleteHWPrompt()">
-            <svg width="10" height="12" viewBox="0 0 10 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <svg width="10" height="12" viewBox="0 0 10 12" fill="none" xmlns="http://www.w3.org/2000/svg" >
               <path d="M1.65912 5.23001L1.91 11H7.77L8.02275 5.23001" stroke="white" stroke-width="1.5"/>
               <path d="M0 3.21212H2.98M2.98 3.21212V1H6.7V3.21212M2.98 3.21212H6.7M6.7 3.21212H9.68" stroke="white" stroke-width="1.5"/>
             </svg>
@@ -127,6 +127,11 @@ const WalletSidebarAccounts = defineComponent({
       })
     })
 
+    const isHardwareWalletActive: ComputedRef<boolean> = computed(() => {
+      if (!hardwareAddress.value) { return false }
+      return activeAccount.value?.address.toString() === hardwareAddress.value
+    })
+
     return {
       allAccounts,
       activeAccount,
@@ -140,6 +145,7 @@ const WalletSidebarAccounts = defineComponent({
       setState,
       addAccount,
       switchAccount,
+      isHardwareWalletActive,
       debugSwitch (account: AccountT) {
         switchAccount(account)
       },


### PR DESCRIPTION
This PR correctly highlights the active account, whether it be a software account or a hardware account.

https://www.loom.com/share/d7777b984cc74c55806d83da8b9e07b1 

