### PR TITLE
chore: Enable Latest Builds

### DIFF
--- a/.github/actions/mark-latest/action.yml
+++ b/.github/actions/mark-latest/action.yml
@@ -1,0 +1,6 @@
+name: "mark-latest"
+description: "Mark the release as latest in package.json"
+
+runs:
+  using: "node12"
+  main: "index.js"

--- a/.github/actions/mark-latest/index.js
+++ b/.github/actions/mark-latest/index.js
@@ -1,0 +1,19 @@
+const core = require("@actions/core");
+const fs = require("fs");
+
+const filePath = "./package.json";
+
+const main = async () => {
+  if (fs.existsSync(filePath)) {
+    try {
+      const file = fs.readFileSync(filePath, "utf8");
+      const json = JSON.parse(file);
+      json.latest = true
+      fs.writeFileSync(filePath, JSON.stringify(json), { encoding: "utf8", flag: "w" });
+    } catch (error) {
+      core.setFailed(error);
+    }
+  }
+};
+
+main().catch(err => core.setFailed(err));

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - st/latest-builds
+      - main
 
 name: release-latest
 jobs:

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - never
+      - st/latest-builds
 
 name: release-latest
 jobs:
@@ -11,19 +11,18 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v1
-
-      - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v2
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: '15'
           check-latest: true
+      - run: yarn
+      - name: mark latest
+        uses: ./.github/actions/mark-latest
 
       - name: Build/release Electron app
         uses: samuelmeuli/action-electron-builder@v1
         env:
-          VUE_APP_NETWORK_NAME: STOKENET
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
         with:
@@ -31,9 +30,10 @@ jobs:
           # (No need to define this secret in the repo settings)
           github_token: ${{ secrets.github_token }}
           use_vue_cli: true
-          release: false
+          release: ${{ startsWith(github.ref, 'refs/tags/v') }}
           mac_certs: ${{ secrets.MAC_CERTS }}
           mac_certs_password: ${{ secrets.MAC_CERTS_PASSWORD }}
+          args: "--publish=never"
       - name: Move Files
         shell: bash
         run: ./move_dist.sh

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "vue-toastification": "^2.0.0-rc.1"
   },
   "devDependencies": {
+    "@actions/core": "^1.5.0",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8",
     "@babel/plugin-proposal-optional-chaining": "^7.13.8",
     "@types/chai": "^4.2.11",

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,12 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const NormalModuleReplacementPlugin = require('webpack').NormalModuleReplacementPlugin
+const package = require('./package.json')
+
+const builderReleaseOptions = package.latest ? null : {
+  provider: 'github',
+  private: false,
+  releaseType: 'release'
+}
 
 module.exports = {
   pluginOptions: {
@@ -35,11 +42,7 @@ module.exports = {
       },
 
       builderOptions: {
-        publish: {
-          provider: 'github',
-          private: true,
-          releaseType: 'release'
-        },
+        publish: builderReleaseOptions,
         snap: {
           publish: 'github'
         },
@@ -61,8 +64,7 @@ module.exports = {
   },
   chainWebpack: config => {
     config.plugin('html').tap(args => {
-      const package = require('./package.json')
-      args[0].title = `${package.description} (v${package.version})`
+      args[0].title = `${package.description} ${package.latest ? ' LATEST' : ''} (v${package.version})`
       return args
     })
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,11 @@
   resolved "https://registry.yarnpkg.com/7zip-bin/-/7zip-bin-5.1.1.tgz#9274ec7460652f9c632c59addf24efb1684ef876"
   integrity sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ==
 
+"@actions/core@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.5.0.tgz#885b864700001a1b9a6fba247833a036e75ad9d3"
+  integrity sha512-eDOLH1Nq9zh+PJlYLqEMkS/jLQxhksPNmUGNBHfa4G+tQmnIhzpctxmchETtVGyBOvXgOVVpYuE40+eS4cUnwQ==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.8.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"


### PR DESCRIPTION
This PR enables the latest builds based on commits to main while preventing the build process from conflicting with the release cycle that could be running in parallel.

On release of 1.2.0, we discovered an issue where `release-please` and `release-latest` were racing to provide packaged builds that would be linked with the official release.

This PR removes that race condition by using a custom action to mark the `release-latest` builds as 'latest'.  This custom action does this by modifying the `package.json` file.

This enables:
* `vue.config.js` updates the `html title` of the electron app to include the 'LATEST' flag.
* `vue.config.js` overrides the default release behavior, setting it to null (there's a combination of bugs and poor documentation in `electron-builder` on the correct arguments to override publish feature) so `release-latest` will never target the tags and releases on github.
* 
<img width="701" alt="Screen Shot 2021-09-27 at 1 44 01 PM" src="https://user-images.githubusercontent.com/2738409/134958874-d6c754f7-a7d5-4464-895a-0a3f30818009.png">

