### PR TITLE
feat: show copy when verifying non-active hw acct

### DIFF
--- a/src/views/Wallet/WalletLedgerVerifyAddressModal.vue
+++ b/src/views/Wallet/WalletLedgerVerifyAddressModal.vue
@@ -3,12 +3,12 @@
     <div class="h-modalSmall bg-white rounded-md py-7 px-7 w-full max-w-3xl absolute top-1/2 left-1/2 transform -translate-x-1/3 -translate-y-1/2">
       <h3 class="font-medium text-rBlack mb-2 w-full">Verify Hardware Wallet Address</h3>
       <div v-if="hardwareAddress !== activeAddress.toString()">
-        <div class="py-2">
+        <div class="py-2 mb-9">
           Whenever copying a hardware wallet address, it is strongly recommended to verify it on the hardware device. To copy and verify this address, please switch to the hardware address first by selecting it in the account picker.
         </div>
         <div class="flex items-center">
           <div
-            class="text-rGrayDark py-3 text-base py-12 mx-auto cursor-pointer"
+            class="text-rGrayDark text-base p-3 mx-auto cursor-pointer"
             @click="hideLedgerVerify()"
           >
             Dismiss
@@ -24,7 +24,7 @@
         </div>
         <div class="mt-4">
           <div class="bg-translucent-gray rounded-md border border-rGray text-rBlack mb-4 w-full">
-            <div class="border-b border-rGray py-5 flex items-center">
+            <div class="py-5 flex items-center">
               <div class="w-20 text-right text-rGrayDark mr-4">Address</div>
               <div class="flex-1 flex">
                 {{ hardwareAddress }}

--- a/src/views/Wallet/WalletLedgerVerifyAddressModal.vue
+++ b/src/views/Wallet/WalletLedgerVerifyAddressModal.vue
@@ -2,27 +2,42 @@
   <div class="fixed w-screen h-screen z-20 flex items-center justify-center bg-translucent-black left-0 top-0">
     <div class="h-modalSmall bg-white rounded-md py-7 px-7 w-full max-w-3xl absolute top-1/2 left-1/2 transform -translate-x-1/3 -translate-y-1/2">
       <h3 class="font-medium text-rBlack mb-2 w-full">Verify Hardware Wallet Address</h3>
-      <div v-if="shouldShowError" class="text-rRed">
-        Your Ledger device was not detected. Please attach it you would like to verify your address.
-      </div>
-      <div v-else class="text-rBlack">
-        Please verify this address matches the one currently shown on your Ledger.
-      </div>
-      <div class="mt-4">
-        <div class="bg-translucent-gray rounded-md border border-rGray text-rBlack mb-4 w-full">
-          <div class="border-b border-rGray py-5 flex items-center">
-            <div class="w-20 text-right text-rGrayDark mr-4">Address</div>
-            <div class="flex-1 flex">
-              {{ hardwareAddress }}
-              <click-to-copy :address="hardwareAddress" class="hover:text-rGreen active:text-rGreenDark ml-1" />
-            </div>
+      <div v-if="hardwareAddress !== activeAddress.toString()">
+        <div class="py-2">
+          Whenever copying a hardware wallet address, it is strongly recommended to verify it on the hardware device. To copy and verify this address, please switch to the hardware address first by selecting it in the account picker.
+        </div>
+        <div class="flex items-center">
+          <div
+            class="text-rGrayDark py-3 text-base py-12 mx-auto cursor-pointer"
+            @click="hideLedgerVerify()"
+          >
+            Dismiss
           </div>
         </div>
       </div>
-      <div class="text-center pt-4">
-        <ButtonSubmit @click="hideLedgerVerify()" class="w-72 mx-auto mt-2" :disabled=false>
-          Done
-        </ButtonSubmit>
+      <div v-else>
+        <div v-if="shouldShowError" class="text-rRed">
+          Your Ledger device was not detected. Please attach it you would like to verify your address.
+        </div>
+        <div v-else class="text-rBlack">
+          Please verify this address matches the one currently shown on your Ledger.
+        </div>
+        <div class="mt-4">
+          <div class="bg-translucent-gray rounded-md border border-rGray text-rBlack mb-4 w-full">
+            <div class="border-b border-rGray py-5 flex items-center">
+              <div class="w-20 text-right text-rGrayDark mr-4">Address</div>
+              <div class="flex-1 flex">
+                {{ hardwareAddress }}
+                <click-to-copy :address="hardwareAddress" class="hover:text-rGreen active:text-rGreenDark ml-1" />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="text-center pt-4">
+          <ButtonSubmit @click="hideLedgerVerify()" class="w-72 mx-auto mt-2" :disabled=false>
+            Done
+          </ButtonSubmit>
+        </div>
       </div>
     </div>
   </div>
@@ -46,8 +61,8 @@ const WalletLedgerVerifyAddressModal = defineComponent({
   setup () {
     const toast = useToast()
     const router = useRouter()
-    const { hardwareAddress, hardwareError, hideLedgerVerify } = useWallet(router)
-    return { toast, hardwareAddress, hardwareError, hideLedgerVerify }
+    const { hardwareAddress, hardwareError, hideLedgerVerify, activeAddress } = useWallet(router)
+    return { toast, hardwareAddress, hardwareError, hideLedgerVerify, activeAddress }
   },
 
   computed: {


### PR DESCRIPTION
When a user attempts to copy the non-active hardware account account number, we now show appropriate copy instead of the verify process. See video for details.

https://www.loom.com/share/bf3c3800d1b34d019daf8dc109b79d1d