### PR TITLE
feat: Allow users to enter 12, 18 and 24 phrase mnemonics

### DIFF
--- a/src/components/AppSelect.vue
+++ b/src/components/AppSelect.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="mt-1 relative w-56">
+    <button
+      class="bg-white relative flex items-center justify-between w-full border border-gray-300 rounded-sm shadow-sm px-3 py-2 text-left cursor-pointer focus:outline-none focus:ring-1 focus:ring-rBlue focus:border-rBlue sm:text-sm hover:bg-rGrayLight transition-colors"
+      @click="toggleIsOpen"
+    >
+      <span class="block truncate flex-1">
+        {{ selected.label }}
+      </span>
+      <svg width="14" height="8" viewBox="0 0 14 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M1 1L7 7L13 1" class="stroke-current text-rBlack" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </button>
+
+    <ul
+      v-if="isOpen"
+      class="absolute z-10 top-0 w-full border-solid border border-rGray bg-white shadow-lg max-h-60 rounded-sm text-base overflow-auto focus:outline-none sm:text-sm"
+    >
+      <li
+        v-for="(option, i) in options"
+        :key="option.id"
+        @click.prevent="() => handleSelect(option.id)"
+        class="text-rBlue border-b border-solid border-rGray hover:bg-rGrayLight transition-colors cursor-pointer select-none relative py-2 px-3 flex items-center justify-between"
+      >
+        <span class="font-normal block truncate">
+          {{ option.label }}
+        </span>
+        <svg v-if="i === 0" width="14" height="8" viewBox="0 0 14 8" fill="none" xmlns="http://www.w3.org/2000/svg" class="transform rotate-180">
+          <path d="M1 1L7 7L13 1" class="stroke-current text-rBlue" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType, Ref, ref } from 'vue'
+
+export type AppSelectOptionT = {
+  id: string | number;
+  label: string;
+}
+
+export default defineComponent({
+  props: {
+    options: {
+      type: Array as PropType<Array<AppSelectOptionT>>,
+      required: true
+    },
+    selected: {
+      type: Object as PropType<AppSelectOptionT>,
+      required: false
+    }
+  },
+
+  setup (props, { emit }) {
+    const isOpen: Ref<boolean> = ref(false)
+    const toggleIsOpen = () => { isOpen.value = !isOpen.value }
+    const handleSelect = (id: string | number) => {
+      isOpen.value = false
+      emit('select', id)
+    }
+
+    return {
+      isOpen,
+
+      // methods
+      handleSelect,
+      toggleIsOpen
+    }
+  },
+
+  emits: ['select']
+})
+</script>

--- a/src/components/MnemonicDisplay.vue
+++ b/src/components/MnemonicDisplay.vue
@@ -1,6 +1,10 @@
 <template>
   <div
-    class="w-40 border rounded-full border-rGray leading-tight h-16 justify-center inline-flex items-center"
+    class="border rounded-full border-rGray leading-tight h-16 justify-center inline-flex items-center"
+    :class="{
+      'w-40': isWide,
+      'w-32': !isWide
+    }"
   >
     <div :class="{ 'filter-blur': obfuscate }">
       {{index + 1}}. {{ word }}
@@ -24,6 +28,11 @@ const MnemonicDisplay = defineComponent({
     index: {
       type: Number,
       required: true
+    },
+    isWide: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   }
 })

--- a/src/components/MnemonicInput.vue
+++ b/src/components/MnemonicInput.vue
@@ -1,9 +1,10 @@
 <template>
   <div
-    class="w-40"
     :class="{
       'border rounded-full border-rGray leading-tight h-16 justify-center inline-flex': !requireInput,
-      'h-full': requireInput
+      'h-full': requireInput,
+      'w-40': !isSmall,
+      'w-26': isSmall
     }"
   >
     <input
