### PR TITLE
chore: only validated Validator URLs are links, otherwise displayed as plain text.

### DIFF
--- a/src/components/StakeListItem.vue
+++ b/src/components/StakeListItem.vue
@@ -12,7 +12,7 @@
                 <span class="bg-rRed w-2 h-2 rounded-full"></span>
                 <span class="text-rRed ml-2">unregistered</span>
               </div>
-              <a class="relative text-rBlack hover:text-rBlue group" v-if="validator.infoURL && validatedValidatorUrl" :href="validator.infoURL" target="__blank"> {{ validator.name }}
+              <a class="relative text-rBlack hover:text-rBlue group underline" v-if="validator.infoURL && validatedValidatorUrl" :href="validator.infoURL" target="__blank"> {{ validator.name }}
                 <tooltip>
                   {{$t('staking.validatorWarning')}} {{validator.infoURL.toString()}}
                 </tooltip>

--- a/src/components/StakeListItem.vue
+++ b/src/components/StakeListItem.vue
@@ -17,12 +17,6 @@
                   {{$t('staking.validatorWarning')}} {{validator.infoURL.toString()}}
                 </tooltip>
               </a>
-              <span v-else-if="validator.infoURL && validatedValidatorUrl === false" class="relative text-rBlack group">
-                <tooltip>
-                  {{$t('staking.validatorWarning')}} {{validator.infoURL.toString()}}
-                </tooltip>
-                {{validator.name}}
-              </span>
               <span v-else>{{validator.name}}</span>
             </div>
           </div>
