### PR TITLE
Fix: don't error on null/empty tokens

### DIFF
--- a/src/components/OtherTokenBalanceListItem.vue
+++ b/src/components/OtherTokenBalanceListItem.vue
@@ -2,7 +2,7 @@
   <div class="border border-rGray rounded-md divide-rGray">
     <div class="flex flex-row py-1">
       <div class="flex-1 flex flex-row items-center px-6 pt-3 overflow-x-auto justify-between">
-        <span class="text-md text-rGrayDark">{{ token.name }}</span>
+        <span class="text-md text-rGrayDark" v-if="token">{{ token.name }}</span>
         <div>
           <a :href="rriUrl" target="_blank" class="hover:text-rGreen transition-colors text-rGrayMed">
             <div class="rounded-full border border-solid border-rGray w-6 h-6 flex items-center justify-center ">


### PR DESCRIPTION
On a slow connection (current mainnet), I was receiving errors as the component attempted to load without data. This patch corrects that.