### PR TITLE
Transaction subjects

### DIFF
--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -271,7 +271,7 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
       pollTXStatusTrigger: interval(1000),
       message
     })
-
+    userDidConfirm.next(false)
     shouldShowConfirmation.value = true
 
     transactionSubs.add(completion.subscribe(handleTransactionCompleted))
@@ -290,6 +290,7 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
       pollTXStatusTrigger: interval(1000)
     })
 
+    userDidConfirm.next(false)
     shouldShowConfirmation.value = true
 
     transactionSubs.add(completion.subscribe(handleTransactionCompleted))
@@ -308,6 +309,7 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
       pollTXStatusTrigger: interval(1000)
     })
 
+    userDidConfirm.next(false)
     shouldShowConfirmation.value = true
 
     transactionSubs.add(completion.subscribe(handleTransactionCompleted))

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -271,7 +271,7 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
       pollTXStatusTrigger: interval(1000),
       message
     })
-    userDidConfirm.next(false)
+
     shouldShowConfirmation.value = true
 
     transactionSubs.add(completion.subscribe(handleTransactionCompleted))
@@ -290,7 +290,6 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
       pollTXStatusTrigger: interval(1000)
     })
 
-    userDidConfirm.next(false)
     shouldShowConfirmation.value = true
 
     transactionSubs.add(completion.subscribe(handleTransactionCompleted))
@@ -309,7 +308,6 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
       pollTXStatusTrigger: interval(1000)
     })
 
-    userDidConfirm.next(false)
     shouldShowConfirmation.value = true
 
     transactionSubs.add(completion.subscribe(handleTransactionCompleted))


### PR DESCRIPTION
Co-authored-by: Alex Stela <xstelea>

From @xstelea 
I refactored watchUserDidConfirm and moved it outside of useTransactionsfunction.
In the confirm transaction modal there are at least 3 components rendered that import and use useTransactions , and each is subscribed to userConfirmation. This causes multiple subscriptions to trigger when the user confirms the transaction, resulting in multiple finalize& submit requests