### PR TITLE
fix: show the selected currency in the conf modal

### DIFF
--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -65,7 +65,8 @@
             <div class="w-26 text-right text-rGrayDark mr-6">{{ $t('transaction.amountLabel') }}</div>
             <div class="flex-1 flex flex-row items-center">
               <big-amount :amount="amount" class="mr-1" />
-              <span class="uppercase" v-if="nativeToken">{{ nativeToken.symbol }}</span>
+              <span class="uppercase" v-if="stakeInput && nativeToken">{{ nativeToken.symbol }}</span>
+              <span class="uppercase" v-else>{{ selectedCurrency.token.symbol }}</span>
             </div>
           </div>
 
@@ -182,7 +183,8 @@ const WalletConfirmTransactionModal = defineComponent({
       transactionFee,
       transactionState,
       transferInput,
-      transactionUnsub
+      transactionUnsub,
+      selectedCurrency
     } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value, {
       ledgerSigningError: () => {
         hardwareAccountFailedToSign()
@@ -295,7 +297,8 @@ const WalletConfirmTransactionModal = defineComponent({
       transactionFee,
       transactionState,
       transferInput,
-      values
+      values,
+      selectedCurrency
     }
   }
 })

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -66,7 +66,7 @@
             <div class="flex-1 flex flex-row items-center">
               <big-amount :amount="amount" class="mr-1" />
               <span class="uppercase" v-if="stakeInput && nativeToken">{{ nativeToken.symbol }}</span>
-              <span class="uppercase" v-else>{{ selectedCurrency.token.symbol }}</span>
+              <span class="uppercase" v-else-if="selectedCurrency">{{ selectedCurrency.token.symbol }}</span>
             </div>
           </div>
 

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -167,6 +167,7 @@ const WalletTransaction = defineComponent({
     const { t } = useI18n({ useScope: 'global' })
     const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
     const { tokenBalances, tokenBalanceFor, tokenBalancesUnsub } = useTokenBalances(radix)
+    let nativeTokenLoaded = false
 
     onBeforeRouteLeave(() => {
       nativeTokenUnsub()
@@ -181,7 +182,10 @@ const WalletTransaction = defineComponent({
 
     // reset currency when required state has loaded. Especially necessary when switching account
     watch([nativeToken, tokenBalances], ([nt, tb]) => {
-      if (tb && nt) setXRDByDefault(nt)
+      if (tb && nt && !nativeTokenLoaded) {
+        setXRDByDefault(nt)
+        nativeTokenLoaded = true
+      }
     })
 
     watch(transactionErrorMessage, (val) => {

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -167,7 +167,7 @@ const WalletTransaction = defineComponent({
     const { t } = useI18n({ useScope: 'global' })
     const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
     const { tokenBalances, tokenBalanceFor, tokenBalancesUnsub } = useTokenBalances(radix)
-    let nativeTokenLoaded = false
+    const nativeTokenLoaded: Ref<boolean> = ref(false)
 
     onBeforeRouteLeave(() => {
       nativeTokenUnsub()
@@ -182,9 +182,9 @@ const WalletTransaction = defineComponent({
 
     // reset currency when required state has loaded. Especially necessary when switching account
     watch([nativeToken, tokenBalances], ([nt, tb]) => {
-      if (tb && nt && !nativeTokenLoaded) {
+      if (tb && nt && !nativeTokenLoaded.value) {
         setXRDByDefault(nt)
-        nativeTokenLoaded = true
+        nativeTokenLoaded.value = true
       }
     })
 


### PR DESCRIPTION
In the Great Refactor we introduced a regression where on the Amount in the transaction confirmation modal we always displayed the `nativeToken` symbol, where we should be showing the transaction's `selectedCurrency` symbol. This PR fixes that issue. It also ensures that we show the `nativeToken` symbol when staking/unstaking. 

<img width="1312" alt="Screen Shot 2021-09-24 at 8 32 01 AM" src="https://user-images.githubusercontent.com/102228/134675049-52f6d51f-3f61-48a3-a783-794fd600690c.png">


Also, there was a secondary issue on the create transaction form. The view was set up to watch the value of `nativeToken` and set it as the top (selected) item in the currency list every time the value changed. This meant that for every successful poll, XRD would bump to the top, replacing whatever the user had selected. This issue has also been patched.

