### PR TITLE
Samuel/rdx 221 add additional information to the wallet

### DIFF
--- a/src/components/MultipleAccountsDisclaimerModal.vue
+++ b/src/components/MultipleAccountsDisclaimerModal.vue
@@ -4,11 +4,11 @@
     :title="'Re-adding Accounts'"
   >
     <template v-slot:icon>
-      <svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg" class="transform rotate-45">
+      <svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
       <circle cx="25" cy="25" r="24" stroke="#052CC0" stroke-width="1.5"/>
       <path d="M25 14V36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-      <path d="M14 25H36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
+
     </template>
     <template v-slot:content>
       <p>If you previously used multiple accounts in the wallet, all of these accounts are associated to your seed phrase and will be recovered in the order you added them. However, the Desktop Wallet app cannot tell from the seed phrase how many accounts you had before or what you named them.</p>

--- a/src/components/MultipleAccountsDisclaimerModal.vue
+++ b/src/components/MultipleAccountsDisclaimerModal.vue
@@ -1,0 +1,47 @@
+<template>
+  <AppModal
+    :visible="isVisible"
+    :title="'Re-adding Accounts'"
+  >
+    <template v-slot:icon>
+      <svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg" class="transform rotate-45">
+      <circle cx="25" cy="25" r="24" stroke="#052CC0" stroke-width="1.5"/>
+      <path d="M25 14V36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M14 25H36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </template>
+    <template v-slot:content>
+      <p>If you previously used multiple accounts in the wallet, all of these accounts are associated to your seed phrase and will be recovered in the order you added them. However, the Desktop Wallet app cannot tell from the seed phrase how many accounts you had before or what you named them.</p>
+
+      <p>On the next screen you will be asked to provide a new name for the first account you used previously. After this, please use the "Add Account" feature to re-add, name, and access your other previous accounts. They will be re-added in exactly the same order as before, and will hold any tokens you held there previously.</p>
+      <div>
+        <AppButtonSubmit @click="handleClose">I Understand</AppButtonSubmit>
+      </div>
+    </template>
+  </AppModal>
+</template>
+
+<script lang="ts">
+import { defineComponent, Ref, ref } from 'vue'
+import AppModal from '@/components/AppModal.vue'
+import AppButtonSubmit from '@/components/AppButtonCancel.vue'
+
+export default defineComponent({
+  components: {
+    AppButtonSubmit,
+    AppModal
+  },
+
+  setup () {
+    const isVisible: Ref<boolean> = ref(true)
+    const handleClose = () => {
+      isVisible.value = false
+    }
+
+    return {
+      handleClose,
+      isVisible
+    }
+  }
+})
+</script>

--- a/src/components/MultipleAccountsDisclaimerModal.vue
+++ b/src/components/MultipleAccountsDisclaimerModal.vue
@@ -15,7 +15,9 @@
 
       <p>On the next screen you will be asked to provide a new name for the first account you used previously. After this, please use the "Add Account" feature to re-add, name, and access your other previous accounts. They will be re-added in exactly the same order as before, and will hold any tokens you held there previously.</p>
       <div>
-        <AppButtonSubmit @click="handleClose">I Understand</AppButtonSubmit>
+        <ButtonSubmit class="w-96" :disabled="disableSubmit">
+          I Understand
+        </ButtonSubmit>
       </div>
     </template>
   </AppModal>
@@ -24,11 +26,11 @@
 <script lang="ts">
 import { defineComponent, Ref, ref } from 'vue'
 import AppModal from '@/components/AppModal.vue'
