### PR TITLE
fix: don't clip token mouseovers

### DIFF
--- a/src/components/BigAmount.vue
+++ b/src/components/BigAmount.vue
@@ -1,8 +1,7 @@
 <template>
   <span class="relative inline-flex flex-col items-center group cursor-pointer" @click.stop="copyText">
     <span>{{numberForDisplay}}</span>
-    <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight"
-    :class="numberLessThanFourDigits && 'ml-32'">
+    <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight">
       {{fullNumber}}
     </div>
   </span>
@@ -121,10 +120,6 @@ const BigAmount = defineComponent({
 
     fullNumber (): string {
       return asBigNumber(this.amount, true)
-    },
-
-    numberLessThanFourDigits (): boolean {
-      return asBigNumber(this.amount, false).toString().length < 4
     }
   },
 

--- a/src/components/OtherTokenBalanceListItem.vue
+++ b/src/components/OtherTokenBalanceListItem.vue
@@ -15,7 +15,7 @@
         </div>
       </div>
     </div>
-    <div class="overflow-x-scroll relative">
+    <div class="overflow-x-visible relative">
       <div class="flex flex-row absolute">
         <div class="flex-1 flex flex-row items-center px-6 overflow-x-auto">
           <span class="text-sm font-mono text-rGrayDark">{{ truncateRRIStringForDisplay(tokenBalance.tokenIdentifier.toString()) }}</span>


### PR DESCRIPTION
This PR better handles token mouseovers. The previous fix from @SK-Sam was clever, but didn't work in some edge cases where the presented token value was very short, like `0.106`, but the mouseover value was the full 18 digits. This solution allows the token mouseover to just extend outside the other token cell.
<img width="1312" alt="Screen Shot 2021-11-23 at 7 57 32 AM" src="https://user-images.githubusercontent.com/102228/143040092-90de9c87-9ca0-468b-a3de-3ed1d08cd2a2.png">


