### PR TITLE
chore: disable Escape event listener earlier in lifecycle

### DIFF
--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -121,7 +121,7 @@
               {{ $t('transaction.cancelButton') }}
             </div>
 
-            <ButtonSubmit class="w-44 py-3" :disabled="disableSubmit" :small="true" >
+            <ButtonSubmit class="w-44 py-3" :disabled="disableSubmit" :small="true" v-on:click="disableEscape" >
               {{ $t('transaction.confirmButton') }}
             </ButtonSubmit>
           </div>
@@ -211,6 +211,10 @@ const WalletConfirmTransactionModal = defineComponent({
       window.removeEventListener('keydown', escapeListener)
     })
 
+    const disableEscape = () => {
+      window.removeEventListener('keydown', escapeListener)
+    }
+
     const toContent: ComputedRef<string> = computed(() => {
       if (stakeInput.value) {
         return stakeInput.value.validator.toString()
@@ -279,6 +283,7 @@ const WalletConfirmTransactionModal = defineComponent({
       canCancel,
       closeModal,
       confirmationMode,
+      disableEscape,
       disableSubmit,
       errors,
       fromLabel,


### PR DESCRIPTION
This PR prevents User from closing the Transaction modal by hitting Escape. It gives a false sense that the tx has been cancelled when in fact it hasn't. For hardware wallet, the tx can still be cancelled via declining on said hardware wallet. On Olympia, the tx can't be cancelled after Confirm button has been hit(this isn't new behavior).

I've created a function which removes an event listener upon hitting the Confirm button. Using this lifecycle, should I remove the `windows.removeEventListener()` from `onUnmounted` hook, since it should be disabled by then?