### PR TITLE
fix: Ledger Immediately Unavailalble after creating a new Wallet

### DIFF
--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -244,7 +244,8 @@ const connectHardwareWallet = () => {
   }
   hardwareError.value = null
   hardwareInteractionState.value = 'DERIVING'
-  radix.deriveHWAccount({
+
+  const data = {
     keyDerivation: HDPathRadix.create({
       address: { index: 0, isHardened: true }
     }),
@@ -253,18 +254,21 @@ const connectHardwareWallet = () => {
     }),
     alsoSwitchTo: true,
     verificationPrompt: !hardwareAddress.value
-  }).subscribe({
-    next: (hwAccount: AccountT) => {
-      activeAccount.value = hwAccount
-      hardwareAccount.value = hwAccount
-      if (!hardwareAddress.value && activeNetwork.value) {
-        saveHardwareWalletAddress(hwAccount.address.toString(), activeNetwork.value)
-        saveAccountName(hwAccount.address.toString(), 'Hardware Account')
-        hardwareAddress.value = hwAccount.address.toString()
-      }
-      hardwareInteractionState.value = ''
-    },
-    error: (err) => { hardwareError.value = err }
+  }
+
+  firstValueFrom(radix.__wallet).then((wallet: WalletT) => {
+    return firstValueFrom(wallet.deriveHWAccount(data))
+  }).then((hwAccount: AccountT) => {
+    activeAccount.value = hwAccount
+    hardwareAccount.value = hwAccount
+    if (!hardwareAddress.value && activeNetwork.value) {
+      saveHardwareWalletAddress(hwAccount.address.toString(), activeNetwork.value)
+      saveAccountName(hwAccount.address.toString(), 'Hardware Account')
+      hardwareAddress.value = hwAccount.address.toString()
+    }
+    hardwareInteractionState.value = ''
+  }).catch((err) => {
+    hardwareError.value = err
   })
 }
 


### PR DESCRIPTION
This commit fixes a problem with the SDK Wallet observable receiving
multiple wallet subjects while creating a new wallet.  This collection
of wallet instances then all forwarded the input for to the ledger
device when deriving a new HW account which resulted in a race condition
and UI Crash.

The work contained in this commit steps away from the RXJS subscriptions
by using `firstValueFrom` to derive promises for both the active wallet
and the first result of `deriveHWAddress` on the derived wallet, thus
only sending a single message to the ledger.

https://www.loom.com/share/e64e5061425b4506a76e4e58ff726c78