### PR TITLE
chore: add legal terms to home view

### DIFF
--- a/src/actions/electron/data-store.ts
+++ b/src/actions/electron/data-store.ts
@@ -89,7 +89,7 @@ export const forgetCustomNodeURL = (event: IpcMainInvokeEvent, nodeURL: string):
 }
 
 export const hideTokenType = (event: IpcMainInvokeEvent, tokenRRI: string): string[] => {
-  let hiddenTokens = store.get('hiddenTokens', []) as string[]
+  const hiddenTokens = store.get('hiddenTokens', []) as string[]
   store.set('hiddenTokens', [...hiddenTokens, tokenRRI])
   return [...hiddenTokens, tokenRRI]
 }

--- a/src/actions/electron/data-store.ts
+++ b/src/actions/electron/data-store.ts
@@ -101,6 +101,14 @@ export const unhideTokenType = (event: IpcMainInvokeEvent, tokenRRI: string): st
   return hiddenTokens
 }
 
+export const getAcceptedTos = (): boolean => {
+  return store.get('acceptedTos', false) as boolean
+}
+
+export const setAcceptedTos = (event: IpcMainInvokeEvent, value: boolean): void => {
+  store.set('acceptedTos', value)
+}
+
 export const getHiddenTokens = (): string[] => {
   const hiddenTokens = store.get('hiddenTokens', []) as string[]
   return hiddenTokens

--- a/src/actions/vue/data-store.ts
+++ b/src/actions/vue/data-store.ts
@@ -77,3 +77,11 @@ export const getHiddenTokens = async (): Promise<string[]> => {
   const data = await window.ipcRenderer.invoke('get-hidden-tokens')
   return data
 }
+
+export const getAcceptedTos = (): Promise<boolean> => new Promise((resolve) => {
+  resolve(window.ipcRenderer.invoke('get-accepted-tos'))
+})
+
+export const setAcceptedTos = (value: boolean): Promise<boolean> => new Promise((resolve) => {
+  resolve(window.ipcRenderer.invoke('set-accepted-tos', value))
+})

--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -19,3 +19,23 @@
 ::selection {
   @apply bg-rGreen text-white;
 }
+
+ol.decimal {
+  counter-reset: item;
+}
+
+ol.decimal > li:before {
+  display: inline-block;
+  margin-right: 16px;
+  content: counters(item, ".");
+  counter-increment: item;
+}
+
+ol.alpha {
+  counter-reset: list;
+}
+
+ol.alpha > li:before {
+  content:"(" counter(list, lower-alpha) ") ";
+  counter-increment: list;
+}

--- a/src/background.ts
+++ b/src/background.ts
@@ -14,6 +14,8 @@ import {
   saveDerivedAccountsIndex,
   saveHardwareAddress,
   saveLatestAccountAddress,
+  getAcceptedTos,
+  setAcceptedTos,
   getHardwareAddress,
   deleteHardwareAddress,
   resetStore,
@@ -143,6 +145,8 @@ ipcMain.handle('refresh-app', () => { win.reload() })
 ipcMain.handle('get-version-number', () => pkg.version)
 ipcMain.handle('download-latest-version', downloadUpdate)
 ipcMain.handle('get-is-update-available', getIsUpdateAvailable)
+ipcMain.handle('get-accepted-tos', getAcceptedTos)
+ipcMain.handle('set-accepted-tos', setAcceptedTos)
 // Exit cleanly on request from parent process in development mode.
 if (isDevelopment) {
   if (process.platform === 'win32') {

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -40,6 +40,7 @@ const messages = {
       restoreContent: 'You previously created a wallet and want to use your seed phrase to restore your access.',
       restoreButton: 'Restore a previous wallet',
       forgotPassword: 'I forgot my password',
+      acceptTos: 'Accept',
       deleteWalletTitle: 'Do you want to delete your current wallet?',
       deleteWalletContent: 'If you can\'t remember your password, you\'ll need to delete this local wallet and restore from your seed phrase or create a new wallet.',
       deleteChoiceContent: 'Are you sure you want to proceed?',

--- a/src/views/Home/HomeTos.vue
+++ b/src/views/Home/HomeTos.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="flex w-full">
+    <div class="flex flex-col justify-center items-center bg-white pt-8 pb-4 px-11 rounded mx-auto">
+      Todo: Add TOS
+      <button
+        @click.prevent="acceptTos"
+        role="button"
+        type="button"
+        class="inline-flex items-center justify-center border font-normal leading-snug rounded transition-colors px-6 py-4 w-72 w-96 bg-rGreen border-4 border-rGreen text-white hover:bg-rGreenDark cursor-pointer focus:ring-0"
+      >{{ $t('home.acceptTos')}}</button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+const HomeTos = defineComponent({
+  emits: ['acceptTos'],
+
+  methods: {
+    acceptTos () {
+      this.$emit('acceptTos')
+    }
+  }
+})
+
+export default HomeTos
+</script>

--- a/src/views/Home/HomeTos.vue
+++ b/src/views/Home/HomeTos.vue
@@ -1,12 +1,283 @@
 <template>
-  <div class="flex w-full">
-    <div class="flex flex-col justify-center items-center bg-white pt-8 pb-4 px-11 rounded mx-auto">
-      Todo: Add TOS
+  <div class="w-full h-full">
+    <div class="flex flex-col overflow-hidden bg-white pt-6 pb-4 px-8 rounded mx-auto
+    max-w-3xl h-modal max-h-modal">
+      <div class="text-rGrayDark mb-4">To proceed, you must accept the user terms below.</div>
+      <div class="overflow-scroll space-y-4 bg-rGrayLight rounded px-24 py-16
+      leading-5">
+        <h3 class="text-sm text-rGrayDark text-center">
+          Published by Radix Publishing Limited (RADIX) on 15 December 2021
+        </h3>
+        <h1 class="my-16 text-xl w-full text-center text-rGrayMed">
+          RADIX WALLET USER TERMS
+        </h1>
+        <p class="text-sm text-rGrayDark">
+          Radix Publishing Limited (RADIX) Registered Number 136972 and having its
+          registered office at First Floor, La Chasse Chambers, Ten La Chasse, La
+          Chasse, St. Helier, JE2 4UE, Jersey makes the RADIX WALLET SOFTWARE
+          available.
+        </p>
+        <p class="text-sm text-rGrayDark">By downloading the RADIX WALLET
+        SOFTWARE, you agree to use the RADIX WALLET in accordance with these TERMS
+        AND CONDITIONS of use.</p>
+        <p class="uppercase text-rRed">you acknowledge that
+        you have read all warnings and disclaimers which apply to THE download and
+        use of the RADIX WALLET SOFTWARE and that you are knowledgeable in the use
+        of wallet software.</p>
+        <ol class="space-y-6 decimal">
+          <li class="uppercase text-rGrayMed space-y-6">
+            <h3 class="inline-block">
+              downloading and using the RADIX WALLET SOFTWARE
+            </h3>
+            <p class="text-rRed uppercase">It is Your sole
+            responsibility to keep Your USER CREDENTIALS, devices’ passwords, pin,
+            seed phrase, private key, security measures and personal credentials
+            up to date, confidential and secure and not to disclose these to any
+            other person.</p>
+            <p class="text-rRed uppercase">The loss OF YOUR
+            PRIVATE KEY, and/or SEED PHRASE will cause permanent loss of access to
+            YOUR RADIX WALLET(S) and any and all TOKENS which may be accessible
+            via such wallet.</p>
+            <p class="text-rRed uppercase">has no
+            control or ability to control the operation of the RADIX WALLET
+            SOFTWARE which is published on an as is basis without warranty or
+            obligation.</p>
+            <p class="text-rRed uppercase">YOUR WALLET ID
+            MAY CONSTITUTE PERSONAL INFORMATION WHICH WILL IDENTIFY YOU
+            PERSONALLY. ONCE YOUR WALLET ID IS RECORDED ON A DISTRIBUTED LEDGER IT
+            CANNOT BE ERASED. BY USING THE RADIX WALLET, YOU CONSENT TO SUCH
+            USE.</p>
+            <p class="text-rRed uppercase">radix is not
+            responsible for any acts you undertake using the wallet.</p>
+          </li>
+          <li class="uppercase text-rGrayMed space-y-6">
+            <h3 class="inline-block">FUNCTIONALITY OF THE WALLET</h3>
+            <ol class="normal-case text-rGrayDark font-normal decimal space-y-6">
+              <li>The RADIX WALLET SOFTWARE enables:</li>
+                <ol class="alpha ml-8 space-y-6 my-6">
+                  <li>Generation of public – private keypairs;</li>
+                  <li>receipt or transmission of TOKENS;</li>
+                  <li>staking and un-staking of TOKENS.</li>
+                </ol>
+              <li>New versions of the RADIX WALLET SOFTWARE may be published from
+              time to time with additional or modified functionality.</li>
+            </ol>
+          </li>
+          <li class="uppercase text-rGrayMed space-y-6">
+            <h3 class="inline-block">RADIX WALLET LIMITATIONS OF USE</h3>
+            <ol class="normal-case text-rGrayDark font-normal decimal space-y-6">
+              <li>You may install and use the RADIX WALLET SOFTWARE (including any
+              updates) subject the following obligations. You must not:
+                <ol class="alpha ml-8 space-y-6 my-6">
+                  <li>remove or tamper with any RADIX copyright or other
+                  attribution notice;</li>
+                  <li>use the RADIX WALLET SOFTWARE in connection with any
+                  fraudulent or other illegal activity including:
+                  money-laundering, tax avoidance, or terrorist financing
+                  activities;</li>
+                  <li>use the RADIX WALLET SOFTWARE to impersonate another person
+                  or in a manner harmful to RADIX or any other person;</li>
+                  <li>violate any law, contract, third-party right or commit a
+                  tort by accessing or using the RADIX WALLET SOFTWARE;</li>
+                  <li>use the RADIX WALLET SOFTWARE to create or transmit false,
+                  inaccurate, or misleading information or conceal unlawful
+                  activity;</li>
+                  <li>use the RADIX WALLET SOFTWARE in any manner that could
+                  interfere with, disrupt, negatively affect or inhibit other
+                  users from using the RADIX WALLET or that could damage, disable,
+                  overburden or impair the functioning of the RADIX WALLET
+                  SOFTWARE in any manner;</li>
+                  <li>use any robot, spider, crawler, scraper or other automated
+                  process or interface not provided by RADIX to access the RADIX
+                  WALLET SOFTWARE or to extract or manipulate data; or</li>
+                  <li>attempt to circumvent any content filtering or seek to
+                  access any service or area of the RADIX WALLET SOFTWARE that you
+                  are not authorized to access.</li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li class="uppercase text-rGrayMed space-y-6">
+            <h3 class="inline-block">SECURITY OF YOUR radix wallet</h3>
+            <p class="normal-case text-rGrayDark font-normal">
+            You must not permit, either directly or indirectly, any third party
+            to access or use your RADIX WALLET neither may you use your RADIX
+            WALLET SOFTWARE to provide escrow services nor to obfuscate
+            transmission of tokens by others.</p>
+          </li>
+          <li class="uppercase text-rGrayMed space-y-6">
+            <h3 class="inline-block">WAIVER</h3>
+            <ol class="normal-case text-rGrayDark font-normal decimal space-y-6">
+              <li>RADIX makes no warranties, expressed or implied, and hereby
+              disclaims and negates all warranties, including without limitation,
+              implied warranties or conditions of merchantability, fitness for a
+              particular purpose, or non-infringement of intellectual property
+              rights or other violation of rights.</li>
+              <li>
+                You forever waive and release all rights and claims known and
+                unknown, present and future, arising out of the use, possession,
+                control and access to the RADIX WALLET SOFTWARE including without
+                limitation any loss, damage or claim arising out of:
+                <ol class="alpha ml-8 space-y-6 my-6">
+                  <li>the operation or use of the RADIX WALLET SOFTWARE and any
+                  failure in the security, operation, allocation, custody, return
+                  and or transfer of TOKENS;</li>
+                  <li>any loss of TOKENS or the ability to control the possession
+                  use receipt or transmission thereof caused by logic errors,
+                  bugs, or security breach relating to the RADIX WALLET SOFTWARE
+                  or its interaction or failure to interact as anticipated with
+                  any public ledger, node or third-party software;</li>
+                  <li>any loss of ownership, access or control of TOKENS, SEED
+                  PHRASE, PIN, PRIVATE KEY, to a RADIX WALLET;</li>
+                  <li>any loss of control, ownership, access to or control of the
+                  RADIX WALLET SOFTWARE resulting from action by a statutory body,
+                  regulatory authority or enforcement agency including but not
+                  limited to changes in law or regulation, or decision order or
+                  award by any court relating to the operation or use of the RADIX
+                  WALLET SOFTWARE including orders relating to the seizure of
+                  TOKENS, WALLETS, or freezing of accounts;</li>
+                  <li>any loss of TOKENS resulting from the transmission of TOKENS
+                  to an incorrect WALLET address;</li>
+                  <li>errors or omissions, timing differences, failures in systems
+                  or processes of the RADIX WALLET SOFTWARE;</li>
+                  <li>failure, delay or error in any telecommunications network or
+                  computer system including any algorithm, logic or code errors,
+                  whether human or otherwise;</li>
+                  <li>failures, errors, hacking, corruption, loss of access, loss
+                  of control, termination of services, or damage to any device to
+                  which the RADIX WALLET SOFTWARE is downloaded;</li>
+                  <li>hacking, destruction or unlawful interference with any
+                  computer system, network (or part thereof) or failure of any
+                  security protocol, including the unlawful introduction of
+                  malware, ransomware, malicious code of any kind into any system
+                  or process operated by or on behalf of RADIX or a third-party
+                  providing services to RADIX, including without limit the theft
+                  destruction or interference with and hardware, physical security
+                  devices, codes, or passwords;</li>
+                  <li>misconduct, error, omission, system failure, failure or
+                  neglect including any failure in transmission, misappropriation
+                  of tokens, hacking;</li>
+                  <li>any act of any third-party, government or regulatory action;
+                  or</li>
+                  <li>enforcement action taken by any regulatory, government
+                  agency, or tax authority or relating to or arising out of the
+                  use of the RADIX SERVICES or the possession, use, access or
+                  control of a RADIX WALLET;</li>
+                </ol>
+                save where any such loss is attributable to fraud on the part of
+                RADIX.
+              </li>
+            </ol>
+          </li>
+          <li class="uppercase text-rGrayMed space-y-6">
+            <h3 class="inline-block">INDEMNITY</h3>
+            <p class="text-rRed">You hereby fully and effectively
+            indemnify and hold safe RADIX and its DIRECTORS officers employees and
+            CONTRACTORS AGAINST all claims demands, taxes levies and fines, legal
+            fees, expenses, and costs relating from arising from the possession,
+            use, access and function of the RADIX WALLET SOFTWARE and/or any use
+            made by You and any successor in title of any the RADIX WALLET
+            SOFTWARE to the fullest extent permitted by law.</p>
+            <p class="text-rRed">Such indemnity shall include all
+            legal costs and expenses of commencing or defending any proceedings
+            relating thereto (on a full indemnity basis).</p>
+          </li>
+          <li class="uppercase text-rGrayMed space-y-6">
+            <h3 class="inline-block">MISCELLANEOUS TERMS</h3>
+            <ol class="normal-case text-rGrayDark font-normal decimal space-y-6">
+              <li>The right to use the RADIX WALLET SOFTWARE is personal to you,
+              you may not transfer or assign, or delegate, the benefit of this
+              license to any third party.</li>
+              <li>No failure to enforce any of RADIX’s rights under these TERMS
+              AND CONDITIONS or otherwise, will result in a waiver of such
+              right(s).</li>
+              <li>If any provision of these TERMS AND CONDITIONS is found to be
+              unenforceable, all other provisions shall remain unaffected.</li>
+            </ol>
+          </li>
+          <li class="uppercase text-rGrayMed space-y-6">
+            <h3 class="inline-block">ENTIRE AGREEMENT</h3>
+            <ol class="normal-case text-rGrayDark font-normal decimal space-y-6">
+              <li>These TERMS AND CONDITIONS shall constitute the entire agreement
+              between the parties and supersede and extinguish all previous
+              agreements, promises, assurances, warranties, representations, and
+              understandings between the parties, whether written or oral,
+              relating to its subject matter.</li>
+              <li>Save as expressly provided for here in each party agrees that it
+              shall have no claim for innocent or negligent misrepresentation or
+              negligent misstatement based on any statement in these TERMS AND
+              CONDITIONS or such statement or representation which has been made
+              by either party prior to downloading or use of the RADIX WALLET
+              SOFTWARE.</li>
+            </ol>
+          </li>
+          <li class="uppercase text-rGrayMed space-y-6">
+            <h3 class="inline-block">THIRD PARTY RIGHTS</h3>
+            <p class="normal-case text-rGrayDark font-normal">
+            No third-party shall be entitled to enforce the terms of this
+            Agreement.</p>
+          </li>
+          <li class="uppercase text-rGrayMed space-y-6">
+            <h3 class="inline-block">EXCLUSION OF LIABILITY</h3>
+            <p class="text-rRed">radix EXCLUDES ALL liablity and makes no REPRESENTATIONS,
+            WARRANTIES noR provides ANY GUARANTEE, WHETHER IMPLIED OR EXPRESS AND
+            WHETHER ARISING BY LAW, CONTRACT OR FROM A COURSE OF DEALINGS as to
+            the operation use function or performance of the radix wallet TO THE
+            FULLEST EXTENT PERMITTED BY LAW for any loss or damage, potential or
+            actual, resulting from lost or disclosed private key, seed phrase, pin
+            or password.</p>
+            <p class="text-rRed text-center">------</p>
+            <p class="text-rRed">to the extent any fiduciary duty
+            may be implied all liability for breach of such duty is excluded.</p>
+            <p class="text-rRed">RADIX’S liablity SHALL NOT in any
+            event EXCEED THE SUM OF £150 for all use you make of the wallet
+            software.</p>
+          </li>
+          <li class="uppercase text-rGrayMed space-y-6">
+            <h3 class="inline-block">GOVERNING LAW AND JURISDICTION</h3>
+            <ol class="normal-case text-rGrayDark font-normal decimal space-y-6">
+              <li>These TERMS AND CONDITIONS and any dispute or claim arising out
+              of or in connection with them their subject matter or formation
+              (including non-contractual disputes or claims) shall be governed by
+              and construed in accordance with the law of England and Wales.</li>
+              <li>The COURTS OF ENGLAND AND WALES shall have exclusive
+              jurisdiction to settle any dispute or claims (including
+              non-contractual disputes or claims) arising out of or in connection
+              with these TERMS AND CONDITIONS or in relation to their
+              formation.</li>
+              <li>The situs of any agreement formed in accordance with these TERMS
+              AND CONDITIONS and of all debts assets, property (including the
+              situs of all property in any TOKEN, cryptographic keys created
+              stored or transmitted using the RADIX WALLET SOFTWARE shall be
+              deemed to be England.</li>
+              <li>The performance of all obligations and accrual of causes of
+              action arising out of the operation, use and functioning of RADIX
+              WALLET SOFTWARE the location and exchange of all property and
+              assets, TOKENS, rights and causes of action relating thereto or the
+              subject thereof are deemed to have been made performed and located
+              in ENGLAND, irrespective of the residence, domicile, location,
+              principal place of business or location, place of business of any
+              third-party beneficiary or where the benefit accrues or any loss is
+              realised.</li>
+              <li>Nothing in this Clause 11 shall limit or exclude any rights of
+              RADIX to enforce any rights in in any territory in relation to
+              intellectual property owned by or licensed to RADIX in accordance
+              with the laws applicable to such rights which subsist in any
+              territory where such intellectual property rights are owned or used
+              (whether such use is authorised or not).</li>
+              <li>All operation of conflict of laws is excluded.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
       <button
         @click.prevent="acceptTos"
         role="button"
         type="button"
-        class="inline-flex items-center justify-center border font-normal leading-snug rounded transition-colors px-6 py-4 w-72 w-96 bg-rGreen border-4 border-rGreen text-white hover:bg-rGreenDark cursor-pointer focus:ring-0"
+        class="inline-flex items-center justify-center border font-normal
+        leading-snug rounded transition-colors px-6 py-3 w-28 bg-rGreen
+        border-4 border-rGreen text-white hover:bg-rGreenDark cursor-pointer
+        focus:ring-0 mt-4 self-end"
       >{{ $t('home.acceptTos')}}</button>
     </div>
   </div>

--- a/src/views/Home/index.vue
+++ b/src/views/Home/index.vue
@@ -1,58 +1,64 @@
 <template>
-  <div data-ci="home-view" class="flex flex-row min-h-screen" :class="{'items-center': hasWallet}" v-if="!loading">
-    <template v-if="hasWallet">
-      <img alt="Radix DLT Logo" src="../../assets/logo.svg" class="absolute inset-0 mt-6 mx-4">
-      <div v-if="hasWallet == null" class="flex w-full justify-center items-center">
-        <loading-icon/>
-      </div>
-
-      <div
-        v-if="hasWallet == true"
-        class="bg-white pt-8 pb-4 px-11 max-w-lg rounded mx-auto"
-      >
-        <home-enter-passcode
-          @forgotPassword="forgotPassword"
-          ref="enterPasscodeComponent"
-        />
-      </div>
-      <home-locked-modal :open="modal === 'locked-out'" @close="closeModal"/>
-      <home-forgot-password
-        :open="modal === 'forgot-password'"
-        @close="closeModal"
-        @resetAndCreate="resetAndCreate"
-        @resetAndRestore="resetAndRestore"
-      />
+  <div data-ci="home-view" class="flex flex-row min-h-screen"
+  :class="{'items-center': hasWallet || !acceptedTos }" v-if="!loading">
+    <template v-if="!acceptedTos">
+      <home-tos @acceptTos="acceptTos" />
     </template>
-
     <template v-else>
-      <div class="w-72 mx-5 py-8">
-        <div class="flex">
-          <img alt="Radix DLT Logo" src="../../assets/logo.svg" class="w-30 mb-8">
+      <template v-if="hasWallet">
+        <img alt="Radix DLT Logo" src="../../assets/logo.svg" class="absolute inset-0 mt-6 mx-4">
+        <div v-if="hasWallet == null" class="flex w-full justify-center items-center">
+          <loading-icon/>
         </div>
-        <div class="text-white font-normal text-normal leading-snug mr-12">
-          <div class="text-lg"> {{ $t('home.welcomeOne') }} </div>
-          <div class="text-sm mt-3"> {{ $t('home.welcomeFour') }} </div>
-          <div class="text-sm mt-3"> {{ $t('home.welcomeFive') }} </div>
+
+        <div
+          v-if="hasWallet == true"
+          class="bg-white pt-8 pb-4 px-11 max-w-lg rounded mx-auto"
+        >
+          <home-enter-passcode
+            @forgotPassword="forgotPassword"
+            ref="enterPasscodeComponent"
+          />
         </div>
-      </div>
-      <div class="py-8 flex flex-row w-full">
-        <div v-if="unableToConnect" class="bg-white rounded py-9 px-11 flex max-w-sm self-start">
-          <div class="flex flex-col gap-4">
-            <p>
-              Sorry, the Radix Desktop Wallet cannot currently connect to the Radix mainnet network.  Please check your
-              internet connection, or check our <a class="text-rBlue" href="https://status.radixdlt.com">network status page</a> for known connection issues.
-            </p>
-            <p>
-              If you have further problems, please contact us at <a class="text-rBlue" href="mailto:hello@radixdlt.com">hello@radixdlt.com</a>
-            </p>
+        <home-locked-modal :open="modal === 'locked-out'" @close="closeModal"/>
+        <home-forgot-password
+          :open="modal === 'forgot-password'"
+          @close="closeModal"
+          @resetAndCreate="resetAndCreate"
+          @resetAndRestore="resetAndRestore"
+        />
+      </template>
+
+      <template v-else>
+        <div class="w-72 mx-5 py-8">
+          <div class="flex">
+            <img alt="Radix DLT Logo" src="../../assets/logo.svg" class="w-30 mb-8">
+          </div>
+          <div class="text-white font-normal text-normal leading-snug mr-12">
+            <div class="text-lg"> {{ $t('home.welcomeOne') }} </div>
+            <div class="text-sm mt-3"> {{ $t('home.welcomeFour') }} </div>
+            <div class="text-sm mt-3"> {{ $t('home.welcomeFive') }} </div>
           </div>
         </div>
-        <div v-else-if="!connected" class="bg-white rounded p-11 flex items-center gap-4 justify-center self-start">
-          <wallet-loading />
-          Connecting...
+        <div class="py-8 flex flex-row w-full">
+          <div v-if="unableToConnect" class="bg-white rounded py-9 px-11 flex max-w-sm self-start">
+            <div class="flex flex-col gap-4">
+              <p>
+                Sorry, the Radix Desktop Wallet cannot currently connect to the Radix mainnet network.  Please check your
+                internet connection, or check our <a class="text-rBlue" href="https://status.radixdlt.com">network status page</a> for known connection issues.
+              </p>
+              <p>
+                If you have further problems, please contact us at <a class="text-rBlue" href="mailto:hello@radixdlt.com">hello@radixdlt.com</a>
+              </p>
+            </div>
+          </div>
+          <div v-else-if="!connected" class="bg-white rounded p-11 flex items-center gap-4 justify-center self-start">
+            <wallet-loading />
+            Connecting...
+          </div>
+          <home-create-and-restore v-else />
         </div>
-        <home-create-and-restore v-else />
-      </div>
+      </template>
     </template>
   </div>
 </template>
@@ -61,6 +67,7 @@
 import { defineComponent, Ref, ref } from 'vue'
 import HomeCreateAndRestore from './HomeCreateAndRestore.vue'
 import HomeEnterPasscode from './HomeEnterPasscode.vue'
+import HomeTos from './HomeTos.vue'
 import HomeLockedModal from './HomeLockedModal.vue'
 import HomeForgotPassword from './HomeForgotPassword.vue'
 import LoadingIcon from '@/components/LoadingIcon.vue'
@@ -70,12 +77,14 @@ import { firstValueFrom } from 'rxjs'
 import { Network } from '@radixdlt/application'
 import WalletLoading from '@/views/Wallet/WalletLoading.vue'
 import { hasKeystore } from '@/actions/vue/create-wallet'
+import { getAcceptedTos, setAcceptedTos } from '@/actions/vue/data-store'
 const Home = defineComponent({
   components: {
     HomeCreateAndRestore,
     HomeEnterPasscode,
     HomeLockedModal,
     HomeForgotPassword,
+    HomeTos,
     LoadingIcon,
     WalletLoading
   },
@@ -87,6 +96,10 @@ const Home = defineComponent({
     const { modal, setModal } = useHomeModal()
     const router = useRouter()
     const { hasWallet, resetWallet, radix, setNetwork } = useWallet(router)
+    const acceptedTos: Ref<boolean> = ref(false)
+    getAcceptedTos().then((res) => {
+      acceptedTos.value = res
+    })
     hasKeystore().then((val: boolean) => {
       loading.value = false
       if (!val) {
@@ -111,6 +124,7 @@ const Home = defineComponent({
       modal,
       connected,
       unableToConnect,
+      acceptedTos,
 
       closeModal () {
         setModal(null)
@@ -126,6 +140,11 @@ const Home = defineComponent({
 
       resetAndRestore () {
         resetWallet('restore-wallet')
+      },
+
+      acceptTos () {
+        setAcceptedTos(true)
+        acceptedTos.value = true
       }
     }
   }


### PR DESCRIPTION
This PR adds the TOS to the home screen, displaying it if it has not been accepted yet. Once it's been accepted, the value is added to the store; if the terms ever need to change, we should be able to add a migration to reset that field to 'false' for all users again, forcing them to accept the new terms before use.

Below are a few screenshots of the implementation:
<img width="1198" alt="Screen Shot 2021-12-07 at 8 08 19 PM" src="https://user-images.githubusercontent.com/8646176/145141522-a17db319-8a1e-4c7b-be7e-6505a2833cad.png">
<img width="1192" alt="Screen Shot 2021-12-07 at 8 08 31 PM" src="https://user-images.githubusercontent.com/8646176/145141524-0a869723-f846-487b-8d5b-7f7a6d832d46.png">
<img width="1197" alt="Screen Shot 2021-12-07 at 8 08 38 PM" src="https://user-images.githubusercontent.com/8646176/145141531-1d4a0630-a406-4b82-aa59-f7ac0a33f1be.png">


