### PR TITLE
chore: bump radix sdk version to 3.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@headlessui/vue": "^1.3.0",
     "@ledgerhq/hw-transport-node-hid": "^6.0.2",
     "@nopr3d/vue-next-rx": "^1.0.6",
-    "@radixdlt/application": "^3.0.5",
+    "@radixdlt/application": "^3.0.6",
     "@radixdlt/hardware-ledger": "^2.1.15",
     "@tailwindcss/forms": "^0.2.1",
     "@tailwindcss/postcss7-compat": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,15 +1531,15 @@
     prelude-ts "^1.0.2"
     rxjs "7.0.0"
 
-"@radixdlt/account@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@radixdlt/account/-/account-3.0.0.tgz#8e966395b5585ca575102372c41f339926c23738"
-  integrity sha512-lNFOGTTaABE8PRyQc4/COFVhvV4ZcqkyindiQi80omcpmY5Ug6t1/frju05AZmYItTRFlaUDcLZ5tisF66+8mQ==
+"@radixdlt/account@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@radixdlt/account/-/account-3.0.1.tgz#ddb3103f7e463f9c27729619ab29efb9db866dd9"
+  integrity sha512-2kWjeX3BfifNNP1JQHGtB1Jf4VLsJFNTVhJhXLgUstZwDA12PNBIveJQ4SNgbygPuJziSEiYwZadFQITM3cFfw==
   dependencies:
-    "@radixdlt/crypto" "^2.1.4"
+    "@radixdlt/crypto" "^2.1.5"
     "@radixdlt/data-formats" "1.0.30"
-    "@radixdlt/hardware-wallet" "^2.1.7"
-    "@radixdlt/primitives" "^3.0.0"
+    "@radixdlt/hardware-wallet" "^2.1.8"
+    "@radixdlt/primitives" "^3.0.1"
     "@radixdlt/uint256" "1.1.0"
     "@radixdlt/util" "1.0.29"
     bech32 "^2.0.0"
@@ -1550,19 +1550,19 @@
     prelude-ts "^1.0.2"
     rxjs "7.0.0"
 
-"@radixdlt/application@^3.0.5":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@radixdlt/application/-/application-3.0.5.tgz#4e00a8dbf26b228dc4e86c3f234167130246cf37"
-  integrity sha512-Pamw6khmdzhO8Gsf1sFt7qEZN1jOvHUwJljzBMEPYg+dlHgEIir8Qz0KezCVyJr4mNdi3+xCXYZRDjay+IDJLA==
+"@radixdlt/application@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@radixdlt/application/-/application-3.0.6.tgz#8b64bf53c0bf16c5cd5ca9d9ab20284d55068fbf"
+  integrity sha512-c6O93tJTD/LICtR4Nfh0TN/8uQGWgP2rroM7M0s1VgP0+oE3wz1yC2rmaAqKy+GTsQ/KQUal2vn3Jtt44m1B+A==
   dependencies:
     "@open-rpc/mock-server" "1.7.2"
     "@open-rpc/schema-utils-js" "1.14.3"
-    "@radixdlt/account" "^3.0.0"
-    "@radixdlt/crypto" "^2.1.4"
+    "@radixdlt/account" "^3.0.1"
+    "@radixdlt/crypto" "^2.1.5"
     "@radixdlt/data-formats" "1.0.30"
-    "@radixdlt/networking" "^2.1.4"
+    "@radixdlt/networking" "^2.1.5"
     "@radixdlt/open-rpc-spec" "^1.0.19"
-    "@radixdlt/primitives" "^3.0.0"
+    "@radixdlt/primitives" "^3.0.1"
     "@radixdlt/util" "1.0.29"
     jest "^26.6.3"
     json-schema-faker "^0.5.0-rcv.34"
@@ -1587,13 +1587,13 @@
     scrypt-js "^3.0.1"
     uuid "^8.3.2"
 
-"@radixdlt/crypto@^2.1.4":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@radixdlt/crypto/-/crypto-2.1.4.tgz#2fd2e01d865e0dacb3e381e9b8f25df33dea97cb"
-  integrity sha512-zlH5C/VQWmrzpF2GuWMO95X3h2cxZIGh9uDBt48K7DKXHvMlapjJLTJlnrhW0dZ6PfFnK2FbvUB5eCOXh67BJg==
+"@radixdlt/crypto@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@radixdlt/crypto/-/crypto-2.1.5.tgz#87245f1ff2839f25955331b4ecb373fbdc5b285d"
+  integrity sha512-OvQdhtZ1gNBoXhfgXQDwCq4akUAjeQ06GdSO0sJC3Jl6NCbJjDl1r35FXIEKrqiwW0L1rMGLX/YAFyFb8SY/gw==
   dependencies:
     "@radixdlt/data-formats" "1.0.30"
