### PR TITLE
chore: warn of caps lock in password inputs

### DIFF
--- a/src/components/PasswordField.vue
+++ b/src/components/PasswordField.vue
@@ -10,8 +10,8 @@
       :label="label"
       :validateOnInput="validateOnInput"
       :validateOnBlur="validateOnBlur"
-      v-on:keyup="checkCapsLock"
-      v-on:keydown.caps-lock="checkCapsLock"
+      @keyup="checkCapsLock"
+      @keydown.caps-lock="checkCapsLock"
     >
     </FormField>
     <div v-if="isCapsEnabled" class="absolute top-2 right-0 flex flex-row

--- a/src/components/PasswordField.vue
+++ b/src/components/PasswordField.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="relative w-full">
+    <FormField
+      type="password"
+      :name="name"
+      :rules="rules"
+      :data-ci="dataCi"
+      class="w-full"
+      :placeholder="placeholder"
+      :label="label"
+      :validateOnInput="validateOnInput"
+      :validateOnBlur="validateOnBlur"
+      v-on:keyup="checkCapsLock"
+      v-on:keydown.caps-lock="checkCapsLock"
+    >
+    </FormField>
+    <div v-if="isCapsEnabled" class="absolute top-2 right-0 flex flex-row
+    items-center">
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect x="3.19995" y="9.6001" width="5.6" height="2.4" fill="#EF4136"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M12 6.4L6 0L0 6.4H3.2V8H8.8V6.4H12Z" fill="#EF4136"/>
+      </svg>
+      <span class="ml-2 text-red-400">caps lock on</span>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import FormField from '@/components/FormField.vue'
+
+const PasswordField = defineComponent({
+  components: {
+    FormField
+  },
+
+  data () {
+    return {
+      isCapsEnabled: false
+    }
+  },
+
+  methods: {
+    checkCapsLock (event: KeyboardEvent) {
+      this.isCapsEnabled = event.getModifierState('CapsLock')
+    }
+  },
+
+  props: {
+    name: {
+      type: String,
+      required: true
+    },
+    placeholder: {
+      type: String,
+      required: true
+    },
+    rules: {
+      type: [String, Object],
+      required: true
+    },
+    dataCi: {
+      type: String,
+      required: false
+    },
+    label: {
+      type: String,
+      required: false
+    },
+    validateOnInput: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    validateOnBlur: {
+      type: Boolean,
+      required: false,
+      default: true
+    },
+    underlineStyle: {
+      type: Boolean,
+      required: false,
+      default: true
+    }
+  }
+})
+
+export default PasswordField
+</script>

--- a/src/views/CreateWallet/CreateWalletCreatePasscode.vue
+++ b/src/views/CreateWallet/CreateWalletCreatePasscode.vue
@@ -2,10 +2,8 @@
   <div data-ci="create-wallet-create-passcode-component">
     <form class="flex flex-col w-96" @submit.prevent="$emit('confirm', values.password)">
       <div class="mb-14">
-        <FormField
-          type="password"
+        <PasswordField
           name="password"
-          class="w-full"
           :placeholder="$t('createWallet.passwordPlaceholder')"
           rules="required"
           data-ci="create-wallet-passcode-input"
@@ -14,10 +12,8 @@
       </div>
 
       <div class="mb-56">
-        <FormField
-          type="password"
+        <PasswordField
           name="confirmation"
-          class="w-full"
           :placeholder="$t('createWallet.passwordConfirmationPlaceholder')"
           rules="required|confirmed:@password"
           data-ci="create-wallet-confirm-input"
@@ -36,7 +32,7 @@
 import { defineComponent } from 'vue'
 import { useForm } from 'vee-validate'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
