### PR TITLE
chore: show warning when txn brings total XRD < 10

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -125,6 +125,8 @@ const messages = {
       confirmButton: 'Confirm Transaction',
       sendButton: 'Send',
       insufficientFunds: 'Sorry, but you don\'t have any tokens to send!',
+      warningTitle: 'Warning',
+      lessThanTenXRDBalanceWarning: 'This transaction will leave you with less than 10 XRD. Remember that you must have XRD to pay fees to unstake and perform other transactions.',
       recipientPlaceholder: 'Enter address',
       amountPlaceholder: 'Available balance ...',
       messagePlaceholder: 'Add an optional message',

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -97,7 +97,10 @@
           </div>
         </div>
 
-        <div class="pr-6" v-if="xrdRemainderBalanceBelowTen">
+        <div
+          v-if="xrdRemainderBalanceBelowTen"
+          class="pr-6"
+        >
           <span class="text-rRed text-md"><b>{{ $t('transaction.warningTitle') }}:</b> {{ $t('transaction.lessThanTenXRDBalanceWarning') }}</span>
         </div>
 
@@ -193,10 +196,10 @@ const WalletConfirmTransactionModal = defineComponent({
 
     const balanceSub = updateObservable.pipe(
       switchMap(() => radix.activeAccount),
-      mergeMap((account) => forkJoin([
+      mergeMap((account) =>
         radix.ledger.tokenBalancesForAddress(account.address)
-      ]))
-    ).subscribe(([balances]) => {
+      )
+    ).subscribe((balances) => {
       tokenBalances.value = balances
       loading.value = false
     })

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -97,7 +97,7 @@
           </div>
         </div>
 
-        <div class="pr-6" v-if="remainderBalanceAboveTen">
+        <div class="pr-6" v-if="xrdRemainderBalanceAboveTen">
           <span class="text-rRed text-md"><b>{{ $t('transaction.warningTitle') }}:</b> {{ $t('transaction.lessThanTenXRDBalanceWarning') }}</span>
         </div>
 
@@ -353,12 +353,16 @@ const WalletConfirmTransactionModal = defineComponent({
     }
   },
   computed: {
-    // Do not check for balance above 10XRD if unstaking. Only run validation if staking/sending.
-    remainderBalanceAboveTen (): boolean {
-      if (this.totalXRD && this.amount && this.transactionFee && this.toLabel !== 'Unstake from') {
+    // Do not check for balance above 10XRD if unstaking. Only run validation if staking/sending. Two possible calculations
+    // can occur. Either (Total XRD - Transaction Fee) OR (Total XRD - XRD Amount Input - Transaction Fee). Calculation is
+    // based on whether or not User chose to send/stake XRD or another token.
+    xrdRemainderBalanceAboveTen (): boolean {
+      if (this.selectedCurrency && this.selectedCurrency.token.symbol !== 'xrd' && this.toLabel !== 'Unstake from') {
+        return Number(this.totalXRD) - Number(this.transactionFee) < Math.pow(10, 19)
+      } else if (this.totalXRD && this.amount && this.transactionFee && this.toLabel !== 'Unstake from') {
         return Number(this.totalXRD) - Number(this.amount) - Number(this.transactionFee) < Math.pow(10, 19)
       } else {
-        return false
+        return true
       }
     }
   }

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -98,7 +98,7 @@
         </div>
 
         <div class="pr-6" v-if="remainderBalanceAboveTen">
-          <span class="text-rRed text-md"><b>Warning:</b> This transaction will leave you with less than 10 XRD. Remember that you must have XRD to pay fees to unstake and perform other transactions.</span>
+          <span class="text-rRed text-md"><b>{{ $t('transaction.warningTitle') }}:</b> {{ $t('transaction.lessThanTenXRDBalanceWarning') }}</span>
         </div>
 
         <div class="flex items-start justify-between w-full mt-1">

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -328,8 +328,13 @@ const WalletConfirmTransactionModal = defineComponent({
     // based on whether or not User chose to send/stake XRD or another token.
     // Default value is false because we don't want to blindly throw this warning outside of said cases.
     const xrdRemainderBalanceBelowTen: ComputedRef<boolean> = computed(() => {
-      if (selectedCurrency.value && selectedCurrency.value.token.symbol !== 'xrd' && toLabel.value !== 'Unstake from') {
-        return Number(totalXRD.value) - Number(transactionFee.value) < Math.pow(10, 19)
+      // Don't show error if starting total is < 10 xrd
+      if (totalXRD.value && Number(totalXRD.value) < Math.pow(10, 19)) {
+        return false
+      // Check transaction fee doesn't bring total < 10 xrd for non-exd transactioins
+      } else if (selectedCurrency.value && selectedCurrency.value.token.symbol !== 'xrd' && toLabel.value !== 'Unstake from') {
+        return Number(totalXRD.value) - Number(transactionFee.value) < Math.pow(10, 19)s
+      // Check amount and transaction feed don't bring total < 10 xrd
       } else if (totalXRD.value && amount.value && transactionFee && toLabel.value !== 'Unstake from') {
         return Number(totalXRD.value) - Number(amount.value) - Number(transactionFee.value) < Math.pow(10, 19)
       } else {

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -189,7 +189,6 @@ const WalletStaking = defineComponent({
     })
 
     const sortedPositions: ComputedRef<Array<Position>> = computed(() => {
-      console.log('computed sorted', activeStakes.value, activeUnstakes.value)
       if (!activeStakes.value || !activeUnstakes.value) return []
       // If more than 1 stake exists for the same validator, only display the validator once and sum their amounts
       let positions: Position[] = []


### PR DESCRIPTION
[Demo for Sending/Staking](https://www.loom.com/share/a91f49fb5c0d4e178a5c51edd8cc078d)
[Demo for Unstaking & the lack of this warning message](https://www.loom.com/share/b2823102ee4f4b9e94f16625a5180eaf)

This PR will throw a warning to the User to let them know upon this transaction, their total XRD balance will be < 10 XRD. This message applies to Staking and Sending Tokens, but not Unstaking.

Warning message should apply to case where User sends NON XRD token as well, since there is still a `Transaction Fee` involved.
- Sending/Staking XRD Calculation:
   -  Total XRD - XRD Amount Input(to stake or to send) - Transaction Fee > 10?
- Sending NON XRD Calculation:
   - Total XRD - Transaction Fee > 10?
- Unstaking should never trigger this warning, even if...User has 2 XRD and is unstaking 1 XRD. Even if this is < 10 XRD we don't want to warn them in the case of unstaking.

Since we're hitting the API to get User's Total XRD Balance in the WalletConfirmTransactionModal, would it be helpful to display the User's total XRD post-transaction as well? Another row that says...`Remaining XRD After Transaction: ` `1,0004.068 XRD`? something like this? Would like your thoughts on this @alexandreaco @saminakh Example:

![Screen Shot 2021-11-04 at 7 33 18 PM](https://user-images.githubusercontent.com/10618376/140434487-c44f1b4e-76fb-47db-b5eb-7d11da2ca5d8.png)
 