@@ -37,6 +38,11 @@ const MnemonicInput = defineComponent({
     index: {
       type: Number,
       required: true
+    },
+    isSmall: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
 

--- a/src/helpers/mnemonic.ts
+++ b/src/helpers/mnemonic.ts
@@ -1,0 +1,17 @@
+import { AppSelectOptionT } from '@/components/AppSelect.vue'
+import { StrengthT } from '@radixdlt/application'
+
+export const mnemonicStrengthOptions: AppSelectOptionT[] = [
+  {
+    id: StrengthT.WORD_COUNT_12,
+    label: '12 word seed phrase'
+  },
+  {
+    id: StrengthT.WORD_COUNT_18,
+    label: '18 word seed phrase'
+  },
+  {
+    id: StrengthT.WORD_COUNT_24,
+    label: '24 word seed phrase'
+  }
+]

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -48,9 +48,9 @@ const messages = {
     },
     createWallet: {
       recoveryTitle: 'Seed Phrase',
-      recoveryHelpOne: 'The following 12 words are the seed of your new account. As long as you have them, you will always be able to recover your account, but remember not to store them digitally.',
+      recoveryHelpOne: 'The following %{numWords} words are the seed of your new account. As long as you have them, you will always be able to recover your account, but remember not to store them digitally.',
       recoveryButtonOne: 'I\'ve written down my seed phrase',
-      recoveryHelpTwo: 'Please enter your 12-word seed phrase. The words must be in the correct order.',
+      recoveryHelpTwo: 'Please enter your %{numWords}-word seed phrase. The words must be in the correct order.',
       recoveryButtonTwoDisabled: 'Fill these out first',
       recoveryButtonTwoEnabled: 'I\'ve done it!',
       passwordTitle: 'Password',
@@ -64,11 +64,12 @@ const messages = {
       pinButton: 'Confirm PIN',
       startOver: 'Start Over',
       newPinLabel: 'Create your PIN',
-      confirmPinLabel: 'Confirm your PIN'
+      confirmPinLabel: 'Confirm your PIN',
+      changeSeedPhraseLength: 'Change seed phrase length'
     },
     restoreWallet: {
       recoveryTitle: 'Seed Phrase',
-      recoveryHelp: 'Enter your 12 word seed phrase to restore your wallet.',
+      recoveryHelp: 'Enter your 12, 18 or 24 word seed phrase to restore your wallet.',
       recoveryButtonDisabled: 'Fill these out first',
       recoveryButtonEnabled: 'I\'ve done it!',
       passwordTitle: 'Password',
@@ -174,7 +175,7 @@ const messages = {
       currentPinLabel: 'Enter current PIN',
       pinLabel: 'Enter new PIN',
       confirmationPinLabel: 'Confirm new PIN',
-      mnemonicDisclaimer: 'Your seed phrase is a secret list of 12 words that uniquely provide access to your wallet. As long as you have them, you will always be able to recover access to your accounts within this wallet. You may view it here if you need to back it up for future recovery.',
+      mnemonicDisclaimer: 'Your seed phrase is a secret list of 12, 18 or 24 words that uniquely provide access to your wallet. As long as you have them, you will always be able to recover access to your accounts within this wallet. You may view it here if you need to back it up for future recovery.',
       mnemonicDisclaimerTwo: 'This seed phrase grants full access to all accounts in your wallet!',
       mnemonicDisclaimerThree: 'Please do not view it in a public place, and remember to not store it digitally.',
       mnemonicModalHeading: 'Enter your password to access your seed phrase',

--- a/src/views/CreateWallet/CreateWalletEnterMnemonic.vue
+++ b/src/views/CreateWallet/CreateWalletEnterMnemonic.vue
@@ -1,11 +1,19 @@
 <template>
   <form data-ci="create-wallet-enter-mnemonic-component" @submit.prevent="$emit('confirm')">
-    <div class="flex flex-wrap mb-4">
-      <div v-for="(word, i) in mnemonic" :key="i" class="w-1/4 mb-14">
+    <div
+      class="grid mb-12"
+      :class="{
+        'grid-cols-4 gap-y-14': mnemonicStrength === StrengthT.WORD_COUNT_12,
+        'grid-cols-6 gap-y-14': mnemonicStrength === StrengthT.WORD_COUNT_18,
+        'grid-cols-6 gap-y-6': mnemonicStrength === StrengthT.WORD_COUNT_24
+      }"
+    >
+      <div v-for="(word, i) in mnemonic" :key="i">
         <mnemonic-input
           :require-input="requiredWords.indexOf(word) > 0"
           :modelValue="inputWords[i]"
-          :index=i
+          :index="i"
+          :isSmall="mnemonicStrength != StrengthT.WORD_COUNT_12"
           @update:modelValue="handleChange(i, $event)"
         ></mnemonic-input>
       </div>
@@ -21,6 +29,7 @@
 import { defineComponent, PropType } from 'vue'
 import MnemonicInput from '@/components/MnemonicInput.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
+import { StrengthT } from '@radixdlt/application'
 
 const CreateWalletViewMnemonic = defineComponent({
   components: {
@@ -32,7 +41,15 @@ const CreateWalletViewMnemonic = defineComponent({
     mnemonic: {
       type: Array as PropType<Array<string>>,
       required: true
+    },
+    mnemonicStrength: {
+      type: Number as PropType<StrengthT>,
+      required: true
     }
+  },
+
+  setup () {
+    return { StrengthT }
   },
 
   data () {
@@ -44,8 +61,8 @@ const CreateWalletViewMnemonic = defineComponent({
       }
     }
     return {
-      requiredWords: [],
-      inputWords: this.mnemonic as string[]
+      inputWords: this.mnemonic as string[],
+      requiredWords: []
     }
   },
 

--- a/src/views/CreateWallet/CreateWalletViewMnemonic.vue
+++ b/src/views/CreateWallet/CreateWalletViewMnemonic.vue
@@ -1,11 +1,41 @@
 <template>
   <div data-ci="create-wallet-view-mnemonic-component">
-    <div class="flex flex-wrap mb-4">
-      <div v-for="(word, i) in mnemonic" :key="i" class="w-1/4 mb-14">
-        <span class="w-40 border rounded-full border-rGray leading-tight h-16 justify-center items-center inline-flex">
-          {{ i + 1 }}. &nbsp;{{word}}
+    <div
+      class="grid"
+      :class="{
+        'grid-cols-4 gap-y-14 mb-12': mnemonicStrength === StrengthT.WORD_COUNT_12,
+        'grid-cols-6 gap-y-14 mb-12': mnemonicStrength === StrengthT.WORD_COUNT_18,
+        'grid-cols-6 gap-y-6 mb-6': mnemonicStrength === StrengthT.WORD_COUNT_24
+      }"
+    >
+      <div v-for="(word, i) in mnemonic" :key="i">
+        <span
+          class="border rounded-full border-rGray leading-tight h-16 justify-center items-center inline-flex"
+          :class="{
+            'w-40': mnemonicStrength === StrengthT.WORD_COUNT_12,
+            'w-26': mnemonicStrength != StrengthT.WORD_COUNT_12
+          }"
+        >
+          {{ word }}
         </span>
       </div>
+    </div>
+
+    <div class="mb-12 h-10">
+      <button
+        v-if="!shouldShowStrengthOptions"
+        @click="handleShowStrengthOptions"
+        class="text-rGrayDark hover:text-rBlue transition-colors underline text-sm"
+      >
+        {{ $t('createWallet.changeSeedPhraseLength') }}
+      </button>
+
+      <AppSelect
+        v-if="shouldShowStrengthOptions"
+        :options="mnemonicStrengthOptions"
+        :selected="selectedStrengthOption"
+        @select="handleSelect"
+      />
     </div>
 
     <ButtonSubmit @click="$emit('confirm')" :disabled="false" class="w-96">
@@ -15,22 +45,54 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from 'vue'
+import { ComputedRef, defineComponent, PropType, Ref, ref, computed } from 'vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
+import AppSelect, { AppSelectOptionT } from '@/components/AppSelect.vue'
+import { StrengthT } from '@radixdlt/application'
+import { mnemonicStrengthOptions } from '@/helpers/mnemonic'
 
 const CreateWalletViewMnemonic = defineComponent({
   components: {
+    AppSelect,
     ButtonSubmit
+  },
+
+  setup (props, { emit }) {
+    const shouldShowStrengthOptions: Ref<boolean> = ref(false)
+    const handleShowStrengthOptions = () => { shouldShowStrengthOptions.value = !shouldShowStrengthOptions.value }
+
+    const selectedStrengthOption: ComputedRef<AppSelectOptionT | undefined> = computed(() => {
+      return mnemonicStrengthOptions.find((opt: AppSelectOptionT) => opt.id === props.mnemonicStrength)
+    })
+    const handleSelect = (id: number) => {
+      shouldShowStrengthOptions.value = false
+      emit('setSeedStrength', id)
+    }
+
+    return {
+      selectedStrengthOption,
+      shouldShowStrengthOptions,
+      mnemonicStrengthOptions,
+      StrengthT,
+
+      // methods
+      handleSelect,
+      handleShowStrengthOptions
+    }
   },
 
   props: {
     mnemonic: {
       type: Array as PropType<Array<string>>,
       required: true
+    },
+    mnemonicStrength: {
+      type: Number as PropType<StrengthT>,
+      required: true
     }
   },
 
-  emits: ['confirm']
+  emits: ['confirm', 'setSeedStrength']
 })
 
 export default CreateWalletViewMnemonic

--- a/src/views/RestoreWallet/RestoreWalletEnterMnemonic.vue
+++ b/src/views/RestoreWallet/RestoreWalletEnterMnemonic.vue
@@ -1,15 +1,30 @@
 <template>
   <form data-ci="create-wallet-enter-mnemonic-component" @submit.prevent="$emit('confirm', inputWords)">
-    <div class="flex flex-wrap mb-4">
-      <div v-for="(word, i) in inputWords" :key="i" class="w-1/4 mb-14">
+    <div
+      class="grid"
+      :class="{
+        'grid-cols-4 gap-y-14 mb-12': mnemonicStrength === StrengthT.WORD_COUNT_12,
+        'grid-cols-6 gap-y-14 mb-12': mnemonicStrength === StrengthT.WORD_COUNT_18,
+        'grid-cols-6 gap-y-10 mb-12': mnemonicStrength === StrengthT.WORD_COUNT_24
+      }"
+    >
+      <div v-for="(word, i) in inputWords" :key="i">
         <mnemonic-input
           :require-input="true"
           :modelValue="word"
-          :index=i
+          :index="i"
+          :isSmall="mnemonicStrength != StrengthT.WORD_COUNT_12"
           @update:modelValue="handleChange(i, $event)"
         ></mnemonic-input>
       </div>
     </div>
+
+    <AppSelect
+      :options="mnemonicStrengthOptions"
+      :selected="selectedStrengthOption"
+      @select="handleSelect"
+      class="mb-16"
+    />
 
     <ButtonSubmit data-ci="create-wallet-enter-mnemonic-component--confirm-button" class="w-96" :disabled="!inputValid">
       {{buttonText}}
@@ -18,36 +33,74 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { computed, ComputedRef, defineComponent, onMounted, ref, Ref } from 'vue'
 import MnemonicInput from '@/components/MnemonicInput.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
+import AppSelect, { AppSelectOptionT } from '@/components/AppSelect.vue'
+import { StrengthT } from '@radixdlt/application'
+import { useI18n } from 'vue-i18n'
+import { mnemonicStrengthOptions } from '@/helpers/mnemonic'
 
 const RestoreWalletEnterMnemonic = defineComponent({
   components: {
+    AppSelect,
     ButtonSubmit,
     MnemonicInput
   },
 
-  data () {
-    return {
-      inputWords: new Array(12).fill('') as string[]
-    }
-  },
+  setup () {
+    const { t } = useI18n({ useScope: 'global' })
+    const mnemonicStrength: Ref<StrengthT> = ref(StrengthT.WORD_COUNT_12)
 
-  computed: {
-    inputValid (): boolean {
-      return this.inputWords.every((value: string) => value && value.length > 0)
-    },
-    buttonText (): string {
-      return this.inputValid ? this.$t('restoreWallet.recoveryButtonEnabled') : this.$t('restoreWallet.recoveryButtonDisabled')
+    const selectedStrengthOption: ComputedRef<AppSelectOptionT | undefined> = computed(() => {
+      return mnemonicStrengthOptions.find((opt: AppSelectOptionT) => opt.id === mnemonicStrength.value)
+    })
+    const inputWords: Ref<string[]> = ref([])
+    const inputValid: ComputedRef<boolean> = computed(() =>
+      inputWords.value.every((value: string) => value && value.length > 0)
+    )
+    const buttonText: ComputedRef<string> = computed(() =>
+      inputValid.value ? t('restoreWallet.recoveryButtonEnabled') : t('restoreWallet.recoveryButtonDisabled')
+    )
+    const handleSelect = (id: StrengthT) => {
+      mnemonicStrength.value = id
+      initInputWords()
     }
-  },
-
-  methods: {
-    handleChange (index: number, value: string) {
-      const newWords: string[] = [...this.inputWords as string[]]
+    const handleChange = (index: number, value: string) => {
+      const newWords: string[] = [...inputWords.value as string[]]
       newWords[index] = value
-      this.inputWords = newWords
+      inputWords.value = newWords
+    }
+    const initInputWords = () => {
+      let arrLength = 0
+      switch (mnemonicStrength.value) {
+        case StrengthT.WORD_COUNT_18:
+          arrLength = 18
+          break
+        case StrengthT.WORD_COUNT_24:
+          arrLength = 24
+          break
+        default:
+          arrLength = 12
+          break
+      }
+      inputWords.value = new Array(arrLength).fill('') as string[]
+    }
+
+    onMounted(() => { initInputWords() })
+
+    return {
+      buttonText,
+      inputWords,
+      inputValid,
+      mnemonicStrength,
+      selectedStrengthOption,
+      mnemonicStrengthOptions,
+      StrengthT,
+
+      // methods
+      handleChange,
+      handleSelect
     }
   },
 

--- a/src/views/RestoreWallet/index.vue
+++ b/src/views/RestoreWallet/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div data-ci="create-wallet-view" class="flex flex-row min-h-screen">
+  <div data-ci="create-wallet-view" class="flex flex-row h-screen">
     <div class="w-72 mr-5 py-8 px-5 text-white leading-snug">
       <router-link to="/" class="flex">
         <img alt="Radix DLT Logo" src="../../assets/logo.svg" class="w-30 mb-12 ">
@@ -52,7 +52,7 @@
       </router-link>
     </div>
 
-    <div class="bg-white pt-headerHeight pb-8 px-11 flex-1">
+    <div class="bg-white pt-headerHeight pb-8 px-11 flex-1 overflow-y-scroll">
       <restore-wallet-enter-mnemonic
         v-if="step == 0"
         @confirm="captureMnemonic"

--- a/src/views/Settings/SettingsRevealMnemonic.vue
+++ b/src/views/Settings/SettingsRevealMnemonic.vue
@@ -7,19 +7,22 @@
       {{ $t('settings.mnemonicDisclaimerThree') }}
     </div>
 
-    <div class="flex flex-row flex-wrap relative">
-      <div
+    <div
+      class="grid gap-y-12 relative mb-12"
+      :class="{
+        'grid-cols-4': mnemonicStrength === StrengthT.WORD_COUNT_12,
+        'grid-cols-6': mnemonicStrength != StrengthT.WORD_COUNT_12
+      }"
+    >
+      <mnemonic-display
         v-for="(word, i) in displayMnemonic"
         :key="i"
-        class="w-1/4 mb-8"
+        :word="word"
+        :index="i"
+        :obfuscate="!this.mnemonic"
+        :isWide="mnemonicStrength === StrengthT.WORD_COUNT_12"
       >
-        <mnemonic-display
-          :word="word"
-          :index="i"
-          :obfuscate="!this.mnemonic"
-        >
-        </mnemonic-display>
-      </div>
+      </mnemonic-display>
 
       <ButtonSubmit
         v-if="mnemonicNotRequested"
@@ -47,7 +50,7 @@
           />
           <FormErrorMessage name="password" />
           <ButtonSubmit
-            :disabled="disableSubmit"
+            :disabled="submitDisabled"
             class="mb-2 mt-9"
           >
             {{ $t('settings.accessMnemonicButton') }}
@@ -66,8 +69,8 @@
 </template>
 
 <script lang="ts">
-import { MnemomicT, Keystore, KeystoreT } from '@radixdlt/application'
-import { defineComponent, PropType } from 'vue'
+import { MnemomicT, Keystore, KeystoreT, StrengthT } from '@radixdlt/application'
+import { defineComponent, PropType, ref, Ref, ComputedRef, computed } from 'vue'
 import { useForm } from 'vee-validate'
 import MnemonicDisplay from '@/components/MnemonicDisplay.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
@@ -88,34 +91,47 @@ const SettingsRevealMnemonic = defineComponent({
     FormErrorMessage
   },
 
-  setup () {
+  setup (props) {
     const { errors, meta, values, setErrors, resetForm } = useForm<RevealMnemonicForm>()
+    const enteringPassword: Ref<boolean> = ref(false)
 
-    return { errors, meta, values, setErrors, resetForm }
+    const displayMnemonic: ComputedRef<string[]> = computed(() =>
+      props.mnemonic ? props.mnemonic.words : Array(12).fill('noop')
+    )
+
+    const mnemonicStrength: ComputedRef<StrengthT> = computed(() =>
+      props.mnemonic ? props.mnemonic.strength : StrengthT.WORD_COUNT_12
+    )
+
+    const mnemonicNotRequested: ComputedRef<boolean> = computed(() =>
+      !props.mnemonic && !enteringPassword.value
+    )
+
+    const submitDisabled: ComputedRef<boolean> = computed(() =>
+      meta.value.dirty ? !meta.value.valid : true
+    )
+
+    return {
+      displayMnemonic,
+      enteringPassword,
+      errors,
+      meta,
+      mnemonicNotRequested,
+      mnemonicStrength,
+      submitDisabled,
+      StrengthT,
+      values,
+
+      // methods
+      setErrors,
+      resetForm
+    }
   },
 
   props: {
     mnemonic: {
       type: Object as PropType<MnemomicT> | null,
       required: false
-    }
-  },
-
-  data () {
-    return {
-      enteringPassword: false
-    }
-  },
-
-  computed: {
-    displayMnemonic (): string[] {
-      return this.mnemonic ? this.mnemonic.words : Array(12).fill('noop')
-    },
-    mnemonicNotRequested (): boolean {
-      return !this.mnemonic && !this.enteringPassword
-    },
-    disableSubmit (): boolean {
-      return this.meta.dirty ? !this.meta.valid : true
     }
   },
 


### PR DESCRIPTION
Users can now select seed length options from a dropdown when creating and restoring a wallet s.

<img width="1312" alt="Screen Shot 2021-11-08 at 8 43 32 AM" src="https://user-images.githubusercontent.com/4480888/140754435-e7505965-c10b-4170-97bc-2031abb51964.png">

Creating a wallet: https://www.loom.com/share/685ec18951cb4cf7b2d06ef2a6ee7780
Restoring a wallet: https://www.loom.com/share/e22d659f81bb4fc7b17464fa79af24de