-    "@radixdlt/primitives" "^3.0.0"
+    "@radixdlt/primitives" "^3.0.1"
     "@radixdlt/uint256" "1.1.0"
     "@radixdlt/util" "1.0.29"
     base-x "^3.0.8"
@@ -1641,23 +1641,23 @@
     rxjs "7.0.0"
     uuid "^8.3.2"
 
-"@radixdlt/hardware-wallet@^2.1.7":
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/@radixdlt/hardware-wallet/-/hardware-wallet-2.1.7.tgz#862bf3aa8acfd6b20fe9aa826b3fc086aaee7abb"
-  integrity sha512-hm4m1ie+cdc9tpIJ16EslyFS1cK81JsYyi17Nzktv47L3joqXpPbqQOZbxwcxamn9Hbsg4hU3byIPXBqCmxRYA==
+"@radixdlt/hardware-wallet@^2.1.8":
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/@radixdlt/hardware-wallet/-/hardware-wallet-2.1.8.tgz#107833aa27ecc0c7c676a5e726660a5b4ef0583b"
+  integrity sha512-o19anwAngR9cSS1GHhXIzlTjswb6lUfAv18DJGaRKvjA0/5j9kciWobduQDHqX/EGUkyeJC4LF/zvDhtx41wzQ==
   dependencies:
-    "@radixdlt/crypto" "^2.1.4"
-    "@radixdlt/primitives" "^3.0.0"
+    "@radixdlt/crypto" "^2.1.5"
+    "@radixdlt/primitives" "^3.0.1"
     "@radixdlt/util" "1.0.29"
     neverthrow "4.0.1"
     prelude-ts "^1.0.2"
     rxjs "7.0.0"
     uuid "^8.3.2"
 
-"@radixdlt/networking@^2.1.4":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@radixdlt/networking/-/networking-2.1.4.tgz#cff339140b912f926a3d515dda08ba538a800dab"
-  integrity sha512-GNjbJKlliPP9kuXClrc4kMfrI7S73WsTNYbmkdDvDyuDQY3YR3lmvNqd7+RjeDRP0qrZTR8InGq/xeIqN73N5Q==
+"@radixdlt/networking@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@radixdlt/networking/-/networking-2.1.5.tgz#3548970bb69299aff140201bd5a5bb11e97db739"
+  integrity sha512-f9lllU4vjemNIIJb5UZBJ6M5NM5xUb6AtC/t2Ba/RwBDO3EefjH7C5U1m56xL8xYJfkf8AfDewtZ3JrDMqujbg==
   dependencies:
     "@open-rpc/client-js" "1.6.2"
     "@open-rpc/schema-utils-js" "1.14.3"
@@ -1685,10 +1685,10 @@
     long "^4.0.0"
     neverthrow "^4.0.1"
 
-"@radixdlt/primitives@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@radixdlt/primitives/-/primitives-3.0.0.tgz#fb52cda2578c66fc395099db7e57a512045bf8f0"
-  integrity sha512-sfekbjFNm8/WzZiBBM7EPniLJWCcTTGOcRuRdtFGp6eiojtN3UZAaBe/RFhYlrZLPXniIzic2xn64SE1jUrNCw==
+"@radixdlt/primitives@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@radixdlt/primitives/-/primitives-3.0.1.tgz#e312475730ef0afefe1c646fc1e6805ce4c52e2c"
+  integrity sha512-cTjT6h4cy5vWvgDdtRkNqR5X1MTkOw+6eeq6zs9mVql2YBBtYoTDIB27gkYyRNPW5123ANsaPLauXeTrIYr7UQ==
   dependencies:
     "@radixdlt/data-formats" "1.0.30"
     "@radixdlt/uint256" "1.1.0"


### PR DESCRIPTION
This PR bumps the radix sdk version to 3.0.6, allowing the usage of additional networks.

<img width="1200" alt="Screen Shot 2021-10-25 at 2 27 17 PM" src="https://user-images.githubusercontent.com/8646176/138767140-e7a1ed5f-5d58-4ae4-8fcd-e98af5ef0ff8.png">


