### PR TITLE
chore: api error handling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -57,7 +57,7 @@ const App = defineComponent({
     const isApiError: ComputedRef<boolean> = computed(() => {
       const latest: any = appErrors.value[appErrors.value.length - 1]
       if (latest === null) return false
-      return latest.error?.details?.type
+      return latest.type === 'api'
     })
 
     const errorsCount: ComputedRef<number> = computed(() => appErrors.value.length)

--- a/src/App.vue
+++ b/src/App.vue
@@ -31,7 +31,6 @@ import { useWallet, useErrors } from './composables'
 import ErrorModalGeneric from '@/components/ErrorModalGeneric.vue'
 import ErrorModalTransactionBuilding from '@/components/ErrorModalTransactionBuilding.vue'
 import ErrorModalTransactionConfirming from '@/components/ErrorModalTransactionConfirming.vue'
-import { ClientAppErrorT } from './composables/useErrors'
 
 const App = defineComponent({
   components: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,8 +3,13 @@
     <div class="bg-rBlue w-1/2 h-tallest origin-center transform rotate-45 absolute z-0 top-0 left-0 -translate-x-1/2 -translate-y-1/2"></div>
     <div class="relative z-10 min-h-screen">
       <template v-if="latestError">
+        <ErrorModalApi
+          v-if="isApiError"
+          :error="latestError.error"
+          :errorsCount="errorsCount"
+        />
         <ErrorModalTransactionBuilding
-          v-if="latestError.type === 'TRANSACTION-BUILDING'"
+          v-else-if="latestError.type === 'TRANSACTION-BUILDING'"
           :error="latestError.error"
           :errorsCount="errorsCount"
         />
@@ -29,6 +34,7 @@ import { computed, ComputedRef, defineComponent } from 'vue'
 import { useRouter } from 'vue-router'
 import { useWallet, useErrors } from './composables'
 import ErrorModalGeneric from '@/components/ErrorModalGeneric.vue'
+import ErrorModalApi from '@/components/ErrorModalApi.vue'
 import ErrorModalTransactionBuilding from '@/components/ErrorModalTransactionBuilding.vue'
 import ErrorModalTransactionConfirming from '@/components/ErrorModalTransactionConfirming.vue'
 
@@ -36,7 +42,8 @@ const App = defineComponent({
   components: {
     ErrorModalGeneric,
     ErrorModalTransactionBuilding,
-    ErrorModalTransactionConfirming
+    ErrorModalTransactionConfirming,
+    ErrorModalApi
   },
 
   setup () {
@@ -47,12 +54,19 @@ const App = defineComponent({
     const latestError: ComputedRef<Error | null> = computed(() => {
       return appErrors.value[appErrors.value.length - 1]
     })
+    const isApiError: ComputedRef<boolean> = computed(() => {
+      const latest: any = appErrors.value[appErrors.value.length - 1]
+      if (latest === null) return false
+      return latest.error?.details?.type
+    })
+
     const errorsCount: ComputedRef<number> = computed(() => appErrors.value.length)
 
     return {
       appErrors,
       errorsCount,
-      latestError
+      latestError,
+      isApiError
     }
   }
 })

--- a/src/components/ErrorModalApi.vue
+++ b/src/components/ErrorModalApi.vue
@@ -75,7 +75,7 @@ export default defineComponent({
     const error = toRef(props, 'error')
     const router = useRouter()
     const { radix } = useWallet(router)
-    const { clearLatestError, isApiError } = useErrors(radix)
+    const { clearLatestError, isKnownApiError } = useErrors(radix)
     const { t } = useI18n()
 
     watch((error), (newErrorVal) => {
@@ -89,7 +89,7 @@ export default defineComponent({
       if (props.errorsCount <= 1) isVisible.value = false
     }
     const type: string = error.value?.details?.type
-    const showDetails = !isApiError(type)
+    const showDetails = !isKnownApiError(type)
     let errorMsg: string = t('apiErrors.unknown')
     let errorTitle: string = t('apiErrors.unknown')
     if (!showDetails) {

--- a/src/components/ErrorModalApi.vue
+++ b/src/components/ErrorModalApi.vue
@@ -1,0 +1,89 @@
+<template>
+  <AppModal
+    :visible="isVisible"
+    :title="errorMsg"
+  >
+    <template v-slot:icon>
+      <svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg" class="transform rotate-45">
+      <circle cx="25" cy="25" r="24" stroke="#052CC0" stroke-width="1.5"/>
+      <path d="M25 14V36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M14 25H36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </template>
+    <template v-slot:content>
+      <div v-if="errorsCount > 1" class="absolute top-0 right-0">
+        <div class="bg-rRed rounded-full inline-block px-2 py-0.5 m-2 text-white text-sm">{{ errorsCount }}</div>
+      </div>
+      <div v-if="showDetails">
+        <p class="mb-2">Error Code: {{ error.code }}</p>
+        <p class="mb-2">Error Type: {{ error.details.type }}</p>
+        <p class="mb-5">{{ error.message }}</p>
+      </div>
+      <div class="flex flex-row space-x-5 justify-center">
+        <AppButtonCancel @click="handleClose" class="w-44">{{ $t('errors.closeModal') }}</AppButtonCancel>
+        <AppButtonCancel @click="refreshApp" class="w-44">{{ $t('errors.refreshApp') }}</AppButtonCancel>
+      </div>
+    </template>
+  </AppModal>
+</template>
+
+<script lang="ts">
+import { defineComponent, Ref, ref, toRef, watch } from 'vue'
+import AppButtonCancel from '@/components/AppButtonCancel.vue'
+import AppModal from '@/components/AppModal.vue'
+import { useRouter } from 'vue-router'
+import { useWallet, useErrors } from '@/composables'
+import { refreshApp } from '@/actions/vue/general'
+import { useI18n } from 'vue-i18n'
+
+export default defineComponent({
+  components: {
+    AppButtonCancel,
+    AppModal
+  },
+
+  props: {
+    error: {
+      type: Object,
+      required: true
+    },
+    errorsCount: {
+      type: Number,
+      required: true
+    }
+  },
+
+  setup (props) {
+    const isVisible: Ref<boolean> = ref(true)
+    const updateVisible = () => { isVisible.value = !isVisible.value }
+    const error = toRef(props, 'error')
+    const router = useRouter()
+    const { radix } = useWallet(router)
+    const { clearLatestError, isApiError } = useErrors(radix)
+    const { t } = useI18n()
+
+    watch((error), (newErrorVal) => {
+      if (newErrorVal) isVisible.value = true
+    })
+
+    const handleClose = () => {
+      clearLatestError()
+      // Clear latest error but leave modal open if there are more errors in the list
+      // Close modal if this is the last error
+      if (props.errorsCount <= 1) isVisible.value = false
+    }
+    const type: string = error.value?.details?.type
+    const showDetails = !isApiError(type)
+    const errorMsg: string = showDetails ? 'Unknown Api Error' : t(`apiErrors.${type}`)
+
+    return {
+      handleClose,
+      isVisible,
+      refreshApp,
+      updateVisible,
+      errorMsg,
+      showDetails
+    }
+  }
+})
+</script>

--- a/src/components/ErrorModalApi.vue
+++ b/src/components/ErrorModalApi.vue
@@ -87,24 +87,30 @@ export default defineComponent({
     }
     const type: string = error.value?.details?.type
     const showDetails = !isApiError(type)
-    let errorMsg: string
-    if (showDetails) {
-      errorMsg = 'Unexpected Error'
-    } else if (type === 'BelowMinimumStakeError') {
-      const minimum = error.value.details?.minimum_amount?.value
-      const displayMinimum = minimum ? asBigNumber(minimum) : '10'
-      errorMsg = t(`apiErrors.${type}`, { minimum: displayMinimum })
-    } else if (type === 'NotEnoughTokensForUnstakeError') {
-      const requested = Amount.fromUnsafe(error.value.details.requested_amount.value)._unsafeUnwrap()
-      const staked = Amount.fromUnsafe(error.value.details.stake.delegated_stake.value)._unsafeUnwrap()
-      const pending = Amount.fromUnsafe(error.value.details.pending_stake.delegated_stake.value)._unsafeUnwrap()
-      if (requested > add(staked, pending)) {
-        errorMsg = t(`apiErrors.${type}.default`)
-      } else {
-        errorMsg = t(`apiErrors.${type}.pending`, { pending: asBigNumber(pending) })
+    let errorMsg: string = t('apiErrors.unknown')
+    if (!showDetails) {
+      switch (type) {
+        case 'BelowMinimumStakeError': {
+          const minimum = error.value.details?.minimum_amount?.value
+          const displayMinimum = minimum ? asBigNumber(minimum) : '90'
+          errorMsg = t('apiErrors.BelowMinimumStakeError', { minimum: displayMinimum })
+          break
+        }
+        case 'NotEnoughTokensForUnstakeError': {
+          const requested = Amount.fromUnsafe(error.value.details.requested_amount.value)._unsafeUnwrap()
+          const staked = Amount.fromUnsafe(error.value.details.stake.delegated_stake.value)._unsafeUnwrap()
+          const pending = Amount.fromUnsafe(error.value.details.pending_stake.delegated_stake.value)._unsafeUnwrap()
+          if (requested > add(staked, pending)) {
+            errorMsg = t('apiErrors.NotEnoughTokensForUnstakeError.requested')
+            break
+          }
+          errorMsg = t('apiErrors.NotEnoughTokensForUnstakeError.pending', { pending: asBigNumber(pending) })
+          break
+        }
+        default:
+          errorMsg = t(`apiErrors.${type}`)
+          break
       }
-    } else {
-      errorMsg = t(`apiErrors.${type}`)
     }
 
     return {

--- a/src/components/ErrorModalApi.vue
+++ b/src/components/ErrorModalApi.vue
@@ -15,8 +15,10 @@
         <div class="bg-rRed rounded-full inline-block px-2 py-0.5 m-2 text-white text-sm">{{ errorsCount }}</div>
       </div>
       <div v-if="showDetails">
-        <p class="mb-2">Please contact support at <a class="text-rBlue"
-        href="mailto:hello@radixdlt.com">hello@radixdlt.com</a> and provide the following.
+        <p class="mb-2 px-12">
+          {{ $t('apiErrors.contactCopyOne') }}
+          <a class="text-rBlue" href="mailto:hello@radixdlt.com">hello@radixdlt.com</a>
+          {{ $t('apiErrors.contactCopyTwo') }}
         </p>
         <p class="mb-2 flex justify-between">
           <span class="flex-1">Error: {{ error.details.type }}</span>

--- a/src/components/ErrorModalApi.vue
+++ b/src/components/ErrorModalApi.vue
@@ -1,7 +1,7 @@
 <template>
   <AppModal
     :visible="isVisible"
-    :title="errorMsg"
+    :title="errorTitle"
   >
     <template v-slot:icon>
       <svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg" class="transform rotate-45">
@@ -26,6 +26,9 @@
           <span class="flex-1">Trace ID: {{ error.trace_id }}</span>
           <click-to-copy :address="error.trace_id" />
         </p>
+      </div>
+      <div v-else>
+        <p class="mb-5">{{ errorMsg }}</p>
       </div>
       <div class="flex flex-row space-x-5 justify-center">
         <AppButtonCancel @click="handleClose" class="w-44">{{ $t('errors.closeModal') }}</AppButtonCancel>
@@ -88,12 +91,14 @@ export default defineComponent({
     const type: string = error.value?.details?.type
     const showDetails = !isApiError(type)
     let errorMsg: string = t('apiErrors.unknown')
+    let errorTitle: string = t('apiErrors.unknown')
     if (!showDetails) {
       switch (type) {
         case 'BelowMinimumStakeError': {
           const minimum = error.value.details?.minimum_amount?.value
           const displayMinimum = minimum ? asBigNumber(minimum) : '90'
-          errorMsg = t('apiErrors.BelowMinimumStakeError', { minimum: displayMinimum })
+          errorMsg = t('apiErrors.BelowMinimumStakeError.message', { minimum: displayMinimum })
+          errorTitle = t('apiErrors.BelowMinimumStakeError.title')
           break
         }
         case 'NotEnoughTokensForUnstakeError': {
@@ -101,14 +106,17 @@ export default defineComponent({
           const staked = Amount.fromUnsafe(error.value.details.stake.delegated_stake.value)._unsafeUnwrap()
           const pending = Amount.fromUnsafe(error.value.details.pending_stake.delegated_stake.value)._unsafeUnwrap()
           if (requested > add(staked, pending)) {
-            errorMsg = t('apiErrors.NotEnoughTokensForUnstakeError.requested')
+            errorMsg = t('apiErrors.NotEnoughTokensForUnstakeError.requested.message')
+            errorTitle = t('apiErrors.NotEnoughTokensForUnstakeError.requested.title')
             break
           }
-          errorMsg = t('apiErrors.NotEnoughTokensForUnstakeError.pending', { pending: asBigNumber(pending) })
+          errorMsg = t('apiErrors.NotEnoughTokensForUnstakeError.pending.message', { pending: asBigNumber(pending) })
+          errorTitle = t('apiErrors.NotEnoughTokensForUnstakeError.pending.title')
           break
         }
         default:
-          errorMsg = t(`apiErrors.${type}`)
+          errorMsg = t(`apiErrors.${type}.message`)
+          errorTitle = t(`apiErrors.${type}.title`)
           break
       }
     }
@@ -119,6 +127,7 @@ export default defineComponent({
       refreshApp,
       updateVisible,
       errorMsg,
+      errorTitle,
       showDetails
     }
   }

--- a/src/composables/useErrors.ts
+++ b/src/composables/useErrors.ts
@@ -1,20 +1,12 @@
-import { ErrorT, Radix } from '@radixdlt/application'
+import { Radix } from '@radixdlt/application'
 import { Ref, ref, computed, ComputedRef } from 'vue'
-
-export type TransactionStateT = 'HW-SIGNING' | 'BUILDING' | 'CONFIRM' | 'SUBMITTING'
-
-export type ClientAppErrorTypeT = 'GENERIC' | 'TRANSACTION-HW-SIGNING' | 'TRANSACTION-BUILDING' | 'TRANSACTION-CONFIRM' | 'TRANSACTION-SUBMITTING'
-export type ClientAppErrorT = {
-  type: ClientAppErrorTypeT,
-  error?: ErrorT<'wallet'> | Error
-}
-
 const appErrors: Ref<Error[]> = ref([])
 
 interface useErrorsInterface {
   readonly appErrors: ComputedRef<Error[]>;
   clearLatestError: () => void;
   setError: (error: Error) => void;
+  getApiErrorMsg: (type: string) => string;
 }
 
 const setError = (error: Error) => {

--- a/src/composables/useErrors.ts
+++ b/src/composables/useErrors.ts
@@ -4,8 +4,6 @@ import { Ref, ref, computed, ComputedRef } from 'vue'
 const appErrors: Ref<Error[]> = ref([])
 
 export const apiErrors = [
-  'NetworkNotSupportedError',
-  'InvalidTokenRRIError',
   'InvalidAccountAddressError',
   'InvalidValidatorAddressError',
   'NotEnoughNativeTokensForFeesError',

--- a/src/composables/useErrors.ts
+++ b/src/composables/useErrors.ts
@@ -19,7 +19,7 @@ interface useErrorsInterface {
   readonly appErrors: ComputedRef<Error[]>;
   clearLatestError: () => void;
   setError: (error: Error) => void;
-  isApiError: (type: string) => boolean;
+  isKnownApiError: (type: string) => boolean;
 }
 
 const setError = (error: Error) => {
@@ -32,7 +32,7 @@ const clearLatestError = () => {
   appErrors.value = latestErrors
 }
 
-const isApiError = (type: string) => {
+const isKnownApiError = (type: string) => {
   return apiErrors.includes(type)
 }
 
@@ -46,6 +46,6 @@ export default function useErrors (radix: ReturnType<typeof Radix.create>): useE
     appErrors: computed(() => appErrors.value),
     clearLatestError,
     setError,
-    isApiError
+    isKnownApiError
   }
 }

--- a/src/composables/useErrors.ts
+++ b/src/composables/useErrors.ts
@@ -1,12 +1,27 @@
 import { Radix } from '@radixdlt/application'
 import { Ref, ref, computed, ComputedRef } from 'vue'
+
 const appErrors: Ref<Error[]> = ref([])
+
+export const apiErrors = [
+  'NetworkNotSupportedError',
+  'InvalidTokenRRIError',
+  'InvalidAccountAddressError',
+  'InvalidValidatorAddressError',
+  'NotEnoughNativeTokensForFeesError',
+  'NotEnoughTokensForTransferError',
+  'NotEnoughTokensForStakeError',
+  'NotEnoughTokensForUnstakeError',
+  'BelowMinimumStakeError',
+  'CannotStakeError',
+  'MessageTooLongError'
+]
 
 interface useErrorsInterface {
   readonly appErrors: ComputedRef<Error[]>;
   clearLatestError: () => void;
   setError: (error: Error) => void;
-  getApiErrorMsg: (type: string) => string;
+  isApiError: (type: string) => boolean;
 }
 
 const setError = (error: Error) => {
@@ -19,6 +34,10 @@ const clearLatestError = () => {
   appErrors.value = latestErrors
 }
 
+const isApiError = (type: string) => {
+  return apiErrors.includes(type)
+}
+
 export default function useErrors (radix: ReturnType<typeof Radix.create>): useErrorsInterface {
   // radix.errors
   //   .subscribe((error: ErrorT<'wallet'>) => {
@@ -28,6 +47,7 @@ export default function useErrors (radix: ReturnType<typeof Radix.create>): useE
   return {
     appErrors: computed(() => appErrors.value),
     clearLatestError,
-    setError
+    setError,
+    isApiError
   }
 }

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -33,7 +33,8 @@ import {
   UnstakeTokensInput,
   AccountT,
   TransactionTrackingEventType,
-  TransactionStateUpdate
+  TransactionStateUpdate,
+  APIError
 } from '@radixdlt/application'
 import { Router } from 'vue-router'
 import { useErrors } from '.'
@@ -252,8 +253,11 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
     if (t.transactionState && t.transactionState.fee) transactionFee.value = t.transactionState.fee
     if (t.error) {
       cancelTransaction()
-      setError(t.error)
     }
+  }
+
+  const errorHandler = (err: any) => {
+    setError(err)
   }
 
   // call transferTokens() with built options and subscribe to confirmation and results
@@ -274,8 +278,12 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
 
     shouldShowConfirmation.value = true
 
-    transactionSubs.add(completion.subscribe(handleTransactionCompleted))
-    transactionSubs.add(events.subscribe(handleTransactionLifecycleEvent))
+    transactionSubs.add(
+      completion.subscribe(handleTransactionCompleted, errorHandler)
+    )
+    transactionSubs.add(
+      events.subscribe(handleTransactionLifecycleEvent, errorHandler)
+    )
   }
 
   // call unstakeTokens() with built options and subscribe to confirmation and results
@@ -292,8 +300,12 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
 
     shouldShowConfirmation.value = true
 
-    transactionSubs.add(completion.subscribe(handleTransactionCompleted))
-    transactionSubs.add(events.subscribe(handleTransactionLifecycleEvent))
+    transactionSubs.add(
+      completion.subscribe(handleTransactionCompleted, errorHandler)
+    )
+    transactionSubs.add(
+      events.subscribe(handleTransactionLifecycleEvent, errorHandler)
+    )
   }
 
   // call stakeTokens() with built options and subscribe to confirmation and results
@@ -310,8 +322,12 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
 
     shouldShowConfirmation.value = true
 
-    transactionSubs.add(completion.subscribe(handleTransactionCompleted))
-    transactionSubs.add(events.subscribe(handleTransactionLifecycleEvent))
+    transactionSubs.add(
+      completion.subscribe(handleTransactionCompleted, errorHandler)
+    )
+    transactionSubs.add(
+      events.subscribe(handleTransactionLifecycleEvent, errorHandler)
+    )
   }
 
   const transactionUnsub = () => {

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -257,7 +257,8 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
   }
 
   const errorHandler = (err: any) => {
-    setError(err)
+    const apiError = { ...err, type: 'api' }
+    setError(apiError)
   }
 
   // call transferTokens() with built options and subscribe to confirmation and results

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -150,7 +150,7 @@ const messages = {
       fromLabel: 'Staking Account',
       validatorLabel: 'Validator',
       amountLabel: 'Amount',
-      amountPlaceholder: '90 XRD min stake. Available balance ...',
+      amountPlaceholder: 'Available balance ...',
       feeLabel: 'Fee',
       stakeButton: 'Stake',
       unstakeButton: 'Request Unstake',
@@ -244,15 +244,14 @@ const messages = {
       unableToPrepareUnstakingTransactionPointThree: 'Insufficient XRD to pay the required transaction fee'
     },
     apiErrors: {
-      NetworkNotSupportedError: 'The network selected is not valid.',
-      InvalidTokenRRIError: 'The token specified is not valid.',
+      unknown: 'Unexpected Error',
       InvalidAccountAddressError: 'The recipient Radix address specified is not valid.',
       InvalidValidatorAddressError: 'The validator node address specified is not valid.',
       NotEnoughNativeTokensForFeesError: 'You do not have enough XRD to pay the required transaction fee',
       NotEnoughTokensForTransferError: 'You do not have enough of the specified token for this transfer.',
       NotEnoughTokensForStakeError: 'You do not have enough XRD for the requested stake.',
       NotEnoughTokensForUnstakeError: {
-        default: 'You do not have enough XRD for the requested unstake.',
+        requested: 'You do not have enough XRD for the requested unstake.',
         pending: 'You must wait until the next epoch (approx. 30 minutes) before unstaking this quantity of XRD – %{pending} XRD are currently pending stake and cannot yet be unstaked.'
       },
       BelowMinimumStakeError: 'You must stake at least %{minimum} XRD.',

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -245,6 +245,8 @@ const messages = {
     },
     apiErrors: {
       unknown: 'Unexpected Error',
+      contactCopyOne: 'Please contact support at',
+      contactCopyTwo: 'and provide the following.',
       InvalidAccountAddressError: {
         message: 'The recipient Radix address specified is not valid.',
         title: 'Cannot Create Transaction'

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -245,18 +245,48 @@ const messages = {
     },
     apiErrors: {
       unknown: 'Unexpected Error',
-      InvalidAccountAddressError: 'The recipient Radix address specified is not valid.',
-      InvalidValidatorAddressError: 'The validator node address specified is not valid.',
-      NotEnoughNativeTokensForFeesError: 'You do not have enough XRD to pay the required transaction fee',
-      NotEnoughTokensForTransferError: 'You do not have enough of the specified token for this transfer.',
-      NotEnoughTokensForStakeError: 'You do not have enough XRD for the requested stake.',
-      NotEnoughTokensForUnstakeError: {
-        requested: 'You do not have enough XRD for the requested unstake.',
-        pending: 'You must wait until the next epoch (approx. 30 minutes) before unstaking this quantity of XRD – %{pending} XRD are currently pending stake and cannot yet be unstaked.'
+      InvalidAccountAddressError: {
+        message: 'The recipient Radix address specified is not valid.',
+        title: 'Cannot Create Transaction'
       },
-      BelowMinimumStakeError: 'You must stake at least %{minimum} XRD.',
-      CannotStakeError: 'The specified validator node does not accept stake, other than from its owner.',
-      MessageTooLongError: 'The messages specified for the transaction is too long.'
+      InvalidValidatorAddressError: {
+        message: 'The validator node address specified is not valid.',
+        title: 'Cannot Complete Stake or Unstake'
+      },
+      NotEnoughNativeTokensForFeesError: {
+        message: 'You do not have enough XRD to pay the required transaction fee',
+        title: 'Cannot Create Transaction'
+      },
+      NotEnoughTokensForTransferError: {
+        message: 'You do not have enough of the specified token for this transfer.',
+        title: 'Cannot Create Transaction'
+      },
+      NotEnoughTokensForStakeError: {
+        message: 'You do not have enough XRD for the requested stake.',
+        title: 'Cannot Complete Stake'
+      },
+      NotEnoughTokensForUnstakeError: {
+        requested: {
+          message: 'You do not have enough XRD for the requested unstake.',
+          title: 'Cannot Complete Unstake'
+        },
+        pending: {
+          message: 'You must wait until the next epoch (approx. 30 minutes) before unstaking this quantity of XRD – %{pending} XRD are currently pending stake and cannot yet be unstaked.',
+          title: 'Cannot Complete Unstake'
+        }
+      },
+      BelowMinimumStakeError: {
+        message: 'You must stake at least %{minimum} XRD.',
+        title: 'Cannot Complete Stake'
+      },
+      CannotStakeError: {
+        message: 'The specified validator node does not accept stake, other than from its owner.',
+        title: 'Cannot Complete Stake'
+      },
+      MessageTooLongError: {
+        message: 'The messages specified for the transaction is too long.',
+        title: 'Cannot Create Transaction'
+      }
     }
   }
 }

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -241,7 +241,7 @@ const messages = {
       unableToPrepareUnstakingTransactionTitle: 'The transaction you’ve specified cannot be created. Possible reasons for this error include:',
       unableToPrepareUnstakingTransactionPointOne: 'Attempting to request an unstake in the same “epoch” (~30 min period) that you staked',
       unableToPrepareUnstakingTransactionPointTwo: 'Attempting to unstake more than you currently have staked to the validator',
-      unableToPrepareUnstakingTransactionPointThree: 'Insufficient XRD to paythe required transaction fee'
+      unableToPrepareUnstakingTransactionPointThree: 'Insufficient XRD to pay the required transaction fee'
     },
     apiErrors: {
       NetworkNotSupportedError: 'The network selected is not valid.',
@@ -251,8 +251,11 @@ const messages = {
       NotEnoughNativeTokensForFeesError: 'You do not have enough XRD to pay the required transaction fee',
       NotEnoughTokensForTransferError: 'You do not have enough of the specified token for this transfer.',
       NotEnoughTokensForStakeError: 'You do not have enough XRD for the requested stake.',
-      NotEnoughTokensForUnstakeError: 'You do not have enough XRD for the requested unstake. You must wait until the next epoch (approx 30 minutes) before unstaking this XRD.',
-      BelowMinimumStakeError: 'You must stake at least 90 XRD.',
+      NotEnoughTokensForUnstakeError: {
+        default: 'You do not have enough XRD for the requested unstake.',
+        pending: 'You must wait until the next epoch (approx. 30 minutes) before unstaking this quantity of XRD – %{pending} XRD are currently pending stake and cannot yet be unstaked.'
+      },
+      BelowMinimumStakeError: 'You must stake at least %{minimum} XRD.',
       CannotStakeError: 'The specified validator node does not accept stake, other than from its owner.',
       MessageTooLongError: 'The messages specified for the transaction is too long.'
     }

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -241,7 +241,20 @@ const messages = {
       unableToPrepareUnstakingTransactionTitle: 'The transaction you’ve specified cannot be created. Possible reasons for this error include:',
       unableToPrepareUnstakingTransactionPointOne: 'Attempting to request an unstake in the same “epoch” (~30 min period) that you staked',
       unableToPrepareUnstakingTransactionPointTwo: 'Attempting to unstake more than you currently have staked to the validator',
-      unableToPrepareUnstakingTransactionPointThree: 'Insufficient XRD to pay the required transaction fee'
+      unableToPrepareUnstakingTransactionPointThree: 'Insufficient XRD to paythe required transaction fee'
+    },
+    apiErrors: {
+      NetworkNotSupportedError: 'The network selected is not valid.',
+      InvalidTokenRRIError: 'The token specified is not valid.',
+      InvalidAccountAddressError: 'The recipient Radix address specified is not valid.',
+      InvalidValidatorAddressError: 'The validator node address specified is not valid.',
+      NotEnoughNativeTokensForFeesError: 'You do not have enough XRD to pay the required transaction fee',
+      NotEnoughTokensForTransferError: 'You do not have enough of the specified token for this transfer.',
+      NotEnoughTokensForStakeError: 'You do not have enough XRD for the requested stake.',
+      NotEnoughTokensForUnstakeError: 'You do not have enough XRD for the requested unstake. You must wait until the next epoch (approx 30 minutes) before unstaking this XRD.',
+      BelowMinimumStakeError: 'You must stake at least 90 XRD.',
+      CannotStakeError: 'The specified validator node does not accept stake, other than from its owner.',
+      MessageTooLongError: 'The messages specified for the transaction is too long.'
     }
   }
 }

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -96,9 +96,6 @@
                       class="w-full"
                       label="Message"
                       :placeholder="$t('transaction.messagePlaceholder')"
-                      :rules="{
-                        max: 160
-                      }"
                     />
                   </div>
                   <FormCheckbox name="encrypt" label="Encrypt" :value="true" />

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -96,6 +96,7 @@
                       class="w-full"
                       label="Message"
                       :placeholder="$t('transaction.messagePlaceholder')"
+                      :rules="{}"
                     />
                   </div>
                   <FormCheckbox name="encrypt" label="Encrypt" :value="true" />


### PR DESCRIPTION
This PR adds an additional error modal specifically for handling API errors. For known errors, a friendly message is displayed; otherwise, a detailed modal with the error message, trace id, and contact email is displayed.

Examples:
<img width="1201" alt="Screen Shot 2022-01-07 at 3 17 22 PM" src="https://user-images.githubusercontent.com/8646176/148615250-50036483-75e7-4ef8-9bb6-a6b1b5450595.png">
<img width="1195" alt="Screen Shot 2022-01-07 at 3 18 33 PM" src="https://user-images.githubusercontent.com/8646176/148615195-bb277c4e-083a-4e3f-b49b-626263f50de3.png">
<img width="1197" alt="Screen Shot 2022-01-06 at 11 40 04 PM" src="https://user-images.githubusercontent.com/8646176/148502910-0807a96d-b7ba-45aa-a79e-684acafe9a3b.png">

