### PR TITLE
fix: make rri address scroll with token balance

### DIFF
--- a/src/components/OtherTokenBalanceListItem.vue
+++ b/src/components/OtherTokenBalanceListItem.vue
@@ -15,7 +15,7 @@
         </div>
       </div>
     </div>
-    <div class="overflow-x-scroll">
+    <div class="overflow-x-scroll relative">
       <div class="flex flex-row absolute">
         <div class="flex-1 flex flex-row items-center px-6 overflow-x-auto">
           <span class="text-sm font-mono text-rGrayDark">{{ truncateRRIStringForDisplay(tokenBalance.tokenIdentifier.toString()) }}</span>


### PR DESCRIPTION
This PR fixes an issue where the rri address wouldn't scroll with its other token balance.

https://www.loom.com/share/48dc7029c6c14080803e63f0597fcf2f
