### PR TITLE
chore: show full balance in staking, txn forms

### DIFF
--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -228,7 +228,7 @@ const WalletStaking = defineComponent({
 
     const amountPlaceholder: ComputedRef<string> = computed(() =>
       (xrdBalance.value && activeForm.value === 'STAKING')
-        ? `${t('staking.amountPlaceholder')} ${asBigNumber(xrdBalance.value)} `
+        ? `${t('staking.amountPlaceholder')} ${asBigNumber(xrdBalance.value, true)} `
         : t('staking.availableBalancePlaceholder'))
 
     const explorerUrl: ComputedRef<string> = computed(() => `${explorerUrlBase.value}/#/validators`)

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -222,7 +222,7 @@ const WalletTransaction = defineComponent({
 
     const amountPlaceholder: ComputedRef<string> = computed(() => {
       if (!selectedCurrency.value || !selectedCurrency.value.amount) return ''
-      return `${t('transaction.amountPlaceholder')} ${asBigNumber(selectedCurrency.value.amount)} `
+      return `${t('transaction.amountPlaceholder')} ${asBigNumber(selectedCurrency.value.amount, true)} `
     })
 
     const disableSubmit: ComputedRef<boolean> = computed(() => {


### PR DESCRIPTION
This PR updates the staking and transaction forms to show the full account balance, rather than shortening it.
<img width="1199" alt="Screen Shot 2021-10-22 at 3 32 01 PM" src="https://user-images.githubusercontent.com/8646176/138526099-7bd8080e-5ab1-4ea9-ba78-142f193a7eb0.png">
<img width="1196" alt="Screen Shot 2021-10-22 at 3 32 08 PM" src="https://user-images.githubusercontent.com/8646176/138526103-b509c01c-aad6-4880-acea-606af6ecc7f4.png">