@@ -149,12 +143,7 @@ const StakeListItem = defineComponent({
       if (!this.validator) {
         return false
       }
-      // return checkValidatorUrlExploitable(this.validator.infoURL.toString())
-      // Spoofs
-      return checkValidatorUrlExploitable('htxp://www.radixstake.com')
-      // return checkValidatorUrlExploitable('www.radixstake.com')
-      // return checkValidatorUrlExploitable('radixstake.com')
-      // return checkValidatorUrlExploitable('httpss://www.radixstake.com')
+      return checkValidatorUrlExploitable(this.validator.infoURL.toString())
     },
 
     stakeAmount (): AmountT {

--- a/src/components/StakeListItem.vue
+++ b/src/components/StakeListItem.vue
@@ -12,11 +12,17 @@
                 <span class="bg-rRed w-2 h-2 rounded-full"></span>
                 <span class="text-rRed ml-2">unregistered</span>
               </div>
-              <a class="relative text-rBlack hover:text-rBlue group" v-if="validator.infoURL" :href="validator.infoURL" target="__blank"> {{ validator.name }}
+              <a class="relative text-rBlack hover:text-rBlue group" v-if="validator.infoURL && validatedValidatorUrl" :href="validator.infoURL" target="__blank"> {{ validator.name }}
                 <tooltip>
                   {{$t('staking.validatorWarning')}} {{validator.infoURL.toString()}}
                 </tooltip>
               </a>
+              <span v-else-if="validator.infoURL && validatedValidatorUrl === false" class="relative text-rBlack group">
+                <tooltip>
+                  {{$t('staking.validatorWarning')}} {{validator.infoURL.toString()}}
+                </tooltip>
+                {{validator.name}}
+              </span>
               <span v-else>{{validator.name}}</span>
             </div>
           </div>
@@ -83,6 +89,7 @@ import { Token, UnstakePosition, Validator, Amount, AmountT, StakePosition } fro
 import { computed, ComputedRef, defineComponent, PropType, Ref, ref, toRef } from 'vue'
 import BigAmount from '@/components/BigAmount.vue'
 import ClickToCopy from '@/components/ClickToCopy.vue'
+import { checkValidatorUrlExploitable } from '@/helpers/explorerLinks'
 import { firstValueFrom } from 'rxjs'
 import { formatValidatorAddressForDisplay } from '@/helpers/formatter'
 import { Position } from '@/services/_types'
@@ -137,6 +144,17 @@ const StakeListItem = defineComponent({
     },
     unstakesForValidator (): UnstakePosition[] {
       return this.position.unstakes
+    },
+    validatedValidatorUrl (): boolean {
+      if (!this.validator) {
+        return false
+      }
+      // return checkValidatorUrlExploitable(this.validator.infoURL.toString())
+      // Spoofs
+      return checkValidatorUrlExploitable('htxp://www.radixstake.com')
+      // return checkValidatorUrlExploitable('www.radixstake.com')
+      // return checkValidatorUrlExploitable('radixstake.com')
+      // return checkValidatorUrlExploitable('httpss://www.radixstake.com')
     },
 
     stakeAmount (): AmountT {

--- a/src/helpers/explorerLinks.ts
+++ b/src/helpers/explorerLinks.ts
@@ -2,13 +2,22 @@ export const createRRIUrl = function (rriString: string): string {
   return `${process.env.VUE_APP_EXPLORER}/#/tokens/${rriString}`
 }
 
-// Currently we're validating Validator URL by seeing if the first substring
-// is https:// or http:// . We may expand on how we validate URL later on.
-// If the Validator URL is NOT exploitable, we return true.
+// Currently we're validating Validator URL by first  having JS URL Constructor catch
+// any errors and then seeing if the first substring is https:// or http://. We may
+// expand on how we validate URL later on. If the Validator URL is NOT exploitable,
+// we return true.
 export const checkValidatorUrlExploitable = function (url: string | null): boolean {
   if (!url) {
     return false
   }
   const urlFormattedToCheck = url.toLowerCase()
+  // If there are issues creating a URL via JS URL Constructor, we will return as false.
+  // This should catch any case not RFC3987 compliant.
+  try {
+    const urlConstructedByJs = new URL(urlFormattedToCheck)
+  } catch {
+    return false
+  }
+
   return urlFormattedToCheck.search('https://') === 0 || urlFormattedToCheck.search('http://') === 0
 }

--- a/src/helpers/explorerLinks.ts
+++ b/src/helpers/explorerLinks.ts
@@ -19,5 +19,5 @@ export const checkValidatorUrlExploitable = function (url: string | null): boole
     return false
   }
 
-  return urlFormattedToCheck.search('https://') === 0 || urlFormattedToCheck.search('http://') === 0
+  return urlFormattedToCheck.indexOf('https://') === 0 || urlFormattedToCheck.indexOf('http://') === 0
 }

--- a/src/helpers/explorerLinks.ts
+++ b/src/helpers/explorerLinks.ts
@@ -1,3 +1,14 @@
 export const createRRIUrl = function (rriString: string): string {
   return `${process.env.VUE_APP_EXPLORER}/#/tokens/${rriString}`
 }
+
+// Currently we're validating Validator URL by seeing if the first substring
+// is https:// or http:// . We may expand on how we validate URL later on.
+// If the Validator URL is NOT exploitable, we return true.
+export const checkValidatorUrlExploitable = function (url: string | null): boolean {
+  if (!url) {
+    return false
+  }
+  const urlFormattedToCheck = url.toLowerCase()
+  return urlFormattedToCheck.search('https://') === 0 || urlFormattedToCheck.search('http://') === 0
+}


### PR DESCRIPTION
This PR removes the ability to click on an invalid/exploitable URL. The tooltip hover effect has been removed as well, but open to thoughts on a custom tooltip text IF a URL exists, but the URL is invalid? @alexandreaco @staylorwr 

So far I've only found Validator URLs used on the Staking Page within Olympia. Let me know if it's being used elsewhere.

Right now we are only considering "exploitable URL's" as URL's that do not begin w/ `http://` or `https://`. The validation created will check specifically for these substrings to be at the beginning of URLs passed into it.

[Demo](https://www.loom.com/share/c665f14d5f664d32a75698ab60b43a56)

To spoof the "bad urls" since I'm not quite sure how to add custom Validators to test, I changed `computed` values as seen in the Loom video

Spoof cases
- htxp://www.radixstake.com
- www.radixstake.com'
- radixstake.com
- httpss://www.radixstake.com'

Additional feature:
- Add underline to CLICKABLE Validator URL, leave UNCLICKABLE Validator URL as is. This is to not confuse the User w/ what can be interacted with.