### PR TITLE
chore: change digit acceptance for tooltip change from 4 to 7

### DIFF
--- a/src/components/BigAmount.vue
+++ b/src/components/BigAmount.vue
@@ -1,8 +1,7 @@
 <template>
   <span class="relative inline-flex flex-col items-center group cursor-pointer" @click.stop="copyText">
     <span>{{numberForDisplay}}</span>
-    <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight"
-    :class="numberLessThanSevenDigits && 'ml-32'">
+    <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 left-0 rounded-sm shadow border border-solid border-rGrayLight">
       {{fullNumber}}
     </div>
   </span>

--- a/src/components/BigAmount.vue
+++ b/src/components/BigAmount.vue
@@ -2,7 +2,7 @@
   <span class="relative inline-flex flex-col items-center group cursor-pointer" @click.stop="copyText">
     <span>{{numberForDisplay}}</span>
     <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight"
-    :class="numberLessThanFourDigits && 'ml-32'">
+    :class="numberLessThanSevenDigits && 'ml-32'">
       {{fullNumber}}
     </div>
   </span>
@@ -123,8 +123,8 @@ const BigAmount = defineComponent({
       return asBigNumber(this.amount, true)
     },
 
-    numberLessThanFourDigits (): boolean {
-      return asBigNumber(this.amount, false).toString().length < 4
+    numberLessThanSevenDigits (): boolean {
+      return asBigNumber(this.amount, false).toString().length < 7
     }
   },
 


### PR DESCRIPTION
[Demo](https://www.loom.com/share/0cdaba0ba0d947b79c2aa85eb1566502)

This PR widens the range of when the tooltip changes styling from 4 digits to 7 digits. Let me know if 7 is too forgiving.