### PR TITLE
Keystore changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@ledgerhq/hw-transport-node-hid": "^6.0.2",
     "@nopr3d/vue-next-rx": "^1.0.6",
     "@radixdlt/application": "^4.0.1",
-    "@radixdlt/hardware-ledger": "^2.1.15",
+    "@radixdlt/hardware-ledger": "^2.1.26",
     "@tailwindcss/forms": "^0.2.1",
     "@tailwindcss/postcss7-compat": "^2.0.2",
     "@types/bn.js": "^5.1.0",

--- a/src/components/OtherTokenBalanceListItem.vue
+++ b/src/components/OtherTokenBalanceListItem.vue
@@ -70,9 +70,9 @@ export default defineComponent({
     const { radix } = useWallet(router)
 
     firstValueFrom(radix.ledger.tokenInfo(tokenBalance.value.tokenIdentifier))
-    .then((t: any) => {
-      token.value = t
-    })
+      .then((t: any) => {
+        token.value = t
+      })
 
     const rriUrl: ComputedRef<string> = computed(() =>
       `${props.explorerUrlBase}/#/tokens/${props.tokenBalance.tokenIdentifier.toString()}`

--- a/src/composables/useNativeToken.ts
+++ b/src/composables/useNativeToken.ts
@@ -9,7 +9,7 @@ interface useNativeTokenInterface {
 
 export default function useNativeToken (radix: RadixT): useNativeTokenInterface {
   const nativeToken: Ref<Token | null> = ref(null)
-  const nativeTokenSub = 
+  const nativeTokenSub =
   radix.ledger.networkId()
     .pipe(mergeMap((networkId: string) => radix.ledger.nativeToken(networkId)))
     .subscribe((nativeTokenRes) => {

--- a/src/composables/useStaking.ts
+++ b/src/composables/useStaking.ts
@@ -31,11 +31,11 @@ export default function useStaking (radix: RadixT): useStakingInterface {
     loadingUnstakes.value = false
   })
   const validatorSub = radix.ledger.networkId()
-  .pipe(mergeMap((network) => radix.ledger.validators({ network })))
-  .subscribe((validatorsRes: any) => {
-    validators.value = validatorsRes
-    loadingValidators.value = false
-  })
+    .pipe(mergeMap((network) => radix.ledger.validators({ network })))
+    .subscribe((validatorsRes: any) => {
+      validators.value = validatorsRes
+      loadingValidators.value = false
+    })
 
   return {
     activeForm: computed(() => activeForm.value),

--- a/src/composables/useStaking.ts
+++ b/src/composables/useStaking.ts
@@ -1,5 +1,6 @@
 import { ref, computed, ComputedRef, Ref } from 'vue'
-import { RadixT, StakePositions, UnstakePositions, Validators, ValidatorsEndpoint } from '@radixdlt/application'
+import { RadixT, StakePositions, UnstakePositions, Validators, Network } from '@radixdlt/application'
+import { mergeMap } from 'rxjs/operators'
 
 interface useStakingInterface {
   readonly activeForm: ComputedRef<'STAKING'|'UNSTAKING'>;
@@ -29,7 +30,9 @@ export default function useStaking (radix: RadixT): useStakingInterface {
     activeUnstakes.value = unstakes
     loadingUnstakes.value = false
   })
-  const validatorSub = radix.ledger.validators({ size: 100 }).subscribe((validatorsRes: any) => {
+  const validatorSub = radix.ledger.networkId()
+  .pipe(mergeMap((network) => radix.ledger.validators({ network })))
+  .subscribe((validatorsRes: any) => {
     validators.value = validatorsRes
     loadingValidators.value = false
   })

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -280,7 +280,8 @@ export default function useTransactions (radix: RadixT, router: Router, activeAc
         next: (txnID: TransactionIdentifierT) => {
           pendingTransactions.value = pendingTransactions.value.filter((pendingTxn: TransactionStateSuccess) => {
             const transactionState = pendingTxn.transactionState as unknown as FinalizedTransaction
-            return txnID.toString() !== transactionState.txID.toString()
+            return false
+            // return txnID.toString() !== transactionState.txID.toString()
           })
           shouldShowConfirmation.value = false
           router.push('/wallet/history')
@@ -361,7 +362,7 @@ export default function useTransactions (radix: RadixT, router: Router, activeAc
   const unstakeTokens = (unstakeTokensInput: UnstakeTokensInput) => {
     let pollTXStatusTrigger: Observable<unknown>
     cleanupInputs()
-    stakeInput.value = unstakeTokensInput
+    // stakeInput.value = unstakeTokensInput
     confirmationMode.value = 'unstake'
 
     const buildTransferTokens = (): UnstakeOptions => ({

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -209,7 +209,7 @@ const initWallet = (): void => {
     .subscribe((network: Network) => {
       activeNetwork.value = network
       fetchAccountsForNetwork(network)
-      if (network === 'MAINNET') explorerUrlBase.value = 'https://explorer.radixdlt.com/'
+      if (network === Network.MAINNET) explorerUrlBase.value = 'https://explorer.radixdlt.com/'
       else explorerUrlBase.value = 'https://stokenet-explorer.radixdlt.com/'
     })
 
@@ -465,9 +465,9 @@ export default function useWallet (router: Router): useWalletInterface {
     networkPreamble: computed(() => {
       switch (activeNetwork.value) {
         case Network.STOKENET:
-          return HRP.STOKENET.account
-        case HRP.MAINNET.account:
-          return HRP.MAINNET.account
+          return HRP[Network.STOKENET].account
+        case Network.MAINNET:
+          return HRP[Network.MAINNET].account
         default:
           return ''
       }

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -312,6 +312,7 @@ const hashNodeUrl = async (url:string, signingKeychain: SigningKeychainT): Promi
 }
 
 const persistNodeUrl = async (url: string): Promise<void> => {
+  console.log(url, 'node url')
   if (!signingKeychain.value) return
   const hash = await hashNodeUrl(url, signingKeychain.value)
   const saveToStore = await persistNodeSelection(url, hash)
@@ -455,6 +456,7 @@ export default function useWallet (router: Router): useWalletInterface {
     },
 
     setNetwork (network: Network) {
+      console.log(network)
       activeNetwork.value = network
     },
 

--- a/src/helpers/network.ts
+++ b/src/helpers/network.ts
@@ -8,17 +8,17 @@ export type ChosenNetworkT = {
 
 export const network = (networkName: Network): ChosenNetworkT => {
   let response: ChosenNetworkT
-  if (networkName === 'STOKENET') {
+  if (networkName === 'stokenet') {
     response = {
       network: Network.STOKENET,
       networkURL: 'https://stokenet.radixdlt.com',
-      preamble: HRP.STOKENET.account
+      preamble: HRP[Network.STOKENET].account
     }
-  } else if (networkName === 'MAINNET') {
+  } else if (networkName === 'mainnet') {
     response = {
       network: Network.MAINNET,
       networkURL: 'https://mainnet.radixdlt.com',
-      preamble: HRP.MAINNET.account
+      preamble: HRP[Network.MAINNET].account
     }
   } else {
     throw new Error(`Invalid Network Name ${networkName} Provided`)
@@ -30,12 +30,12 @@ export const defaultNetworks: ChosenNetworkT[] = [
   {
     network: Network.MAINNET,
     networkURL: 'https://mainnet.radixdlt.com',
-    preamble: HRP.MAINNET.account
+    preamble: HRP[Network.MAINNET].account
   },
   {
     network: Network.STOKENET,
     networkURL: 'https://stokenet.radixdlt.com',
-    preamble: HRP.STOKENET.account
+    preamble: HRP[Network.STOKENET].account
   }
 ]
 

--- a/src/helpers/network.ts
+++ b/src/helpers/network.ts
@@ -8,13 +8,13 @@ export type ChosenNetworkT = {
 
 export const network = (networkName: Network): ChosenNetworkT => {
   let response: ChosenNetworkT
-  if (networkName === 'stokenet') {
+  if (networkName === Network.STOKENET) {
     response = {
       network: Network.STOKENET,
       networkURL: 'https://stokenet.radixdlt.com',
       preamble: HRP[Network.STOKENET].account
     }
-  } else if (networkName === 'mainnet') {
+  } else if (networkName === Network.MAINNET) {
     response = {
       network: Network.MAINNET,
       networkURL: 'https://mainnet.radixdlt.com',

--- a/src/views/Home/index.vue
+++ b/src/views/Home/index.vue
@@ -87,18 +87,23 @@ const Home = defineComponent({
     const { modal, setModal } = useHomeModal()
     const router = useRouter()
     const { hasWallet, resetWallet, radix, setNetwork } = useWallet(router)
+
     hasKeystore().then((val: boolean) => {
       loading.value = false
+      console.log('hi', val)
       if (!val) {
-        Promise.race([
-          radix.connect('https://mainnet.radixdlt.com'),
-          new Promise((resolve, reject) => setTimeout(() => reject(new Error()), 5000))
-        ]).then(() => {
+        // Promise.race([
+        //   radix.connect('https://mainnet.radixdlt.com'),
+        //   new Promise((resolve, reject) => setTimeout(() => reject(new Error()), 5000))
+        // ]).then(() => {
+        radix.connect('https://mainnet.radixdlt.com').then(() => {
+          console.log('hello')
           connected.value = true
           return firstValueFrom(radix.ledger.networkId())
-        }).then((network) => {
+        }).then((network: Network) => {
           setNetwork(network as Network)
         }).catch(() => {
+          console.log('whoops')
           unableToConnect.value = true
           connected.value = false
         })

--- a/src/views/Settings/SettingsResetPassword.vue
+++ b/src/views/Settings/SettingsResetPassword.vue
@@ -103,31 +103,25 @@ const SettingsResetPassword = defineComponent({
       subs.add(getMnemonicForPassword)
     }
 
-    const handleSubmit = () => {
+    const handleSubmit = async () => {
       isLoading.value = true
-      touchKeystore()
-        .then((keystore: KeystoreT) =>
-          Keystore.decrypt({
-            keystore,
-            password: values.currentPassword
-          })
-        )
-        .then((res: Result<Buffer, Error>) => {
-          if (res.isOk()) {
-            handleResetPassword(values.password)
-          } else {
-            isLoading.value = false
-            setErrors({
-              currentPassword: t('validations.incorrectPassword')
-            })
-          }
-        })
-        .catch(() => {
+      try {
+        const keystore = await touchKeystore()
+        const decryptedResult = await Keystore.decrypt({ keystore, password: values.password })
+        if (decryptedResult.isOk()) {
+          handleResetPassword(values.password)
+        } else {
           isLoading.value = false
           setErrors({
             currentPassword: t('validations.incorrectPassword')
           })
+        }
+      } catch {
+        isLoading.value = false
+        setErrors({
+          currentPassword: t('validations.incorrectPassword')
         })
+      }
     }
 
     onUnmounted(() => subs.unsubscribe())

--- a/src/views/Settings/SettingsResetPin.vue
+++ b/src/views/Settings/SettingsResetPin.vue
@@ -58,7 +58,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { computed, defineComponent, ref } from 'vue'
 import { useForm } from 'vee-validate'
 import PinInput from '@/components/PinInput.vue'
 import { storePin, touchKeystore } from '@/actions/vue/create-wallet'
@@ -67,6 +67,7 @@ import FormField from '@/components/FormField.vue'
 import { Result } from 'neverthrow'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
 import { Keystore, KeystoreT } from '@radixdlt/application'
+import { useI18n } from 'vue-i18n'
 
 interface ResetPinForm {
   password: string;
@@ -84,77 +85,71 @@ const SettingsResetPin = defineComponent({
 
   setup () {
     const { errors, meta, values, setErrors, resetForm } = useForm<ResetPinForm>()
+    const { t } = useI18n()
+    const activePin = ref(0)
+    const isValidPin = ref(false)
+    const updatedPin = ref(false)
+    const resetFormForNonmatchingPins = () => {
+      const newValues = { password: values.password, pin: '', confirmationPin: '' }
+      const newErrors = { confirmationPin: t('validations.pinMatch') }
+      resetForm({ values: newValues, errors: newErrors })
+      activePin.value = 1
+    }
 
-    return { errors, meta, values, setErrors, resetForm }
-  },
+    const handleComparePin = () => {
+      if (values.pin === values.confirmationPin) {
+        isValidPin.value = true
+      } else {
+        resetFormForNonmatchingPins()
+      }
+    }
 
-  data () {
+    const handleUnfinishedPin = () => {
+      isValidPin.value = false
+    }
+
+    const handleResetPin = async () => {
+      if (values.pin !== values.confirmationPin) {
+        resetFormForNonmatchingPins()
+        return Promise.resolve()
+      }
+      try {
+        const keystore = await touchKeystore()
+        const decryptedResult = await Keystore.decrypt({ keystore, password: values.password })
+        if (decryptedResult.isOk()) {
+          const storePinResult = await storePin(values.pin)
+          resetForm()
+          updatedPin.value = true
+        } else {
+          setErrors({ password: t('validations.incorrectPassword') })
+        }
+      } catch {
+        setErrors({ password: t('validations.incorrectPassword') })
+      }
+    }
+
+    const disableSubmit = computed(() => {
+      return meta.value.dirty ? !meta.value.valid : true
+    })
+
     return {
-      activePin: 0,
-      isValidPin: false,
-      updatedPin: false
-    }
-  },
+      /* refs */
+      activePin,
+      isValidPin,
+      updatedPin,
+      errors,
+      meta,
+      values,
 
-  computed: {
-    disableSubmit (): boolean {
-      return this.meta.dirty ? !this.meta.valid : true
-    }
-  },
+      /* functions */
+      setErrors,
+      resetForm,
+      handleComparePin,
+      handleUnfinishedPin,
+      handleResetPin,
 
-  methods: {
-    resetFormForNonmatchingPins () {
-      const values = { password: this.values.password, pin: '', confirmationPin: '' }
-      const errors = { confirmationPin: this.$t('validations.pinMatch') }
-      this.resetForm({
-        values: values,
-        errors: errors
-      })
-      this.activePin = 1
-    },
-
-    handleComparePin () {
-      if (this.values.pin === this.values.confirmationPin) {
-        this.isValidPin = true
-      } else {
-        this.resetFormForNonmatchingPins()
-      }
-    },
-
-    handleUnfinishedPin () {
-      this.isValidPin = false
-    },
-
-    handleResetPin () {
-      if (this.values.pin !== this.values.confirmationPin) {
-        this.resetFormForNonmatchingPins()
-      } else {
-        touchKeystore()
-          .then((keystore: KeystoreT) =>
-            Keystore.decrypt({
-              keystore,
-              password: this.values.password
-            })
-          )
-          .then((res: Result<Buffer, Error>) => {
-            if (res.isOk()) {
-              storePin(this.values.pin)
-                .then(() => {
-                  this.resetForm()
-                  this.updatedPin = true
-                })
-            } else {
-              this.setErrors({
-                password: this.$t('validations.incorrectPassword')
-              })
-            }
-          })
-          .catch(() => {
-            this.setErrors({
-              password: this.$t('validations.incorrectPassword')
-            })
-          })
-      }
+      /* computed */
+      disableSubmit
     }
   }
 })

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -221,7 +221,7 @@ const WalletStaking = defineComponent({
 
     const validatorsTopOneHundred: ComputedRef<Array<Position>> = computed(() => {
       if (validators.value && validators.value.validators) {
-        const vals: Validator[] = validators.value.validators
+        const vals: Validator[] = validators.value.validators.slice(0, 100)
         return sortedPositions.value.filter((pos: Position) => {
           const withinTopOneHundredIndex = vals.findIndex((validator: Validator) => pos.address.toString() === validator.address.toString())
           return withinTopOneHundredIndex !== -1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1494,15 +1494,15 @@
     node-ipc "^9.1.1"
     ws "^7.3.1"
 
-"@radixdlt/account@^2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@radixdlt/account/-/account-2.1.6.tgz#36d600edc84969ef1fc531d6e370a7fddd098a57"
-  integrity sha512-veXhZWWYxRNQNYKmgXp/8SE+uANXh4YdOnZwkVmpwrrGFgKe68zb6FCKtAFm10WEP9bA85U0t1CH9KcSHHav7A==
+"@radixdlt/account@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@radixdlt/account/-/account-3.0.3.tgz#9b0d876daa7dee60826745a7529e5cd8140b4147"
+  integrity sha512-5bkAGvNfF2VoZHk8ho4xrWJBNTugn+sHTqVmpD5U6oVQq1Dk9BmiwYv+4Gh7+WmPZcdkRbz+DsVdUFi5XGJ5xQ==
   dependencies:
-    "@radixdlt/crypto" "^2.1.3"
+    "@radixdlt/crypto" "^2.1.7"
     "@radixdlt/data-formats" "1.0.30"
-    "@radixdlt/hardware-wallet" "^2.1.6"
-    "@radixdlt/primitives" "^2.1.3"
+    "@radixdlt/hardware-wallet" "^2.1.10"
+    "@radixdlt/primitives" "^3.0.3"
     "@radixdlt/uint256" "1.1.0"
     "@radixdlt/util" "1.0.29"
     bech32 "^2.0.0"
@@ -1527,13 +1527,13 @@
     ramda "^0.27.1"
     rxjs "7.0.0"
 
-"@radixdlt/crypto@^2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@radixdlt/crypto/-/crypto-2.1.3.tgz#93412cc495326d96fceca0bba12601b0db5cd256"
-  integrity sha512-K9P+W6OWnobxhl2SQa6ns8ncdblIeOUbm2z51qXovqJOm3wlJcN7wA8bXEcDtQh+UJUUwEagsk99t1w5CFX8Pg==
+"@radixdlt/crypto@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@radixdlt/crypto/-/crypto-2.1.7.tgz#06ae0732912175bc208401dce312c7cfbb16e7c6"
+  integrity sha512-MzVe1i+MkA3gEysYIRLNV8vBXCapcW3pNsWzXfUBgMV6dLlgNvGuqkY734zuG2KDb+K5Cl8m6j57NC3zGrAjIA==
   dependencies:
     "@radixdlt/data-formats" "1.0.30"
-    "@radixdlt/primitives" "^2.1.3"
+    "@radixdlt/primitives" "^3.0.3"
     "@radixdlt/uint256" "1.1.0"
     "@radixdlt/util" "1.0.29"
     base-x "^3.0.8"
@@ -1552,39 +1552,39 @@
     neverthrow "^4.0.1"
     ramda "^0.27.1"
 
-"@radixdlt/hardware-ledger@^2.1.15":
-  version "2.1.15"
-  resolved "https://registry.yarnpkg.com/@radixdlt/hardware-ledger/-/hardware-ledger-2.1.15.tgz#615598256452ae2dbd7c00fdd5532c6efc13dbd3"
-  integrity sha512-y6lc3uxDkGo22Q/jUt0QX3z9n26gWIKd/cnzrrras62SVmSxYBzRQpJ9ZKeu6tqe31dSBHjgleaCxOaE4GLsaw==
+"@radixdlt/hardware-ledger@^2.1.26":
+  version "2.1.26"
+  resolved "https://registry.yarnpkg.com/@radixdlt/hardware-ledger/-/hardware-ledger-2.1.26.tgz#d14c9aeb87fde2505a828991354681b5d813dae8"
+  integrity sha512-Zk9xRCeioSxGyoYfdoUHUx3yytx7I47wmnhUbdx0H48CrWmlH0NYhOSi8dXSaWQ0XxlUE/MXJrnmyib/VimbqA==
   dependencies:
     "@ledgerhq/hw-transport-node-hid" "^6.2.0"
-    "@radixdlt/crypto" "^2.1.3"
-    "@radixdlt/hardware-wallet" "^2.1.6"
-    "@radixdlt/primitives" "^2.1.3"
-    "@radixdlt/tx-parser" "^2.1.7"
+    "@radixdlt/crypto" "^2.1.7"
+    "@radixdlt/hardware-wallet" "^2.1.10"
+    "@radixdlt/primitives" "^3.0.3"
+    "@radixdlt/tx-parser" "^2.1.12"
     "@radixdlt/util" "1.0.29"
     neverthrow "4.0.1"
     prelude-ts "^1.0.2"
     rxjs "7.0.0"
     uuid "^8.3.2"
 
-"@radixdlt/hardware-wallet@^2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@radixdlt/hardware-wallet/-/hardware-wallet-2.1.6.tgz#f2bf7e8f2614196a2487770d965313d44111b6f0"
-  integrity sha512-2CXvX3VYaJpFWuE4jZrjAQEOUY0DVqCqoezANeWpiAVKvLGdUtAOaeMiUbtORbvaG+OrswWI/Owg5QYustF52g==
+"@radixdlt/hardware-wallet@^2.1.10":
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/@radixdlt/hardware-wallet/-/hardware-wallet-2.1.10.tgz#b374bc29fef4bcae89976360fdea27b727d878d6"
+  integrity sha512-uSSQA3jcI6L/CjlwI4JgK1uELwhOaT8F3si48tZaYsHucyI7oB4+SigDcKei0LSexA9U2VU+ofWknwtfwLRnHA==
   dependencies:
-    "@radixdlt/crypto" "^2.1.3"
-    "@radixdlt/primitives" "^2.1.3"
+    "@radixdlt/crypto" "^2.1.7"
+    "@radixdlt/primitives" "^3.0.3"
     "@radixdlt/util" "1.0.29"
     neverthrow "4.0.1"
     prelude-ts "^1.0.2"
     rxjs "7.0.0"
     uuid "^8.3.2"
 
-"@radixdlt/primitives@^2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@radixdlt/primitives/-/primitives-2.1.3.tgz#bc80d974cd0a363b03291f36bef1369bd8c291b8"
-  integrity sha512-132/NJQMaHK0JtAPki2vjYCvPEFcVc9+oOsrU/7ydag63oYmWWe7HRAEwAoYQeTvY4eFmWGdU+mw9QtGWn7cvQ==
+"@radixdlt/primitives@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@radixdlt/primitives/-/primitives-3.0.3.tgz#473ff28d302c465bca2a91e71ed3a1f868206b24"
+  integrity sha512-r8tOoxDoB2z0K2pGocWaWpEOYoi3itComVEeNHZJf7ilBODcSlJmVECadFam/AbEg1mpqRJk1wRBDs9CqL/UPQ==
   dependencies:
     "@radixdlt/data-formats" "1.0.30"
     "@radixdlt/uint256" "1.1.0"
@@ -1593,14 +1593,14 @@
     long "^4.0.0"
     neverthrow "^4.0.1"
 
-"@radixdlt/tx-parser@^2.1.7":
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/@radixdlt/tx-parser/-/tx-parser-2.1.7.tgz#bbc5ea62532654dbb57bdc66a9d109c300f7c71e"
-  integrity sha512-XjbkgoeH8jhNHI0CC0odcR+ubZ8pvMBTtKU0ulnRDWKkrd+2mInOrltDxjF3tEdIx+Gq31l9fF1+vwsxCEmsaA==
+"@radixdlt/tx-parser@^2.1.12":
+  version "2.1.12"
+  resolved "https://registry.yarnpkg.com/@radixdlt/tx-parser/-/tx-parser-2.1.12.tgz#338f156e2f8fac1993ab9d557d69d03408c09cff"
+  integrity sha512-FAqWeWQB01QuaHZ4sWrL2sUZsicIJywPOUUOcmdw1fheIr/TC3QAtEdpN0hgHwdH+l5bRtx2ly8WZq5yr7iaeg==
   dependencies:
-    "@radixdlt/account" "^2.1.6"
-    "@radixdlt/crypto" "^2.1.3"
-    "@radixdlt/primitives" "^2.1.3"
+    "@radixdlt/account" "^3.0.3"
+    "@radixdlt/crypto" "^2.1.7"
+    "@radixdlt/primitives" "^3.0.3"
     "@radixdlt/uint256" "1.1.0"
     "@radixdlt/util" "1.0.29"
     long "^4.0.0"


### PR DESCRIPTION
Using https://github.com/radixdlt/radixdlt-javascript/pull/177 as a base for the SDK, I was able to work through a few more type changes.  We have the following errors to content with: 

**hardwareWalletConnection**:
https://github.com/radixdlt/olympia-wallet/blob/st/keystore-changes/src/composables/useWallet.ts#L269

```
ERROR in src/composables/useWallet.ts:269:50
TS2345: Argument of type '{ keyDerivation: HDPathRadixT; hardwareWalletConnection: Observable<Readonly<{ getVersion: () => Observable<Readonly<{ major: number; minor: number; patch: number; equals: (other: Readonly<...>) => boolean; toString: () => string; }>>; ... 4 more ...; makeSigningKey: (path: HDPathRadixT, verificationPrompt?: boolean...' is not assignable to parameter of type 'Readonly<{ keyDerivation: HWSigningKeyDerivation; hardwareWalletConnection: Observable<Readonly<{ getVersion: () => Observable<Readonly<{ major: number; minor: number; patch: number; equals: (other: Readonly<...>) => boolean; toString: () => string; }>>; ... 4 more ...; makeSigningKey: (path: HDPathRadixT, verificat...'.
  Types of property 'hardwareWalletConnection' are incompatible.
```

**to_validator is missing**:
https://github.com/radixdlt/olympia-wallet/blob/st/keystore-changes/src/composables/useTransactions.ts#L364

```
ERROR in src/composables/useTransactions.ts:364:5
TS2741: Property 'to_validator' is missing in type 'Readonly<{ from_validator: ValidatorAddressOrUnsafeInput; amount: AmountOrUnsafeInput; tokenIdentifier: ResourceIdentifierOrUnsafeInput; }>' but required in type 'Readonly<{ to_validator: ValidatorAddressOrUnsafeInput; amount: AmountOrUnsafeInput; tokenIdentifier: ResourceIdentifierOrUnsafeInput; }>'.
    362 |     let pollTXStatusTrigger: Observable<unknown>
    363 |     cleanupInputs()
  > 364 |     stakeInput.value = unstakeTokensInput
        |     ^^^^^^^^^^^^^^^^
    365 |     confirmationMode.value = 'unstake'
    366 |
    367 |     const buildTransferTokens = (): UnstakeOptions => ({
```


**Pending Transactions no longer have a txId**
https://github.com/radixdlt/olympia-wallet/blob/st/keystore-changes/src/composables/useTransactions.ts:283:58
```
ERROR in src/composables/useTransactions.ts:283:58
TS2339: Property 'txID' does not exist on type 'Readonly<{ blob: string; }>'.
    281 |           pendingTransactions.value = pendingTransactions.value.filter((pendingTxn: TransactionStateSuccess) => {
    282 |             const transactionState = pendingTxn.transactionState as unknown as FinalizedTransaction
  > 283 |             return txnID.toString() !== transactionState.txID.toString()
        |                                                          ^^^^
    284 |           })
    285 |           shouldShowConfirmation.value = false
    286 |           router.push('/wallet/history')
```

**Validators Request is no longer paginated?**
https://github.com/radixdlt/olympia-wallet/blob/st/keystore-changes/src/composables/useStaking.ts:32

```
ERROR in src/composables/useStaking.ts:32:50
TS2345: Argument of type '{ size: number; }' is not assignable to parameter of type 'ValidatorsRequest'.
  Object literal may only specify known properties, and 'size' does not exist in type 'ValidatorsRequest'.
    30 |     loadingUnstakes.value = false
    31 |   })
  > 32 |   const validatorSub = radix.ledger.validators({ size: 100 }).subscribe((validatorsRes: any) => {
       |                                                  ^^^^^^^^^
    33 |     validators.value = validatorsRes
    34 |     loadingValidators.value = false
    35 |   })
```

