### PR TITLE
Improve display of complex actions in history

### DIFF
--- a/src/components/ActionListItemTransferTokens.vue
+++ b/src/components/ActionListItemTransferTokens.vue
@@ -55,7 +55,7 @@ const ActionListItemTransferTokens = defineComponent({
   computed: {
     isRecipient (): boolean {
       if (!this.activeAddress) return false
-      return this.action.to_account.toString() === this.activeAddress.toString()
+      return this.action.to_account.equals(this.activeAddress)
     }
   },
 

--- a/src/components/TransactionListItem.vue
+++ b/src/components/TransactionListItem.vue
@@ -52,6 +52,11 @@
             :activeAddress="activeAddress"
           />
         </div>
+        <div class="text-rGrayMed">
+          <span v-if="customTxnDisplayType === 'UNKNOWN'">{{ $t('history.unknownTransaction') }}</span>
+          <span v-else-if="customTxnDisplayType === 'COMPLEX' && relatedActions.length !== transaction.actions.length">{{ $t('history.complexTransactionSomeUnrelated') }}</span>
+          <span v-else-if="customTxnDisplayType === 'COMPLEX'">{{ $t('history.complexTransaction') }}</span>
+        </div>
       </div>
       <div v-if="messageState" class="text-sm px-3 py-2 bg-rGrayLightest bg-opacity-60 flex items-center">
         <div class="h-5 w-6 flex items-center justify-center -ml-1 mr-1">
@@ -137,35 +142,44 @@ export default defineComponent({
       `${props.explorerUrlBase}/#/transactions/${props.transaction.txID}`
     )
 
+    const relatedActions: ComputedRef<ExecutedAction[]> = computed(() => {
+      return props.transaction.actions.filter((action: ExecutedAction) => {
+        let related
+        switch (action.type) {
+          case ActionType.TOKEN_TRANSFER:
+            related = action.to_account.equals(props.activeAddress) || action.from_account.equals(props.activeAddress)
+            break
+          case ActionType.STAKE_TOKENS:
+            related = action.from_account.equals(props.activeAddress)
+            break
+          case ActionType.UNSTAKE_TOKENS:
+            related = action.to_account.equals(props.activeAddress)
+            break
+          case ActionType.OTHER:
+            related = false
+            break
+        }
+        return !!related
+      }) || []
+    })
+
+    // Handle edge case transaction types in wallet UI
+    const customTxnDisplayType: ComputedRef<'UNKNOWN' | 'COMPLEX' | 'DEFAULT'> = computed(() => {
+      if (props.transaction.actions.length <= 0) return 'UNKNOWN'
+      else if (props.transaction.actions.length > 1) return 'COMPLEX'
+      return 'DEFAULT'
+    })
+
     return {
-      explorerUrl
+      customTxnDisplayType,
+      explorerUrl,
+      relatedActions
     }
   },
 
   computed: {
     sentAt (): string {
       return DateTime.fromJSDate(this.transaction.sentAt).toLocaleString(DateTime.DATETIME_SHORT)
-    },
-
-    relatedActions (): ExecutedAction[] {
-      return this.transaction.actions.filter((action: ExecutedAction) => {
-        let related
-        switch (action.type) {
-          case ActionType.TOKEN_TRANSFER:
-            related = action.to_account.equals(this.activeAddress) || action.from_account.equals(this.activeAddress)
-            break
-          case ActionType.STAKE_TOKENS:
-            related = action.from_account.equals(this.activeAddress)
-            break
-          case ActionType.UNSTAKE_TOKENS:
-            related = action.to_account.equals(this.activeAddress)
-            break
-          case ActionType.OTHER:
-            related = false
-            break
-        }
-        return related
-      })
     },
 
     showMessageLock (): boolean {

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -115,7 +115,10 @@ const messages = {
       otherAction: 'Other',
       previous: 'Previous',
       next: 'Next',
-      noHistory: 'Sorry, but you don\'t have transaction history for this account.'
+      noHistory: 'Sorry, but you don\'t have transaction history for this account.',
+      unknownTransaction: 'Unknown transaction',
+      complexTransactionSomeUnrelated: 'Complex transaction, additional actions not shown',
+      complexTransaction: 'Complex Transaction'
     },
     transaction: {
       transactionHeading: 'Send Tokens',


### PR DESCRIPTION
This PR makes some small UI updates to how we display edge cases actions in the history view.

1. For transactions with an empty actions array, we display "Unknown transaction." This most often occurs when we return legacy self-transfers
<img width="1312" alt="Screen Shot 2022-01-10 at 6 15 22 AM" src="https://user-images.githubusercontent.com/4480888/148757689-87737773-1ba9-4f16-aead-a32bc6e07020.png">

2. For transactions with multiple actions, i.e. complex transactions, we display "Complex transaction" and tell the user if some of the actions were filtered out because they don't relate to the current active address
<img width="1312" alt="Screen Shot 2022-01-10 at 6 15 13 AM" src="https://user-images.githubusercontent.com/4480888/148757778-61fd78b6-e220-4817-83cd-3efaafafe9ce.png">

See notes in linear for reference https://linear.app/township/issue/RDX-314/sdk-upgrade-history
