### PR TITLE
chore: change tokenbalance identifier name to token name

### DIFF
--- a/src/components/OtherTokenBalanceListItem.vue
+++ b/src/components/OtherTokenBalanceListItem.vue
@@ -2,7 +2,7 @@
   <div class="border border-rGray rounded-md divide-rGray">
     <div class="flex flex-row py-1">
       <div class="flex-1 flex flex-row items-center px-6 pt-3 overflow-x-auto justify-between">
-        <span class="text-md text-rGrayDark">{{ tokenBalance.tokenIdentifier.name }}</span>
+        <span class="text-md text-rGrayDark">{{ token.name }}</span>
         <div>
           <a :href="rriUrl" target="_blank" class="hover:text-rGreen transition-colors text-rGrayMed">
             <div class="rounded-full border border-solid border-rGray w-6 h-6 flex items-center justify-center ">


### PR DESCRIPTION
This PR changes what's being populated in the Title of each otherTokenBalance. It used to use the token symbol and is now using the token's name.

Before:
<img width="938" alt="Screen Shot 2021-10-05 at 1 43 50 PM" src="https://user-images.githubusercontent.com/10618376/136075615-ab5defaa-e3f9-4cae-8dea-74fda40df1ab.png">

After:
<img width="954" alt="Screen Shot 2021-10-05 at 1 44 03 PM" src="https://user-images.githubusercontent.com/10618376/136075627-3830ca24-e9c2-4917-8b0d-5ec4f75a15c7.png">
 