-import FormField from '@/components/FormField.vue'
+import PasswordField from '@/components/PasswordField.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
 
 interface PasswordForm {
@@ -47,8 +43,8 @@ interface PasswordForm {
 const CreateWalletCreatePasscode = defineComponent({
   components: {
     ButtonSubmit,
-    FormField,
-    FormErrorMessage
+    FormErrorMessage,
+    PasswordField
   },
 
   setup () {

--- a/src/views/Home/HomeEnterPasscode.vue
+++ b/src/views/Home/HomeEnterPasscode.vue
@@ -6,10 +6,8 @@
         <path d="M3.98975 12.1227V8.91388C3.98975 4.54318 7.55907 1 11.962 1C16.3649 1 19.9342 4.54318 19.9342 8.91388V12.1227" stroke="#00C389" stroke-width="1.5" stroke-miterlimit="10"/>
         <path d="M1 30.3952V11.8662H4.23024H19.7567H22.9869V29.4213H5.57166" stroke="#052CC0" stroke-width="1.5" stroke-miterlimit="10"/>
       </svg>
-
       <div class="mb-6 flex flex-col">
-        <FormField
-          type="password"
+        <PasswordField
           name="password"
           class="pl-8"
           :placeholder="$t('home.passwordPlaceholder')"
@@ -40,7 +38,7 @@
 <script lang="ts">
 import { defineComponent, computed, ComputedRef, Ref } from 'vue'
 import { useForm } from 'vee-validate'
-import FormField from '@/components/FormField.vue'
+import PasswordField from '@/components/PasswordField.vue'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
 import { useI18n } from 'vue-i18n'
@@ -56,7 +54,7 @@ interface PasswordForm {
 const HomeEnterPasscode = defineComponent({
   components: {
     ButtonSubmit,
-    FormField,
+    PasswordField,
     FormErrorMessage
   },
 

--- a/src/views/Settings/SettingsResetPassword.vue
+++ b/src/views/Settings/SettingsResetPassword.vue
@@ -7,10 +7,8 @@
     </div>
 
     <div class="mb-14">
-      <FormField
-        type="password"
+      <PasswordField
         name="currentPassword"
-        class="w-full"
         :placeholder="$t('settings.currentPasswordPlaceholder')"
         rules="required"
         :label="$t('settings.currentPasswordLabel')"
@@ -21,10 +19,8 @@
     </div>
 
     <div class="mb-14">
-      <FormField
-        type="password"
+      <PasswordField
         name="password"
-        class="w-full"
         :placeholder="$t('settings.newPasswordLabel')"
         rules="required"
         data-ci="create-wallet-passcode-input"
@@ -34,10 +30,8 @@
     </div>
 
     <div class="mb-8">
-      <FormField
-        type="password"
+      <PasswordField
         name="confirmation"
-        class="w-full"
         :placeholder="$t('settings.confirmPasswordLabel')"
         rules="required|confirmed:@password"
         data-ci="create-wallet-confirm-input"
@@ -64,7 +58,7 @@ import { Subscription } from 'rxjs'
 import { ref } from '@nopr3d/vue-next-rx'
 import { touchKeystore, initWallet } from '@/actions/vue/create-wallet'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
-import FormField from '@/components/FormField.vue'
+import PasswordField from '@/components/PasswordField.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
 import { useRouter } from 'vue-router'
 import { useWallet } from '@/composables'
@@ -79,8 +73,8 @@ interface PasswordForm {
 const SettingsResetPassword = defineComponent({
   components: {
     ButtonSubmit,
-    FormField,
-    FormErrorMessage
+    FormErrorMessage,
+    PasswordField
   },
 
   setup () {

--- a/src/views/Settings/SettingsRevealMnemonic.vue
+++ b/src/views/Settings/SettingsRevealMnemonic.vue
@@ -36,14 +36,12 @@
           @submit.prevent="handleSubmit"
         >
           <div class="text-rGrayDark mb-9">{{ $t('settings.mnemonicModalHeading') }}</div>
-          <FormField
-          type="password"
-          name="password"
-          class="w-full"
-          :placeholder="$t('settings.passwordPlaceholder')"
-          rules="required"
-          data-ci="create-wallet-passcode-input"
-          :validateOnInput="true"
+          <PasswordField
+            name="password"
+            :placeholder="$t('settings.passwordPlaceholder')"
+            rules="required"
+            data-ci="create-wallet-passcode-input"
+            :validateOnInput="true"
           />
           <FormErrorMessage name="password" />
           <ButtonSubmit
@@ -71,7 +69,7 @@ import { defineComponent, PropType } from 'vue'
 import { useForm } from 'vee-validate'
 import MnemonicDisplay from '@/components/MnemonicDisplay.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
-import FormField from '@/components/FormField.vue'
+import PasswordField from '@/components/PasswordField.vue'
 import { touchKeystore } from '@/actions/vue/create-wallet'
 import { Result } from 'neverthrow'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
@@ -84,7 +82,7 @@ const SettingsRevealMnemonic = defineComponent({
   components: {
     ButtonSubmit,
     MnemonicDisplay,
-    FormField,
+    PasswordField,
     FormErrorMessage
   },
 


### PR DESCRIPTION
This PR introduces a `PasswordField` that extends the existing `FormField` and adds some additional logic to detect if either capslock is pushed, or if the input has caps enabled (to handle cases where a user enables caps lock in a separate window and then returns to the wallet).

https://www.loom.com/share/a070f7e403b14641a5e7f0b7730dda4d