### PR TITLE
chore: add indication to current stakes list

### DIFF
--- a/src/components/StakeListItem.vue
+++ b/src/components/StakeListItem.vue
@@ -11,11 +11,11 @@
               <div>
                 <div v-if="!validator.registered" class="inline-flex justify-start items-center">
                   <span class="bg-rRed w-2 h-2 rounded-full"></span>
-                  <span class="text-rRed ml-2 mr-3">unregistered</span>
+                  <span class="text-rRed ml-2 mr-3">{{ $t('staking.unregistered') }}</span>
                 </div>
                 <div v-if="notTopOneHundred" class="inline-flex items-center">
                   <span class="bg-rOrange w-2 h-2 rounded-full"></span>
-                  <span class="text-rOrange ml-2">{{$t('staking.noEmissions')}}</span>
+                  <span class="text-rOrange ml-2">{{ $t('staking.noEmissions') }}</span>
                 </div>
               </div>
               <a class="relative text-rBlack hover:text-rBlue group underline" v-if="validator.infoURL && validatedValidatorUrl" :href="validator.infoURL" target="__blank"> {{ validator.name }}
@@ -125,6 +125,10 @@ const StakeListItem = defineComponent({
     notTopOneHundred: {
       type: Boolean,
       required: true
+    },
+    preloadedValidator: {
+      type: Object as PropType<Validator>,
+      required: false
     }
   },
 
@@ -134,15 +138,17 @@ const StakeListItem = defineComponent({
     const { radix } = useWallet(router)
 
     const position = toRef(props, 'position')
+    const preloadedValidator = toRef(props, 'preloadedValidator')
 
-    firstValueFrom(radix.ledger.lookupValidator(position.value.validator)).then((validatorRes: Validator) => { validator.value = validatorRes })
+    // If validator was included in top 100, use the preloaded value instead of re-fetching
+    if (!preloadedValidator.value) firstValueFrom(radix.ledger.lookupValidator(position.value.validator)).then((validatorRes: Validator) => { validator.value = validatorRes })
 
     const explorerUrl: ComputedRef<string> = computed(() =>
       validator.value ? `${props.explorerUrlBase}/#/validators/${validator.value.address.toString()}` : `${props.explorerUrlBase}/#/validators/`
     )
 
     return {
-      validator,
+      validator: computed(() => preloadedValidator.value || validator.value),
       explorerUrl
     }
   },

--- a/src/components/StakeListItem.vue
+++ b/src/components/StakeListItem.vue
@@ -8,9 +8,15 @@
             class="text-sm flex items-center"
           >
             <div class="flex flex-col">
-              <div v-if="!validator.registered" class="inline-flex justify-start items-center">
-                <span class="bg-rRed w-2 h-2 rounded-full"></span>
-                <span class="text-rRed ml-2">unregistered</span>
+              <div>
+                <div v-if="!validator.registered" class="inline-flex justify-start items-center">
+                  <span class="bg-rRed w-2 h-2 rounded-full"></span>
+                  <span class="text-rRed ml-2 mr-3">unregistered</span>
+                </div>
+                <div v-if="notTopOneHundred" class="inline-flex items-center">
+                  <span class="bg-rOrange w-2 h-2 rounded-full"></span>
+                  <span class="text-rOrange ml-2">{{$t('staking.noEmissions')}}</span>
+                </div>
               </div>
               <a class="relative text-rBlack hover:text-rBlue group underline" v-if="validator.infoURL && validatedValidatorUrl" :href="validator.infoURL" target="__blank"> {{ validator.name }}
                 <tooltip>
@@ -114,6 +120,10 @@ const StakeListItem = defineComponent({
     },
     explorerUrlBase: {
       type: String,
+      required: true
+    },
+    notTopOneHundred: {
+      type: Boolean,
       required: true
     }
   },

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -160,6 +160,7 @@ const messages = {
       validatorPlaceholder: 'Enter validator address',
       validatorFeeLabel: 'Validator Fee',
       recentUptimeLabel: 'Recent Uptime',
+      unregistered: 'unregistered',
       noEmissions: 'no emissions'
     },
     confirmation: {

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -159,7 +159,8 @@ const messages = {
       availableBalancePlaceholder: 'Enter amount',
       validatorPlaceholder: 'Enter validator address',
       validatorFeeLabel: 'Validator Fee',
-      recentUptimeLabel: 'Recent Uptime'
+      recentUptimeLabel: 'Recent Uptime',
+      noEmissions: 'no emissions'
     },
     confirmation: {
       transferFromLabel: 'Your address',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,7 @@ module.exports = {
         rGreenDark: '#00AB84',
         rRed: '#EF4136',
         rOffwhite: '#F8F8FD',
+        rOrange: '#EA8C00',
         rGrayLightest: '#F7F7FD',
         rGrayLight: '#F2F2FC',
         rGray: '#DDE5ED',


### PR DESCRIPTION
[Demo](https://www.loom.com/share/3bb6bef1a1fa4bdab4a01a1a529034a9)

This PR gets the Top 100 Validators, and checks against User's current stake positions. If any positions are outside of the Top 100 Validators, we will indicate by showing a `no emissions` text on validator.

Demo video mocks a Top 28 Validators list, and I want to show that by changing the value to 27, the 28th Validator will show the `no emissions` text.