### PR TITLE
fix: add conditional margin to avoid tooltip from being clipped by parent divs

### DIFF
--- a/src/components/BigAmount.vue
+++ b/src/components/BigAmount.vue
@@ -1,7 +1,10 @@
 <template>
   <span class="relative inline-flex flex-col items-center group cursor-pointer" @click.stop="copyText">
     <span>{{numberForDisplay}}</span>
-    <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight">
+    <div v-if="numberLessThanFourDigits" class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 ml-32 rounded-sm shadow border border-solid border-rGrayLight">
+      {{fullNumber}}
+    </div>
+    <div v-else class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight">
       {{fullNumber}}
     </div>
   </span>
@@ -120,6 +123,14 @@ const BigAmount = defineComponent({
 
     fullNumber (): string {
       return asBigNumber(this.amount, true)
+    },
+
+    numberLessThanFourDigits (): boolean {
+      if (asBigNumber(this.amount, false).toString().length < 4) {
+        return true
+      } else {
+        return false
+      }
     }
   },
 

--- a/src/components/BigAmount.vue
+++ b/src/components/BigAmount.vue
@@ -1,10 +1,8 @@
 <template>
   <span class="relative inline-flex flex-col items-center group cursor-pointer" @click.stop="copyText">
     <span>{{numberForDisplay}}</span>
-    <div v-if="numberLessThanFourDigits" class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 ml-32 rounded-sm shadow border border-solid border-rGrayLight">
-      {{fullNumber}}
-    </div>
-    <div v-else class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight">
+    <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight"
+    :class="numberLessThanFourDigits && 'ml-32'">
       {{fullNumber}}
     </div>
   </span>
@@ -126,11 +124,7 @@ const BigAmount = defineComponent({
     },
 
     numberLessThanFourDigits (): boolean {
-      if (asBigNumber(this.amount, false).toString().length < 4) {
-        return true
-      } else {
-        return false
-      }
+      return asBigNumber(this.amount, false).toString().length < 4
     }
   },
 


### PR DESCRIPTION
[Demo](https://www.loom.com/share/ff8a4d37fb814e47a857be49df8033d7)

This PR addresses the issue of when tooltip amounts of 3rd party balances are clipped by its container. Here is an example.

Before:
![Screen Shot 2021-11-22 at 11 24 57 AM](https://user-images.githubusercontent.com/10618376/142897951-ac996c88-3944-461a-97ac-9f2191287dfb.png)


After: 
![Screen Shot 2021-11-22 at 11 23 16 AM](https://user-images.githubusercontent.com/10618376/142897800-0a273220-13f4-4c64-86ba-b6a9641ed11c.png)

 
As you can see here, the first digit is clipped. This occurs due to tooltips being based on the center of the display number. With the display number being a low amount of digits, the tooltip begins farther on the left as opposed to other longer digit numbers.

To handle this, we are offsetting the margin for numbers with digits lower than 4. In the demo, we are using an extreme case of a 1 digit display balance number, and a 17 digit tooltip balance. We don't want this offsetting to occur on long digit display balances either, so we are using a conditional to offset specifically low digit display balances.

Other approaches attempted:
- Z index doesn't affect tooltip as the overflow of the outermost div doesn't allow z index to go over.
- Changing outermost div's overflow style to `overflow-visible` allows for tooltip to never be clipped, but we lose the ability to scroll horizontally.