### PR TITLE
fix: custom node URL inputs should be trimmed

### DIFF
--- a/src/views/Settings/SettingsSelectNode.vue
+++ b/src/views/Settings/SettingsSelectNode.vue
@@ -124,7 +124,7 @@ export default defineComponent({
     }
 
     const handleAddNode = async () => {
-      const url = values.nodeURL.toLowerCase()
+      const url = values.nodeURL.toLowerCase().trim()
       if (!isUnique(url)) {
         setErrors({
           nodeURL: 'Node URLs must be unique'


### PR DESCRIPTION
When a user submits a custom node URL, we should first trim their entry before comparing for uniqueness or adding the URL.

[See a demo](https://www.loom.com/share/9322f5c00a21426bb0f4b02172ff9a09)