### PR TITLE
fix: prevent crash on sleep and hide max button

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -92,7 +92,7 @@ app.on('ready', async () => {
 
   electron.powerMonitor.on('suspend', () => {
     if (BrowserWindow.getAllWindows().length > 0) {
-      win.webContents.send('resetToHome')
+      win.reload()
     }
   })
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -44,6 +44,7 @@ async function createWindow () {
     maxHeight: 800,
     minWidth: 1200,
     minHeight: 650,
+    maximizable: false,
     webPreferences: {
       // Use pluginOptions.nodeIntegration, leave this alone
       // See nklayman.github.io/vue-cli-plugin-electron-builder/guide/security.html#node-integration for more info
@@ -90,7 +91,9 @@ app.on('activate', () => {
 app.on('ready', async () => {
 
   electron.powerMonitor.on('suspend', () => {
-    win.webContents.send('resetToHome')
+    if (BrowserWindow.getAllWindows().length > 0) {
+      win.webContents.send('resetToHome')
+    }
   })
 
   if (isDevelopment && !process.env.IS_TEST) {


### PR DESCRIPTION
This PR does two small things:

- Currently, if a user clicks the `X` button on OS X only, and then put their computer to sleep they'll return a crash report. This fix prevents that crash from occurring. We were attempting to reset state in a window that did not exist after being closed, we prevent that from occurring.
- It also disables the maximize button which was causing confusion among users.