### PR TITLE
chore: adjust tooltip balance styling

### DIFF
--- a/src/components/BigAmount.vue
+++ b/src/components/BigAmount.vue
@@ -1,8 +1,7 @@
 <template>
   <span class="relative inline-flex flex-col items-center group cursor-pointer" @click.stop="copyText">
     <span>{{numberForDisplay}}</span>
-    <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight"
-    :class="numberLessThanSevenDigits && 'ml-32'">
+    <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 left-0 rounded-sm shadow border border-solid border-rGrayLight">
       {{fullNumber}}
     </div>
   </span>

--- a/src/components/BigAmount.vue
+++ b/src/components/BigAmount.vue
@@ -120,10 +120,6 @@ const BigAmount = defineComponent({
 
     fullNumber (): string {
       return asBigNumber(this.amount, true)
-    },
-
-    numberLessThanSevenDigits (): boolean {
-      return asBigNumber(this.amount, false).toString().length < 7
     }
   },
 

--- a/src/components/BigAmount.vue
+++ b/src/components/BigAmount.vue
@@ -2,7 +2,7 @@
   <span class="relative inline-flex flex-col items-center group cursor-pointer" @click.stop="copyText">
     <span>{{numberForDisplay}}</span>
     <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight"
-    :class="numberLessThanFourDigits && 'ml-32'">
+    :class="numberLessThanSevenDigits && 'ml-32'">
       {{fullNumber}}
     </div>
   </span>
@@ -123,8 +123,8 @@ const BigAmount = defineComponent({
       return asBigNumber(this.amount, true)
     },
 
-    numberLessThanFourDigits (): boolean {
-      return asBigNumber(this.amount, false).toString().length < 4
+    numberLessThanSevenDigits (): boolean {
+      return asBigNumber(this.amount, false).toString().length < 7
     }
   },
 


### PR DESCRIPTION
[Demo](https://www.loom.com/share/187fe731933947c4988db16ff7efab80)

This PR changes Tooltip styling so tooltip will begin from leftmost part of the div. Previously we were running a conditional where only specific amount of digits will offset the tooltip away from the left, but now we will render the tooltip relative to div.