### PR TITLE
fix: do not reset hardware account on sign reject

### DIFF
--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -112,7 +112,7 @@ const userDidCancel = new Subject<boolean>()
 let userConfirmation = new ReplaySubject<ManualUserConfirmTX>()
 const historyPagination = new Subject<TransactionHistoryOfKnownAddressRequestInput>()
 
-export default function useTransactions (radix: RadixT, router: Router, activeAccount: AccountT | null, hardwareAccount: AccountT | null, callbacks: { ledgerSigningError: () => void;}): useTransactionsInterface {
+export default function useTransactions (radix: RadixT, router: Router, activeAccount: AccountT | null, hardwareAccount: AccountT | null): useTransactionsInterface {
   const { setError } = useErrors(radix)
   const refreshHistory = () => {
     loadingHistory.value = true
@@ -240,7 +240,6 @@ export default function useTransactions (radix: RadixT, router: Router, activeAc
         const isLedgerConnectedError = errorEvent.error.message && errorEvent.error.message.includes('Failed to sign tx with Ledger')
         if (isLedgerConnectedError) {
           ledgerTxError.value = errorEvent.error
-          callbacks.ledgerSigningError()
           transactionErrorMessage.value = null
           return
         }

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -125,7 +125,6 @@ interface useWalletInterface {
   connectHardwareWallet: () => void;
   createWallet: (mnemonic: MnemomicT, pass: string, network: Network) => Promise<WalletT>;
   deleteLocalHardwareAddress: () => void;
-  hardwareAccountFailedToSign: () => void;
   hideLedgerVerify: () => void;
   hideLedgerInteraction: () => void;
   initWallet: () => void;
@@ -333,12 +332,6 @@ const fetchSavedNodeUrl = async (signingKeychain: SigningKeychainT): Promise<str
   return selectedNode
 }
 
-const hardwareAccountFailedToSign = () => {
-  hardwareAccount.value = null
-  hardwareInteractionState.value = 'FAILED_TO_SIGN'
-  hardwareError.value = new Error('validations.failedToSign')
-}
-
 const hideLedgerInteraction = () => {
   hardwareInteractionState.value = ''
 }
@@ -429,7 +422,6 @@ export default function useWallet (router: Router): useWalletInterface {
     connectHardwareWallet,
     createWallet,
     deleteLocalHardwareAddress,
-    hardwareAccountFailedToSign,
     hideLedgerInteraction,
     hideLedgerVerify,
     initWallet,

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -168,7 +168,6 @@ const WalletConfirmTransactionModal = defineComponent({
       activeAddress,
       activeAccount,
       hardwareAccount,
-      hardwareAccountFailedToSign,
       radix,
       reset
     } = useWallet(router)
@@ -185,11 +184,7 @@ const WalletConfirmTransactionModal = defineComponent({
       transferInput,
       transactionUnsub,
       selectedCurrency
-    } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value, {
-      ledgerSigningError: () => {
-        hardwareAccountFailedToSign()
-      }
-    })
+    } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value)
 
     const escapeListener = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {

--- a/src/views/Wallet/WalletHistory.vue
+++ b/src/views/Wallet/WalletHistory.vue
@@ -109,7 +109,6 @@ const WalletHistory = defineComponent({
       activeAccount,
       explorerUrlBase,
       hardwareAccount,
-      hardwareAccountFailedToSign,
       radix,
       verifyHardwareWalletAddress
     } = useWallet(router)
@@ -126,11 +125,7 @@ const WalletHistory = defineComponent({
       decryptMessage,
       refreshHistory,
       transactionUnsub
-    } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value, {
-      ledgerSigningError: () => {
-        hardwareAccountFailedToSign()
-      }
-    })
+    } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value)
 
     const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
 

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -150,16 +150,11 @@ const WalletStaking = defineComponent({
       activeAccount,
       explorerUrlBase,
       hardwareAccount,
-      hardwareAccountFailedToSign,
       radix
     } = useWallet(router)
     const { activeForm, setActiveForm } = useStaking(radix)
 
-    const { stakeTokens, unstakeTokens, transactionUnsub, setActiveTransactionForm, transactionErrorMessage } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value, {
-      ledgerSigningError: () => {
-        hardwareAccountFailedToSign()
-      }
-    })
+    const { stakeTokens, unstakeTokens, transactionUnsub, setActiveTransactionForm, transactionErrorMessage } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value)
 
     const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
     const { tokenBalances, tokenBalanceFor, tokenBalancesUnsub } = useTokenBalances(radix)

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -154,13 +154,9 @@ const WalletTransaction = defineComponent({
   setup () {
     const { errors, values, meta, setErrors, resetForm } = useForm<TransactionForm>()
     const router = useRouter()
-    const { activeAddress, activeAccount, hardwareAccount, hardwareAccountFailedToSign, networkPreamble, radix, verifyHardwareWalletAddress } = useWallet(router)
+    const { activeAddress, activeAccount, hardwareAccount, networkPreamble, radix, verifyHardwareWalletAddress } = useWallet(router)
 
-    const { transferTokens, transactionUnsub, setActiveTransactionForm } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value, {
-      ledgerSigningError: () => {
-        hardwareAccountFailedToSign()
-      }
-    })
+    const { transferTokens, transactionUnsub, setActiveTransactionForm } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value)
 
     setActiveTransactionForm('transaction')
 

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -60,15 +60,10 @@ const WalletIndex = defineComponent({
       showDeleteHWWalletPrompt,
       showLedgerVerify,
       walletLoaded,
-      hardwareAccountFailedToSign,
       waitUntilAllLoaded
     } = useWallet(router)
 
-    const { shouldShowConfirmation, transactionUnsub } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value, {
-      ledgerSigningError: () => {
-        hardwareAccountFailedToSign()
-      }
-    })
+    const { shouldShowConfirmation, transactionUnsub } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value)
 
     onBeforeRouteUpdate(async () => {
       await waitUntilAllLoaded()


### PR DESCRIPTION
This PR changes the behavior when a user rejects the signing of a transaction. For some reason we had implemented a function to essentially reset the user's hardware account, and prompt them to reconnect their hardware wallet. I've racked my brain, and can't explain for the life of me why we'd do that. I think this was a poor decision made during the large refactor and not appropriately revisited.

This fixes an issue that surfaced when attempting to send a transaction after rejecting a transaction. The wallet would enter a confused state - thinking it had no hardware wallet connection, when in fact it does.

[Loom Demo.](https://www.loom.com/share/fd4c14ef075a425fab9a36d67a3b6853)

