### PR TITLE
fix: clean up adding hardware account

### DIFF
--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -259,14 +259,18 @@ const connectHardwareWallet = () => {
   firstValueFrom(radix.__wallet).then((wallet: WalletT) => {
     return firstValueFrom(wallet.deriveHWAccount(data))
   }).then((hwAccount: AccountT) => {
-    activeAccount.value = hwAccount
-    hardwareAccount.value = hwAccount
     if (!hardwareAddress.value && activeNetwork.value) {
       saveHardwareWalletAddress(hwAccount.address.toString(), activeNetwork.value)
       saveAccountName(hwAccount.address.toString(), 'Hardware Account')
       hardwareAddress.value = hwAccount.address.toString()
     }
+    activeAccount.value = hwAccount
+    hardwareAccount.value = hwAccount
     hardwareInteractionState.value = ''
+
+    getAccountNames().then((names) => {
+      accountNames.value = names
+    })
   }).catch((err) => {
     hardwareError.value = err
   })

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -95,7 +95,7 @@ const messages = {
       navSettings: 'Wallet Settings',
       navHelp: 'Help',
       navAddHWWallet: '+ Add Hardware Account',
-      hardwareWalletHeading: 'Hardware Wallet',
+      hardwareWalletHeading: 'Hardware Account',
       testNetworkDisclaimer: 'You are currently connected to a TEST NETWORK. To view your legitimate tokens and transactions on the Radix Public Network, you must choose "Mainnet" in Wallet Settings.'
     },
     history: {


### PR DESCRIPTION
This PR does two small things:

1) updates the title shown in the account picker sidebar to show as `Hardware Account` as expected.
2) When a new hardware account is added to the wallet, it now re-fetches account names from the wallet to ensure we have the latest account names to show in the default sidebar.