### PR TITLE
fix: Cleanup restore wallet enter mnemonic UX

### DIFF
--- a/src/components/AppSelect.vue
+++ b/src/components/AppSelect.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mt-1 relative w-56">
-    <button
+    <div
       class="bg-white relative flex items-center justify-between w-full border border-gray-300 rounded-sm shadow-sm px-3 py-2 text-left cursor-pointer focus:outline-none focus:ring-1 focus:ring-rBlue focus:border-rBlue sm:text-sm hover:bg-rGrayLight transition-colors"
       @click="toggleIsOpen"
     >
@@ -10,7 +10,7 @@
       <svg width="14" height="8" viewBox="0 0 14 8" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path d="M1 1L7 7L13 1" class="stroke-current text-rBlack" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
-    </button>
+    </div>
 
     <ul
       v-if="isOpen"

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -74,8 +74,9 @@ const messages = {
     restoreWallet: {
       recoveryTitle: 'Seed Phrase',
       recoveryHelp: 'Enter your 12, 18 or 24 word seed phrase to restore your wallet.',
-      recoveryButtonDisabled: 'Fill these out first',
-      recoveryButtonEnabled: 'I\'ve done it!',
+      recoveryButtonDisabled: 'Enter words to proceed',
+      recoveryButtonEnabled: 'Proceed',
+      invalidMnemonic: 'This mnemonic doesn\'t match an existing wallet. Please try again.',
       passwordTitle: 'Password',
       passwordHelp: 'Please enter a secure password here. This password secures your mnemonicly generated key, and will be required every time you open this application',
       pinTitle: 'PIN',

--- a/src/views/RestoreWallet/RestoreWalletEnterMnemonic.vue
+++ b/src/views/RestoreWallet/RestoreWalletEnterMnemonic.vue
@@ -1,5 +1,5 @@
 <template>
-  <form data-ci="create-wallet-enter-mnemonic-component" @submit.prevent="$emit('confirm', inputWords)">
+  <form data-ci="create-wallet-enter-mnemonic-component" @submit.prevent="handleSubmit">
     <div
       class="grid"
       :class="{
@@ -48,7 +48,7 @@ const RestoreWalletEnterMnemonic = defineComponent({
     MnemonicInput
   },
 
-  setup () {
+  setup (props, { emit }) {
     const { t } = useI18n({ useScope: 'global' })
     const mnemonicStrength: Ref<StrengthT> = ref(StrengthT.WORD_COUNT_12)
 
@@ -87,6 +87,10 @@ const RestoreWalletEnterMnemonic = defineComponent({
       inputWords.value = new Array(arrLength).fill('') as string[]
     }
 
+    const handleSubmit = () => {
+      if (inputValid.value) emit('confirm', inputWords.value)
+    }
+
     onMounted(() => { initInputWords() })
 
     return {
@@ -100,7 +104,8 @@ const RestoreWalletEnterMnemonic = defineComponent({
 
       // methods
       handleChange,
-      handleSelect
+      handleSelect,
+      handleSubmit
     }
   },
 

--- a/src/views/RestoreWallet/index.vue
+++ b/src/views/RestoreWallet/index.vue
@@ -118,14 +118,9 @@ const RestoreWallet = defineComponent({
         })
     }
 
-    const captureMnemonic = (mneomnicVal: string[]) => {
-      const mnemonicRes = Mnemonic.fromEnglishWords(mneomnicVal)
-      if (mnemonicRes.isErr()) {
-        console.warn('error, invalid mnemonic!')
-      } else {
-        mnemonic.value = mnemonicRes.value
-        step.value = 1
-      }
+    const captureMnemonic = (mnemonicVal: MnemomicT) => {
+      mnemonic.value = mnemonicVal
+      step.value = 1
     }
 
     const handleEnterPin = (val: boolean) => {


### PR DESCRIPTION
- fix: Prevent select dropdown from opening on enter press
- fix: Prevent mnemonic from submitting before all fields are present
- fix: Cleanup restore wallet enter mnemonic UX 
<img width="1312" alt="Screen Shot 2022-01-06 at 10 13 17 AM" src="https://user-images.githubusercontent.com/4480888/148404942-f43f18dd-2b68-44e7-a748-13547e3f2409.png">
<img width="1312" alt="Screen Shot 2022-01-06 at 10 14 59 AM" src="https://user-images.githubusercontent.com/4480888/148405047-df04594e-30e9-4438-8852-551e29d0de4a.png">
<img width="1312" alt="Screen Shot 2022-01-06 at 9 25 31 AM" src="https://user-images.githubusercontent.com/4480888/148405066-4a4dcb12-7c71-4525-abb2-97bc67afeb6c.png">