-import AppButtonSubmit from '@/components/AppButtonCancel.vue'
+import ButtonSubmit from '@/components/ButtonSubmit.vue'
 
 export default defineComponent({
   components: {
-    AppButtonSubmit,
+    ButtonSubmit,
     AppModal
   },
 

--- a/src/components/MultipleAccountsDisclaimerModal.vue
+++ b/src/components/MultipleAccountsDisclaimerModal.vue
@@ -12,11 +12,10 @@
 
     </template>
     <template v-slot:content>
-      <p>If you previously used multiple accounts in the wallet, all of these accounts are associated to your seed phrase and will be recovered in the order you added them. However, the Desktop Wallet app cannot tell from the seed phrase how many accounts you had before or what you named them.</p>
-
-      <p>On the next screen you will be asked to provide a new name for the first account you used previously. After this, please use the "Add Account" feature to re-add, name, and access your other previous accounts. They will be re-added in exactly the same order as before, and will hold any tokens you held there previously.</p>
+      <p class="text-justify p-6">If you previously used multiple accounts in the wallet, all of these accounts are associated to your seed phrase and will be recovered in the order you added them. However, the Desktop Wallet app cannot tell from the seed phrase how many accounts you had before or what you named them.<br><br>
+      On the next screen you will be asked to provide a new name for the first account you used previously. After this, please use the "Add Account" feature to re-add, name, and access your other previous accounts. They will be re-added in exactly the same order as before, and will hold any tokens you held there previously.</p>
       <div>
-        <ButtonSubmit class="w-96" :disabled="false" @click="$emit('understood', true) ">
+        <ButtonSubmit class="w-50 my-5" :disabled="false" @click="$emit('understood', true) ">
           I Understand
         </ButtonSubmit>
       </div>

--- a/src/components/MultipleAccountsDisclaimerModal.vue
+++ b/src/components/MultipleAccountsDisclaimerModal.vue
@@ -7,6 +7,7 @@
       <svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
       <circle cx="25" cy="25" r="24" stroke="#052CC0" stroke-width="1.5"/>
       <path d="M25 14V36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M14 25H36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
 
     </template>
@@ -15,7 +16,7 @@
 
       <p>On the next screen you will be asked to provide a new name for the first account you used previously. After this, please use the "Add Account" feature to re-add, name, and access your other previous accounts. They will be re-added in exactly the same order as before, and will hold any tokens you held there previously.</p>
       <div>
-        <ButtonSubmit class="w-96" :disabled="disableSubmit">
+        <ButtonSubmit class="w-96" :disabled="false" @click="$emit('understood', true) ">
           I Understand
         </ButtonSubmit>
       </div>
@@ -39,11 +40,12 @@ export default defineComponent({
     const handleClose = () => {
       isVisible.value = false
     }
-
     return {
       handleClose,
       isVisible
     }
-  }
+  },
+
+  emits: ['understood']
 })
 </script>

--- a/src/views/RestoreWallet/index.vue
+++ b/src/views/RestoreWallet/index.vue
@@ -71,6 +71,7 @@
         @enteredPin="handleEnterPin"
       >
       </create-wallet-create-pin>
+      <multiple-accounts-disclaimer-modal/>
     </div>
   </div>
 </template>
@@ -83,6 +84,7 @@ import { initWallet, storePin } from '@/actions/vue/create-wallet'
 import RestoreWalletEnterMnemonic from './RestoreWalletEnterMnemonic.vue'
 import CreateWalletCreatePasscode from '@/views/CreateWallet/CreateWalletCreatePasscode.vue'
 import CreateWalletCreatePin from '@/views/CreateWallet/CreateWalletCreatePin.vue'
+import MultipleAccountsDisclaimerModal from '@/components/MultipleAccountsDisclaimerModal.vue'
 import { ref as rxRef } from '@nopr3d/vue-next-rx'
 import { saveDerivedAccountsIndex } from '@/actions/vue/data-store'
 import { useSidebar, useWallet } from '@/composables'
@@ -93,6 +95,7 @@ const RestoreWallet = defineComponent({
   components: {
     CreateWalletCreatePasscode,
     CreateWalletCreatePin,
+    MultipleAccountsDisclaimerModal,
     RestoreWalletEnterMnemonic,
     WizardHeading
   },


### PR DESCRIPTION
DRAFT PR(styling needs to be re-done. Began w/ `AppModal`  but will convert away from using `AppModal` due to how it looks.

[Demo](https://www.loom.com/share/fe3227396ec94ffabd64e654a8734bfd)

This PR adds an extra step between Pin confirmation and Wallet creation in the Restore Wallet flow. I've split up `handleCreatePin` logic as it seemed like it was constraining to use this function as the ending to the process. `handleCreatePin` now stores PIN upon confirmation. The actual wallet creation is being done in the interstitial screen where the user hits `I Understand`.

In this demo video, the first pass runs through the scenario where a perfect User inputs everything as planned. The next few passes run through a User who exits the app after confirming their PIN, just to show that wallet creation is dependent on the user hitting `I Understand`. If you see nothing happening, it's me inputting my seed phrase.

TODO:
- [ ] move all text to `text/index.ts` to be i18n-able
- [ ] change style so interstitial screen doesn't look like popup modal
- [ ] confirm that logic is correct