### PR TITLE
fix: password field on login should auto focus

### DIFF
--- a/src/views/Home/HomeEnterPasscode.vue
+++ b/src/views/Home/HomeEnterPasscode.vue
@@ -107,7 +107,7 @@ const HomeEnterPasscode = defineComponent({
   },
 
   mounted () {
-    const passEl = document.getElementById('password')
+    const passEl = document.querySelector<HTMLInputElement>('input[type=\'password\']')
     if (passEl) passEl.focus()
   },
 


### PR DESCRIPTION
The password fields are wrapped in a div to help display the caps lock warning, and as a result the id was being placed on that parent div and not the actual input. The query selector fixes that.