### PR TITLE
fix: remove references to dev-app-update.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,3 @@ pnpm-debug.log*
 /dist_electron
 
 keystore.json
-
-# Auto updater dev file
-dev-app-update.yml

--- a/README.md
+++ b/README.md
@@ -5,11 +5,7 @@ Welcome to the Radix Wallet README.
 ```
 yarn
 cp .envrc{.sample,}
-cp dev-app-update.yml{.sample,}
 ```
-
-After copying the contents of `dev-app-update.yml.sample` to
-`dev-app-update.yml`, make sure to update the github token to a valid token.
 
 ### Compiles and hot-reloads for development
 ```

--- a/dev-app-update.yml.sample
+++ b/dev-app-update.yml.sample
@@ -1,5 +1,0 @@
-provider: github
-private: false
-owner: radixdlt
-repo: olympia-wallet
-token: my-github-token

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -1,15 +1,8 @@
-import path from 'path'
 import { dialog } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import { setUpdateIsAvailable } from '@/actions/electron/general'
 
 autoUpdater.autoDownload = false
-if (process.env.WEBPACK_DEV_SERVER_URL) {
-  autoUpdater.updateConfigPath = path.join(
-    __dirname,
-    '../dev-app-update.yml'
-  )
-}
 
 autoUpdater.on('error', (error) => {
   dialog.showErrorBox('Error: ', error == null ? 'unknown' : (error.stack || error).toString())


### PR DESCRIPTION
Potentially resolves an issue where electron updater is expecting an `app-update.yml`.