### PR TITLE
chore: Differentiate in the UI between loading data and the user having no data

### DIFF
--- a/src/composables/useStaking.ts
+++ b/src/composables/useStaking.ts
@@ -1,23 +1,35 @@
-import { ref, Ref } from 'vue'
+import { ref, computed, ComputedRef, Ref } from 'vue'
 import { RadixT, StakePositions, UnstakePositions } from '@radixdlt/application'
 
 interface useStakingInterface {
   readonly activeStakes: Ref<StakePositions | null>;
   readonly activeUnstakes: Ref<UnstakePositions | null>;
+  readonly loadingAllStaking: ComputedRef<boolean>;
   stakingUnsub: () => void;
 }
 
 export default function useStaking (radix: RadixT): useStakingInterface {
   const activeStakes: Ref<StakePositions | null> = ref(null)
   const activeUnstakes: Ref<UnstakePositions | null> = ref(null)
+  const loadingStakes: Ref<boolean> = ref(true)
+  const loadingUnstakes: Ref<boolean> = ref(true)
 
-  const activeStakesSub = radix.stakingPositions.subscribe((stakes: StakePositions) => { activeStakes.value = stakes })
-  const activeUnstakesSub = radix.unstakingPositions.subscribe((unstakes: UnstakePositions) => { activeUnstakes.value = unstakes })
+  const activeStakesSub = radix.stakingPositions.subscribe((stakes: StakePositions) => {
+    activeStakes.value = stakes
+    loadingStakes.value = false
+  })
+  const activeUnstakesSub = radix.unstakingPositions.subscribe((unstakes: UnstakePositions) => {
+    activeUnstakes.value = unstakes
+    loadingUnstakes.value = false
+  })
 
   return {
     activeStakes,
     activeUnstakes,
+    loadingAllStaking: computed(() => loadingStakes.value && loadingUnstakes.value),
     stakingUnsub: () => {
+      loadingStakes.value = false
+      loadingUnstakes.value = false
       activeStakesSub.unsubscribe()
       activeUnstakesSub.unsubscribe()
     }

--- a/src/views/Wallet/WalletHistory.vue
+++ b/src/views/Wallet/WalletHistory.vue
@@ -17,7 +17,7 @@
     </div>
 
     <div class="text-rBlack py-6 min-h-full text-sm">
-      <div v-if="loading" class="p-4 flex items-center justify-center">
+      <div v-if="loadingHistory || !nativeToken" class="p-4 flex items-center justify-center">
         <loading-icon class="text-rGrayDark" />
       </div>
       <template v-else-if="pendingTransactions.length > 0 || transactionsWithMessages.length > 0">
@@ -88,7 +88,7 @@
 </template>
 
 <script lang="ts">
-import { computed, ComputedRef, defineComponent, onMounted, watch } from 'vue'
+import { computed, defineComponent, onMounted, watch } from 'vue'
 import TransactionListItem from '@/components/TransactionListItem.vue'
 import LoadingIcon from '@/components/LoadingIcon.vue'
 import ClickToCopy from '@/components/ClickToCopy.vue'
@@ -157,10 +157,6 @@ const WalletHistory = defineComponent({
       transactionUnsub()
     })
 
-    const loading: ComputedRef<boolean> = computed(() => {
-      return !nativeToken.value && loadingHistory.value
-    })
-
     return {
       activeAccount,
       activeAddress,
@@ -169,7 +165,7 @@ const WalletHistory = defineComponent({
       decryptMessage,
       explorerUrlBase,
       decryptedMessages,
-      loading,
+      loadingHistory,
       nativeToken,
       nextPage,
       pendingTransactions,

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -82,8 +82,10 @@
           </svg>
         </a>
       </div>
-
-      <template v-if="nativeToken">
+      <div v-if="loadingAllStaking || !nativeToken" class="p-4 flex items-center justify-center">
+        <loading-icon class="text-rGrayDark" />
+      </div>
+      <template v-else>
         <stake-list-item
           v-for="(position) in sortedPositions"
           :key="position.address"
@@ -111,6 +113,7 @@ import FormErrorMessage from '@/components/FormErrorMessage.vue'
 import FormField from '@/components/FormField.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
 import { asBigNumber } from '@/components/BigAmount.vue'
+import LoadingIcon from '@/components/LoadingIcon.vue'
 import { Position } from '@/services/_types'
 import { useNativeToken, useStaking, useTransactions, useTokenBalances, useWallet } from '@/composables'
 import { useRouter, onBeforeRouteLeave } from 'vue-router'
@@ -126,6 +129,7 @@ const WalletStaking = defineComponent({
     ButtonSubmit,
     FormField,
     FormErrorMessage,
+    LoadingIcon,
     StakeListItem,
     TabsContent,
     TabsTab
@@ -153,7 +157,7 @@ const WalletStaking = defineComponent({
 
     const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
     const { tokenBalances, tokenBalanceFor, tokenBalancesUnsub } = useTokenBalances(radix)
-    const { activeStakes, activeUnstakes, stakingUnsub } = useStaking(radix)
+    const { activeStakes, activeUnstakes, loadingAllStaking, stakingUnsub } = useStaking(radix)
 
     onBeforeRouteLeave(() => {
       nativeTokenUnsub()
@@ -185,6 +189,7 @@ const WalletStaking = defineComponent({
     })
 
     const sortedPositions: ComputedRef<Array<Position>> = computed(() => {
+      console.log('computed sorted', activeStakes.value, activeUnstakes.value)
       if (!activeStakes.value || !activeUnstakes.value) return []
       // If more than 1 stake exists for the same validator, only display the validator once and sum their amounts
       let positions: Position[] = []
@@ -280,25 +285,27 @@ const WalletStaking = defineComponent({
       stakeUrl: 'https://learn.radixdlt.com',
       activeForm,
       activeAddress,
-      explorerUrlBase,
-      tokenBalances,
-      nativeToken,
-      errors,
-      values,
-      meta,
-      setErrors,
-      resetForm,
-      sortedPositions,
-      xrdBalance,
-      stakingDisclaimer,
-      stakeButtonCopy,
-      disableSubmit,
       amountPlaceholder,
+      errors,
       explorerUrl,
-      setForm,
+      explorerUrlBase,
+      loadingAllStaking,
+      meta,
+      nativeToken,
+      sortedPositions,
+      stakeButtonCopy,
+      stakingDisclaimer,
+      tokenBalances,
+      values,
+      xrdBalance,
+
+      disableSubmit,
       handleAddToValidator,
       handleReduceFromValidator,
-      handleSubmitStake
+      handleSubmitStake,
+      resetForm,
+      setErrors,
+      setForm
     }
   }
 })

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -15,12 +15,15 @@
         </div>
       </div>
 
-      <div v-if="!hasTokenBalances" class="p-4 flex items-center justify-center">
+      <div v-if="!loadedAllData" class="p-4 flex items-center justify-center">
+        <loading-icon class="text-rGrayDark" />
+      </div>
+      <div v-else-if="!hasTokenBalances" class="p-4 flex items-center justify-center">
         {{ $t('transaction.insufficientFunds') }}
       </div>
       <form
         @submit.prevent="handleSubmit"
-        v-else-if="hasTokenBalances && nativeToken && selectedCurrency"
+        v-else
         class="flex flex-col items-end"
       >
         <div class="bg-white rounded-md border border-rGray text-rBlack mb-8 w-full">
@@ -104,9 +107,6 @@
               </div>
             </div>
           </template>
-          <div v-else class="p-4 flex items-center justify-center">
-            <loading-icon class="text-rGrayDark" />
-          </div>
         </div>
 
         <ButtonSubmit :disabled="disableSubmit" class="w-52 ml-full">


### PR DESCRIPTION
This PR updates three different views

1. The History view should show a loading indicator while the data is loading and only show "No transactions" when the sub resolves with no transactions
2. The Transaction view should show a loading indicator while the data is loading and only show "No tokens" when the sub resolves with no tokens
3. The Staking view should show a loading indicator in the sidebar while the data is loading

https://linear.app/township/issue/RDX-279/better-error-messages-for-slow-loading-history-send-and-stake-views