### PR TITLE
feat: Add error modals for generic and txn errors

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,8 +3,18 @@
     <div class="bg-rBlue w-1/2 h-tallest origin-center transform rotate-45 absolute z-0 top-0 left-0 -translate-x-1/2 -translate-y-1/2"></div>
     <div class="relative z-10 min-h-screen">
       <template v-if="latestError">
+        <ErrorModalTransactionBuilding
+          v-if="latestError.type === 'TRANSACTION-BUILDING'"
+          :error="latestError.error"
+          :errorsCount="errorsCount"
+        />
+        <ErrorModalTransactionConfirming
+          v-else-if="latestError.type === 'TRANSACTION-CONFIRM'"
+          :error="latestError.error"
+          :errorsCount="errorsCount"
+        />
         <ErrorModalGeneric
-          v-if="latestError.type === 'GENERIC'"
+          v-else
           :error="latestError.error"
           :errorsCount="errorsCount"
         />
@@ -17,18 +27,23 @@
 <script lang="ts">
 import { computed, ComputedRef, defineComponent } from 'vue'
 import { useRouter } from 'vue-router'
-import { useWallet } from './composables'
+import { useWallet, useErrors } from './composables'
 import ErrorModalGeneric from '@/components/ErrorModalGeneric.vue'
-import { ClientAppErrorT } from './composables/useWallet'
+import ErrorModalTransactionBuilding from '@/components/ErrorModalTransactionBuilding.vue'
+import ErrorModalTransactionConfirming from '@/components/ErrorModalTransactionConfirming.vue'
+import { ClientAppErrorT } from './composables/useErrors'
 
 const App = defineComponent({
   components: {
-    ErrorModalGeneric
+    ErrorModalGeneric,
+    ErrorModalTransactionBuilding,
+    ErrorModalTransactionConfirming
   },
 
   setup () {
     const router = useRouter()
-    const { appErrors } = useWallet(router)
+    const { radix } = useWallet(router)
+    const { appErrors } = useErrors(radix)
 
     const latestError: ComputedRef<ClientAppErrorT | null> = computed(() => {
       return appErrors.value[appErrors.value.length - 1]

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,11 +2,13 @@
   <div class="relative bg-gradient-to-r from-rBlue via-blueMid to-blueEnd min-h-screen overflow-hidden font-sans antialiased">
     <div class="bg-rBlue w-1/2 h-tallest origin-center transform rotate-45 absolute z-0 top-0 left-0 -translate-x-1/2 -translate-y-1/2"></div>
     <div class="relative z-10 min-h-screen">
-      <ErrorModalGeneric
-        v-if="latestError"
-        :error="latestError"
-        :errorsCount="errorsCount"
-      />
+      <template v-if="latestError">
+        <ErrorModalGeneric
+          v-if="latestError.type === 'GENERIC'"
+          :error="latestError.error"
+          :errorsCount="errorsCount"
+        />
+      </template>
       <router-view />
     </div>
   </div>
@@ -17,7 +19,7 @@ import { computed, ComputedRef, defineComponent } from 'vue'
 import { useRouter } from 'vue-router'
 import { useWallet } from './composables'
 import ErrorModalGeneric from '@/components/ErrorModalGeneric.vue'
-import { ErrorT } from '@radixdlt/application'
+import { ClientAppErrorT } from './composables/useWallet'
 
 const App = defineComponent({
   components: {
@@ -28,7 +30,7 @@ const App = defineComponent({
     const router = useRouter()
     const { appErrors } = useWallet(router)
 
-    const latestError: ComputedRef<ErrorT<'wallet'> | null> = computed(() => {
+    const latestError: ComputedRef<ClientAppErrorT | null> = computed(() => {
       return appErrors.value[appErrors.value.length - 1]
     })
     const errorsCount: ComputedRef<number> = computed(() => appErrors.value.length)

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,24 +2,44 @@
   <div class="relative bg-gradient-to-r from-rBlue via-blueMid to-blueEnd min-h-screen overflow-hidden font-sans antialiased">
     <div class="bg-rBlue w-1/2 h-tallest origin-center transform rotate-45 absolute z-0 top-0 left-0 -translate-x-1/2 -translate-y-1/2"></div>
     <div class="relative z-10 min-h-screen">
+      <ErrorModalGeneric
+        v-if="latestError"
+        :error="latestError"
+        :errorsCount="errorsCount"
+      />
       <router-view />
     </div>
-    <!-- <div class="relative z-10 min-h-screen">
-      <div class="bg-white absolute inset-0 flex items-center justify-center">
-        <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" class="container animate-spin">
-          <path fill-rule="evenodd" clip-rule="evenodd" d="M77.8789 52.8857C72.5168 68.6526 57.5862 80.0002 40.0001 80.0002C29.2115 80.0002 19.417 75.7265 12.2241 68.7838L14.9924 65.9158C21.4721 72.1701 30.2851 76.0141 40.0001 76.0141C55.8278 76.0141 69.2758 65.8025 74.1051 51.6023L77.8789 52.8857Z" fill="#052CC0"/>
-          <path fill-rule="evenodd" clip-rule="evenodd" d="M0 40C0 22.4565 11.2928 7.55578 26.9998 2.16064L28.2947 5.9305C14.1483 10.7896 3.98605 24.2106 3.98605 40C3.98605 46.5378 5.72622 52.663 8.76754 57.9442L5.31331 59.9334C1.93284 54.0632 0 47.2544 0 40Z" fill="#052CC0"/>
-          <path fill-rule="evenodd" clip-rule="evenodd" d="M38.0078 0H40.0008C62.0924 0 80.0008 17.9088 80.0008 40V41.993H38.0078V0ZM41.9939 4.04026V38.007H75.9606C74.9622 19.7039 60.2972 5.03859 41.9939 4.04026Z" fill="#00C389"/>
-        </svg>
-      </div>
-    </div> -->
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { computed, ComputedRef, defineComponent } from 'vue'
+import { useRouter } from 'vue-router'
+import { useWallet } from './composables'
+import ErrorModalGeneric from '@/components/ErrorModalGeneric.vue'
+import { ErrorT } from '@radixdlt/application'
 
-const App = defineComponent({})
+const App = defineComponent({
+  components: {
+    ErrorModalGeneric
+  },
+
+  setup () {
+    const router = useRouter()
+    const { appErrors } = useWallet(router)
+
+    const latestError: ComputedRef<ErrorT<'wallet'> | null> = computed(() => {
+      return appErrors.value[appErrors.value.length - 1]
+    })
+    const errorsCount: ComputedRef<number> = computed(() => appErrors.value.length)
+
+    return {
+      appErrors,
+      errorsCount,
+      latestError
+    }
+  }
+})
 
 export default App
 </script>

--- a/src/components/AppButtonCancel.vue
+++ b/src/components/AppButtonCancel.vue
@@ -1,0 +1,12 @@
+<template>
+  <button class="border border-solid border-rGrayDark rounded py-2.5 font-sm text-rGrayDark cursor-pointer">
+    <slot></slot>
+  </button>
+</template>
+
+<script>
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+})
+</script>

--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -1,0 +1,62 @@
+<template>
+  <transition
+    enter-from-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+    enter-active-class="ease-out duration-300"
+    enter-to-class="opacity-100 translate-y-0 sm:scale-100"
+    leave-from-class="opacity-100 translate-y-0 sm:scale-100"
+    leave-active-class="ease-in duration-200"
+    leave-to-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+  >
+    <div
+      v-if="visible"
+      class="rounded overflow-hidden max-w-lg w-full fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-50"
+    >
+      <div class="bg-rGrayLight text-center pt-8 pb-7">
+        <div
+          v-if="slots.icon != undefined"
+          class="mb-4 flex flex-row justify-center"
+        >
+          <slot name="icon"></slot>
+        </div>
+        <div class="text-rBlue text-2xl font-light">{{ title }}</div>
+      </div>
+      <div
+        v-if="slots.content != undefined"
+        class="bg-white pt-6 pb-5 text-rGrayDark text-base text-center space-y-5"
+      >
+        <slot name="content"></slot>
+      </div>
+      <div
+        v-if="slots.info != undefined"
+        class="bg-rGrayLight pt-6 pb-16 text-rGrayDark text-base text-center"
+      >
+        <slot name="info"></slot>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script lang="ts">
+import { defineComponent, useSlots } from 'vue'
+
+export default defineComponent({
+  props: {
+    title: {
+      type: String,
+      required: false
+    },
+    visible: {
+      type: Boolean,
+      required: true
+    }
+  },
+
+  setup () {
+    const slots = useSlots()
+
+    return {
+      slots
+    }
+  }
+})
+</script>

--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -18,7 +18,7 @@
         >
           <slot name="icon"></slot>
         </div>
-        <div class="text-rBlue text-2xl font-light">{{ title }}</div>
+        <div class="text-rBlue text-2xl font-light px-8">{{ title }}</div>
       </div>
       <div
         v-if="slots.content != undefined"

--- a/src/components/AppModal.vue
+++ b/src/components/AppModal.vue
@@ -9,7 +9,7 @@
   >
     <div
       v-if="visible"
-      class="rounded overflow-hidden max-w-lg w-full fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-50"
+      class="shadow rounded overflow-hidden max-w-lg w-full fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-50"
     >
       <div class="bg-rGrayLight text-center pt-8 pb-7">
         <div
@@ -22,7 +22,7 @@
       </div>
       <div
         v-if="slots.content != undefined"
-        class="bg-white pt-6 pb-5 text-rGrayDark text-base text-center space-y-5"
+        class="bg-white pt-6 pb-5 text-rGrayDark text-base text-center px-4"
       >
         <slot name="content"></slot>
       </div>

--- a/src/components/ErrorModalGeneric.vue
+++ b/src/components/ErrorModalGeneric.vue
@@ -1,0 +1,78 @@
+<template>
+  <AppModal
+    :visible="isVisible"
+    :title="$t('errors.genericErrorTitle')"
+  >
+    <template v-slot:icon>
+      <svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="25" cy="25" r="24" stroke="#052CC0" stroke-width="1.5"/>
+      <path d="M25 14V36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M14 25H36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </template>
+    <template v-slot:content>
+      <div v-if="errorsCount > 1" class="absolute top-0 right-0">
+        <div class="bg-rRed rounded-full inline-block px-2 py-0.5 m-2 text-white text-sm">{{ errorsCount }}</div>
+      </div>
+      <p class="mb-5">{{ error }}</p>
+      <div class="flex flex-row space-x-5 justify-center">
+        <AppButtonCancel @click="handleClose" class="w-44">{{ $t('errors.closeModal') }}</AppButtonCancel>
+        <AppButtonCancel @click="refreshApp" class="w-44">{{ $t('errors.refreshApp') }}</AppButtonCancel>
+      </div>
+    </template>
+  </AppModal>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType, Ref, ref, toRef, watch } from 'vue'
+import AppButtonCancel from '@/components/AppButtonCancel.vue'
+import AppModal from '@/components/AppModal.vue'
+import { ErrorT } from '@radixdlt/application'
+import { useRouter } from 'vue-router'
+import { useWallet } from '@/composables'
+import { refreshApp } from '@/actions/vue/data-store'
+
+export default defineComponent({
+  components: {
+    AppButtonCancel,
+    AppModal
+  },
+
+  props: {
+    error: {
+      type: Object as PropType<ErrorT<'wallet'>>,
+      required: true
+    },
+    errorsCount: {
+      type: Number,
+      required: true
+    }
+  },
+
+  setup (props) {
+    const isVisible: Ref<boolean> = ref(true)
+    const updateVisible = () => { isVisible.value = !isVisible.value }
+    const error = toRef(props, 'error')
+    const router = useRouter()
+    const { clearLatestError } = useWallet(router)
+
+    watch((error), (newErrorVal) => {
+      if (newErrorVal) isVisible.value = true
+    })
+
+    const handleClose = () => {
+      clearLatestError()
+      // Clear latest error but leave modal open if there are more errors in the list
+      // Close modal if this is the last error
+      if (props.errorsCount <= 1) isVisible.value = false
+    }
+
+    return {
+      handleClose,
+      isVisible,
+      refreshApp,
+      updateVisible
+    }
+  }
+})
+</script>

--- a/src/components/ErrorModalTransactionBuilding.vue
+++ b/src/components/ErrorModalTransactionBuilding.vue
@@ -1,7 +1,7 @@
 <template>
   <AppModal
     :visible="isVisible"
-    :title="$t('errors.genericErrorTitle')"
+    :title="$t('errors.transactionBuildingErrorTitle')"
   >
     <template v-slot:icon>
       <svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg" class="transform rotate-45">
@@ -17,7 +17,6 @@
       <p class="mb-5">{{ error }}</p>
       <div class="flex flex-row space-x-5 justify-center">
         <AppButtonCancel @click="handleClose" class="w-44">{{ $t('errors.closeModal') }}</AppButtonCancel>
-        <AppButtonCancel @click="refreshApp" class="w-44">{{ $t('errors.refreshApp') }}</AppButtonCancel>
       </div>
     </template>
   </AppModal>
@@ -30,7 +29,6 @@ import AppModal from '@/components/AppModal.vue'
 import { ErrorT } from '@radixdlt/application'
 import { useRouter } from 'vue-router'
 import { useWallet, useErrors } from '@/composables'
-import { refreshApp } from '@/actions/vue/data-store'
 
 export default defineComponent({
   components: {
@@ -71,7 +69,6 @@ export default defineComponent({
     return {
       handleClose,
       isVisible,
-      refreshApp,
       updateVisible
     }
   }

--- a/src/components/ErrorModalTransactionConfirming.vue
+++ b/src/components/ErrorModalTransactionConfirming.vue
@@ -1,7 +1,7 @@
 <template>
   <AppModal
     :visible="isVisible"
-    :title="$t('errors.genericErrorTitle')"
+    :title="$t('errors.transactionConfirmingErrorTitle')"
   >
     <template v-slot:icon>
       <svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg" class="transform rotate-45">
@@ -14,6 +14,7 @@
       <div v-if="errorsCount > 1" class="absolute top-0 right-0">
         <div class="bg-rRed rounded-full inline-block px-2 py-0.5 m-2 text-white text-sm">{{ errorsCount }}</div>
       </div>
+      <p class="mb-5">{{ $t('errors.transactionConfirmingErrorMsg') }}</p>
       <p class="mb-5">{{ error }}</p>
       <div class="flex flex-row space-x-5 justify-center">
         <AppButtonCancel @click="handleClose" class="w-44">{{ $t('errors.closeModal') }}</AppButtonCancel>

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -1,6 +1,7 @@
 import useConnectableRadix from './useConnectableRadix'
 import useHomeModal from './useHomeModal'
 import useNativeToken from './useNativeToken'
+import useErrors from './useErrors'
 import useSettingsTab from './useSettingsTab'
 import useStaking from './useStaking'
 import useSidebar from './useSidebar'
@@ -12,6 +13,7 @@ export {
   useConnectableRadix,
   useHomeModal,
   useNativeToken,
+  useErrors,
   useSettingsTab,
   useStaking,
   useSidebar,

--- a/src/composables/useErrors.ts
+++ b/src/composables/useErrors.ts
@@ -1,0 +1,41 @@
+import { ErrorT, RadixT } from '@radixdlt/application'
+import { Ref, ref, computed, ComputedRef } from 'vue'
+
+export type TransactionStateT = 'HW-SIGNING' | 'BUILDING' | 'CONFIRM' | 'SUBMITTING'
+
+export type ClientAppErrorTypeT = 'GENERIC' | 'TRANSACTION-HW-SIGNING' | 'TRANSACTION-BUILDING' | 'TRANSACTION-CONFIRM' | 'TRANSACTION-SUBMITTING'
+export type ClientAppErrorT = {
+  type: ClientAppErrorTypeT,
+  error?: ErrorT<'wallet'> | Error
+}
+
+const appErrors: Ref<ClientAppErrorT[]> = ref([])
+
+interface useErrorsInterface {
+  readonly appErrors: ComputedRef<ClientAppErrorT[]>;
+  clearLatestError: () => void;
+  setError: (error: ClientAppErrorT) => void;
+}
+
+const setError = (error: ClientAppErrorT) => {
+  appErrors.value = [...appErrors.value, error]
+}
+
+const clearLatestError = () => {
+  const latestErrors = appErrors.value
+  latestErrors.pop()
+  appErrors.value = latestErrors
+}
+
+export default function useErrors (radix: RadixT): useErrorsInterface {
+  radix.errors
+    .subscribe((error: ErrorT<'wallet'>) => {
+      console.log('error sink:', error)
+    })
+
+  return {
+    appErrors: computed(() => appErrors.value),
+    clearLatestError,
+    setError
+  }
+}

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -281,7 +281,6 @@ export default function useTransactions (radix: RadixT, router: Router, activeAc
           transactionDidComplete.next(true)
           // If we receive a completion event but never received a confirmation event and cleared
           // pending transaction, we should warn the user that something went wrong
-          console.log(transactionState.value)
           if (transactionState.value !== 'submitting') {
             setError({
               type: 'TRANSACTION-CONFIRM'

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -38,6 +38,8 @@ import {
   AccountT
 } from '@radixdlt/application'
 import { Router } from 'vue-router'
+import { useErrors } from '.'
+import { TransactionStateT, ClientAppErrorTypeT } from './useErrors'
 
 export interface PendingTransaction extends TransactionStateSuccess {
   actions: IntendedAction[]
@@ -111,6 +113,7 @@ let userConfirmation = new ReplaySubject<ManualUserConfirmTX>()
 const historyPagination = new Subject<TransactionHistoryOfKnownAddressRequestInput>()
 
 export default function useTransactions (radix: RadixT, router: Router, activeAccount: AccountT | null, hardwareAccount: AccountT | null, callbacks: { ledgerSigningError: () => void;}): useTransactionsInterface {
+  const { setError } = useErrors(radix)
   const refreshHistory = () => {
     loadingHistory.value = true
     historyPagination.next({ size: PAGE_SIZE })
@@ -221,6 +224,13 @@ export default function useTransactions (radix: RadixT, router: Router, activeAc
       }))
       .subscribe((event: TransactionStateUpdate) => {
         const errorEvent: TransactionStateError = event as TransactionStateError
+        const transactionStateConstant: TransactionStateT = transactionState.value.toUpperCase() as TransactionStateT
+        setError({
+          type: 'TRANSACTION-' + transactionStateConstant as ClientAppErrorTypeT,
+          error: errorEvent.error
+        })
+
+        // const errorEvent: TransactionStateError = event as TransactionStateError
         userDidCancel.next(true)
         shouldShowConfirmation.value = false
         const isLedgerConnectedError = errorEvent.error.message && errorEvent.error.message.includes('Failed to sign tx with Ledger')
@@ -269,6 +279,14 @@ export default function useTransactions (radix: RadixT, router: Router, activeAc
           router.push('/wallet/history')
           hasCalculatedFee.value = false
           transactionDidComplete.next(true)
+          // If we receive a completion event but never received a confirmation event and cleared
+          // pending transaction, we should warn the user that something went wrong
+          console.log(transactionState.value)
+          if (transactionState.value !== 'submitting') {
+            setError({
+              type: 'TRANSACTION-CONFIRM'
+            })
+          }
         }
       }))
 

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -15,7 +15,8 @@ import {
   SigningKeychainT,
   WalletErrorCause,
   WalletT,
-  walletError
+  walletError,
+  APIError
 } from '@radixdlt/application'
 import { AccountName } from '@/actions/electron/data-store'
 import { Router } from 'vue-router'
@@ -65,11 +66,19 @@ const showLedgerVerify: Ref<boolean> = ref(false)
 const signingKeychain: Ref<SigningKeychainT | null> = ref(null)
 const switching = ref(false)
 const wallet: Ref<WalletT | null> = ref(null)
+const appErrors: Ref<ErrorT<'wallet'>[]> = ref([])
 
 radix.errors
   .subscribe((error: ErrorT<'wallet'>) => {
-    console.log(error)
+    console.log('error sink:', error)
+    appErrors.value = [...appErrors.value, error]
   })
+
+const clearLatestError = () => {
+  const latestErrors = appErrors.value
+  latestErrors.pop()
+  appErrors.value = latestErrors
+}
 
 const setWallet = (newWallet: WalletT) => {
   wallet.value = newWallet
@@ -99,6 +108,7 @@ interface useWalletInterface {
   readonly activeAccount: Ref<AccountT | null>;
   readonly activeAddress: Ref<AccountAddressT | null>;
   readonly activeNetwork: Ref<Network | null>;
+  readonly appErrors: ComputedRef<ErrorT<'wallet'>[]>;
   readonly explorerUrlBase: ComputedRef<string>;
   readonly hardwareAccount: Ref<AccountT | null>;
   readonly hardwareAddress: Ref<string | null>;
@@ -119,6 +129,7 @@ interface useWalletInterface {
   accountNameFor: (address: AccountAddressT) => string;
   accountRenamed: (newName: string) => void;
   addAccount: () => void;
+  clearLatestError: () => void;
   connectHardwareWallet: () => void;
   createWallet: (mnemonic: MnemomicT, pass: string, network: Network) => Promise<WalletT>;
   deleteLocalHardwareAddress: () => void;
@@ -359,6 +370,7 @@ export default function useWallet (router: Router): useWalletInterface {
     activeAddress,
     activeNetwork,
     allAccounts,
+    appErrors: computed(() => appErrors.value),
     explorerUrlBase: computed(() => explorerUrlBase.value),
     derivedAccountIndex,
     hardwareAccount,
@@ -413,6 +425,7 @@ export default function useWallet (router: Router): useWalletInterface {
     accountNameFor,
     accountRenamed,
     addAccount,
+    clearLatestError,
     connectHardwareWallet,
     createWallet,
     deleteLocalHardwareAddress,

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -44,11 +44,6 @@ const radix: RadixT = Radix.create()
 
 export type WalletError = ErrorT<ErrorCategory.WALLET>
 
-export type ClientAppErrorT = {
-  type: 'GENERIC',
-  error: ErrorT<'wallet'>
-}
-
 const accountNames: Ref<AccountName[]> = ref([])
 const accounts: Ref<AccountsT | null> = ref(null)
 const allAccounts: Ref<AccountT[]> = ref([])
@@ -70,22 +65,6 @@ const showLedgerVerify: Ref<boolean> = ref(false)
 const signingKeychain: Ref<SigningKeychainT | null> = ref(null)
 const switching = ref(false)
 const wallet: Ref<WalletT | null> = ref(null)
-const appErrors: Ref<ClientAppErrorT[]> = ref([])
-
-radix.errors
-  .subscribe((error: ErrorT<'wallet'>) => {
-    console.log('error sink:', error)
-    appErrors.value = [...appErrors.value, {
-      type: 'GENERIC',
-      error
-    }]
-  })
-
-const clearLatestError = () => {
-  const latestErrors = appErrors.value
-  latestErrors.pop()
-  appErrors.value = latestErrors
-}
 
 const setWallet = (newWallet: WalletT) => {
   wallet.value = newWallet
@@ -115,7 +94,6 @@ interface useWalletInterface {
   readonly activeAccount: Ref<AccountT | null>;
   readonly activeAddress: Ref<AccountAddressT | null>;
   readonly activeNetwork: Ref<Network | null>;
-  readonly appErrors: ComputedRef<ClientAppErrorT[]>;
   readonly explorerUrlBase: ComputedRef<string>;
   readonly hardwareAccount: Ref<AccountT | null>;
   readonly hardwareAddress: Ref<string | null>;
@@ -136,7 +114,6 @@ interface useWalletInterface {
   accountNameFor: (address: AccountAddressT) => string;
   accountRenamed: (newName: string) => void;
   addAccount: () => void;
-  clearLatestError: () => void;
   connectHardwareWallet: () => void;
   createWallet: (mnemonic: MnemomicT, pass: string, network: Network) => Promise<WalletT>;
   deleteLocalHardwareAddress: () => void;
@@ -377,7 +354,6 @@ export default function useWallet (router: Router): useWalletInterface {
     activeAddress,
     activeNetwork,
     allAccounts,
-    appErrors: computed(() => appErrors.value),
     explorerUrlBase: computed(() => explorerUrlBase.value),
     derivedAccountIndex,
     hardwareAccount,
@@ -432,7 +408,6 @@ export default function useWallet (router: Router): useWalletInterface {
     accountNameFor,
     accountRenamed,
     addAccount,
-    clearLatestError,
     connectHardwareWallet,
     createWallet,
     deleteLocalHardwareAddress,

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -1,4 +1,4 @@
-import { ref, computed, Ref, ComputedRef, watch } from 'vue'
+import { ref, computed, Ref, ComputedRef } from 'vue'
 import {
   AccountAddressT,
   AccountsT,
@@ -15,8 +15,7 @@ import {
   SigningKeychainT,
   WalletErrorCause,
   WalletT,
-  walletError,
-  APIError
+  walletError
 } from '@radixdlt/application'
 import { AccountName } from '@/actions/electron/data-store'
 import { Router } from 'vue-router'
@@ -45,6 +44,11 @@ const radix: RadixT = Radix.create()
 
 export type WalletError = ErrorT<ErrorCategory.WALLET>
 
+export type ClientAppErrorT = {
+  type: 'GENERIC',
+  error: ErrorT<'wallet'>
+}
+
 const accountNames: Ref<AccountName[]> = ref([])
 const accounts: Ref<AccountsT | null> = ref(null)
 const allAccounts: Ref<AccountT[]> = ref([])
@@ -66,12 +70,15 @@ const showLedgerVerify: Ref<boolean> = ref(false)
 const signingKeychain: Ref<SigningKeychainT | null> = ref(null)
 const switching = ref(false)
 const wallet: Ref<WalletT | null> = ref(null)
-const appErrors: Ref<ErrorT<'wallet'>[]> = ref([])
+const appErrors: Ref<ClientAppErrorT[]> = ref([])
 
 radix.errors
   .subscribe((error: ErrorT<'wallet'>) => {
     console.log('error sink:', error)
-    appErrors.value = [...appErrors.value, error]
+    appErrors.value = [...appErrors.value, {
+      type: 'GENERIC',
+      error
+    }]
   })
 
 const clearLatestError = () => {
@@ -108,7 +115,7 @@ interface useWalletInterface {
   readonly activeAccount: Ref<AccountT | null>;
   readonly activeAddress: Ref<AccountAddressT | null>;
   readonly activeNetwork: Ref<Network | null>;
-  readonly appErrors: ComputedRef<ErrorT<'wallet'>[]>;
+  readonly appErrors: ComputedRef<ClientAppErrorT[]>;
   readonly explorerUrlBase: ComputedRef<string>;
   readonly hardwareAccount: Ref<AccountT | null>;
   readonly hardwareAddress: Ref<string | null>;

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -216,6 +216,9 @@ const messages = {
       hardwareMismatchCopyOne: 'The account provided by the connected hardware wallet device does not match your current hardware wallet account address. Ensure you are using the same hardware wallet device.',
       hardwareMismatchCopyTwo: 'If you would like to use a different hardware wallet device, please remove the existing hardware wallet account and add a new one with the desired device connected. You can always re-add a previous hardware wallet device account later.',
       genericErrorTitle: 'Oops, something unexpected happened',
+      transactionBuildingErrorTitle: 'Something went wrong while building your transaction',
+      transactionConfirmingErrorTitle: 'Something went wrong while confirming your transaction',
+      transactionConfirmingErrorMsg: 'We suggest you reload your app and confirm that your transaction went through before trying again.',
       closeModal: 'Close',
       refreshApp: 'Refresh App'
     }

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -214,7 +214,10 @@ const messages = {
     errors: {
       hardwareMismatchTitle: 'Hardware Wallet Account Mismatch',
       hardwareMismatchCopyOne: 'The account provided by the connected hardware wallet device does not match your current hardware wallet account address. Ensure you are using the same hardware wallet device.',
-      hardwareMismatchCopyTwo: 'If you would like to use a different hardware wallet device, please remove the existing hardware wallet account and add a new one with the desired device connected. You can always re-add a previous hardware wallet device account later.'
+      hardwareMismatchCopyTwo: 'If you would like to use a different hardware wallet device, please remove the existing hardware wallet account and add a new one with the desired device connected. You can always re-add a previous hardware wallet device account later.',
+      genericErrorTitle: 'Oops, something unexpected happened',
+      closeModal: 'Close',
+      refreshApp: 'Refresh App'
     }
   }
 }

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -156,7 +156,7 @@ const WalletTransaction = defineComponent({
     const router = useRouter()
     const { activeAddress, activeAccount, hardwareAccount, hardwareAccountFailedToSign, networkPreamble, radix, verifyHardwareWalletAddress } = useWallet(router)
 
-    const { transactionErrorMessage, transferTokens, transactionUnsub, setActiveTransactionForm } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value, {
+    const { transferTokens, transactionUnsub, setActiveTransactionForm } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value, {
       ledgerSigningError: () => {
         hardwareAccountFailedToSign()
       }
@@ -185,12 +185,6 @@ const WalletTransaction = defineComponent({
       if (tb && nt && !nativeTokenLoaded.value) {
         setXRDByDefault(nt)
         nativeTokenLoaded.value = true
-      }
-    })
-
-    watch(transactionErrorMessage, (val) => {
-      if (val) {
-        setErrors({ amount: t(val) })
       }
     })
 


### PR DESCRIPTION
This PR... 
- adds a reusable modal component that can be expanded upon for more standard errors across the app
- adds a new composable called `useErrors` that manages the list of errors the app has caught
- Displays an error to the user when building a transaction fails
- Displays an error to the user when finalizing a transaction fails