### PR TITLE
chore: update current stakes list warning styling

### DIFF
--- a/src/components/StakeListItem.vue
+++ b/src/components/StakeListItem.vue
@@ -15,7 +15,7 @@
                 </div>
                 <div v-if="notTopOneHundred" class="inline-flex items-center">
                   <span class="bg-rOrange w-2 h-2 rounded-full"></span>
-                  <span class="text-rOrange ml-2">{{ $t('staking.noEmissions') }}</span>
+                  <span class="text-rOrange ml-2">{{ $t('staking.notTopOneHundred') }}</span>
                 </div>
               </div>
               <a class="relative text-rBlack hover:text-rBlue group underline" v-if="validator.infoURL && validatedValidatorUrl" :href="validator.infoURL" target="__blank"> {{ validator.name }}

--- a/src/components/StakeListItem.vue
+++ b/src/components/StakeListItem.vue
@@ -14,6 +14,7 @@
                   <span class="text-rRed ml-2 mr-3">{{ $t('staking.unregistered') }}</span>
                 </div>
                 <div v-if="notTopOneHundred" class="inline-flex items-center">
+                  <span v-if="notTopOneHundred && !validator.registered"></span>
                   <span class="bg-rRed w-2 h-2 rounded-full"></span>
                   <span class="text-rRed ml-2">{{ $t('staking.notTopOneHundred') }}</span>
                 </div>

--- a/src/components/StakeListItem.vue
+++ b/src/components/StakeListItem.vue
@@ -14,8 +14,8 @@
                   <span class="text-rRed ml-2 mr-3">{{ $t('staking.unregistered') }}</span>
                 </div>
                 <div v-if="notTopOneHundred" class="inline-flex items-center">
-                  <span class="bg-rOrange w-2 h-2 rounded-full"></span>
-                  <span class="text-rOrange ml-2">{{ $t('staking.notTopOneHundred') }}</span>
+                  <span class="bg-rRed w-2 h-2 rounded-full"></span>
+                  <span class="text-rRed ml-2">{{ $t('staking.notTopOneHundred') }}</span>
                 </div>
               </div>
               <a class="relative text-rBlack hover:text-rBlue group underline" v-if="validator.infoURL && validatedValidatorUrl" :href="validator.infoURL" target="__blank"> {{ validator.name }}

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -169,7 +169,7 @@ const messages = {
       validatorPlaceholder: 'Enter validator address',
       validatorFeeLabel: 'Validator Fee',
       recentUptimeLabel: 'Recent Uptime',
-      unregistered: 'unregistered',
+      unregistered: 'Unregistered',
       notTopOneHundred: 'Not in top 100 validators'
     },
     confirmation: {

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -170,7 +170,7 @@ const messages = {
       validatorFeeLabel: 'Validator Fee',
       recentUptimeLabel: 'Recent Uptime',
       unregistered: 'unregistered',
-      noEmissions: 'no emissions'
+      notTopOneHundred: 'Not in top 100 validators'
     },
     confirmation: {
       transferFromLabel: 'Your address',


### PR DESCRIPTION
This PR:
- [x] changes warning text to `Not in top 100 validators`
- [x] Changes warning color to red
- [x] Capitalizes `unregistered`
- [x] Adds linebreak between multiple warnings

<img width="1193" alt="Screen Shot 2021-12-07 at 11 03 42 AM" src="https://user-images.githubusercontent.com/10618376/145064115-a84c3395-f305-4a33-8f4a-55ba3db88a89.png">