### PR TITLE
fix: add missing password field to pin reset page

### DIFF
--- a/src/views/Settings/SettingsResetPin.vue
+++ b/src/views/Settings/SettingsResetPin.vue
@@ -8,18 +8,18 @@
       <br />
       {{ $t('settings.resetPinDisclaimerTwo') }}
     </div>
-    <FormField
-      type="password"
-      name="password"
-      class="w-96 mb-2"
-      :placeholder="$t('settings.passwordRequiredLabel')"
-      rules="required"
-      data-ci="create-wallet-passcode-input"
-      :validateOnInput="true"
-      @blur="activePin = 1"
-      @click="activePin = 0"
-    />
-    <FormErrorMessage name="password" />
+    <div class="w-96 mb-2">
+      <PasswordField
+        name="password"
+        :placeholder="$t('settings.passwordRequiredLabel')"
+        rules="required"
+        data-ci="create-wallet-passcode-input"
+        :validateOnInput="true"
+        @blur="activePin = 1"
+        @click="activePin = 0"
+      />
+      <FormErrorMessage name="password" />
+    </div>
 
     <div class="text-rGrayDark mt-12 mb-2">{{ $t('settings.pinLabel') }}</div>
     <pin-input
@@ -63,7 +63,7 @@ import { useForm } from 'vee-validate'
 import PinInput from '@/components/PinInput.vue'
 import { storePin, touchKeystore } from '@/actions/vue/create-wallet'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
-import FormField from '@/components/FormField.vue'
+import PasswordField from '@/components/PasswordField.vue'
 import { Result } from 'neverthrow'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
 import { Keystore, KeystoreT } from '@radixdlt/application'
@@ -77,8 +77,8 @@ interface ResetPinForm {
 const SettingsResetPin = defineComponent({
   components: {
     ButtonSubmit,
+    PasswordField,
     PinInput,
-    FormField,
     FormErrorMessage
   },
 


### PR DESCRIPTION
This PR updates a password field in the pin reset page.

<img width="1195" alt="Screen Shot 2021-12-03 at 12 43 59 PM" src="https://user-images.githubusercontent.com/8646176/144663735-91f3332a-f917-4cdc-b1c8-976534491d09.png">

