### PR TITLE
wip: attempt to handle unhandled errors

### DIFF
--- a/src/views/Settings/SettingsSelectNode.vue
+++ b/src/views/Settings/SettingsSelectNode.vue
@@ -75,7 +75,7 @@
 </template>
 
 <script lang="ts">
-import { ref, Ref, computed, ComputedRef, defineComponent } from 'vue'
+import { ref, Ref, computed, ComputedRef, defineComponent, onMounted, onUnmounted } from 'vue'
 import { ChosenNetworkT, defaultNetworks } from '@/helpers/network'
 import NodeListItem from '@/components/NodeListItem.vue'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
@@ -112,6 +112,18 @@ export default defineComponent({
     const router = useRouter()
     const { updateConnection, switching } = useWallet(router)
     const customNodeURLs: Ref<string[]> = ref([])
+
+    const handleErr = (event: any) => {
+      toast.error('Unable to connect')
+    }
+
+    onMounted(() => {
+      window.addEventListener('unhandledrejection', handleErr)
+    })
+
+    onUnmounted(() => {
+      window.removeEventListener('unhandledrejection', handleErr)
+    })
 
     const loadURLs = () => {
       fetchCustomNodeURLs().then((urls) => { customNodeURLs.value = urls })


### PR DESCRIPTION
Would like some eyes on this!
Linear issue: https://linear.app/township/issue/RDX-324/sdk-upgrade-bug-report-missing-error-when-adding-invalid-node
```
Access to XMLHttpRequest at 'https://coinwrap.co/gateway' from origin 'http://localhost:8080' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.
xhr.js?b50d:210 POST https://coinwrap.co/gateway net::ERR_FAILED
dispatchXhrRequest @ xhr.js?b50d:210
xhrAdapter @ xhr.js?b50d:15
dispatchRequest @ dispatchRequest.js?5270:58
request @ Axios.js?0a06:108
wrap @ bind.js?1d2b:9
eval @ common.js?6b5b:141
eval @ api.js?4373:469
Promise.then (async)
gatewayPost @ api.js?4373:469
eval @ open-api-client.js?9267:33
eval @ _pipe.js?47c6:3
eval @ _arity.js?2550:6
eval @ open-api-client.js?9267:40
eval @ interface.js?653e:6
eval @ _pipe.js?47c6:3
eval @ _arity.js?2550:6
eval @ interface.js?653e:6
eval @ radixCoreAPI.js?421e:15
eval @ defer.js?b078:5
Observable._trySubscribe @ Observable.js?8f2e:68
Observable.subscribe @ Observable.js?8f2e:33
eval @ map.js?3a47:6
eval @ lift.js?60b7:10
Observable.subscribe @ Observable.js?8f2e:28
doInnerSub @ mergeInternals.js?51af:18
outerNext @ mergeInternals.js?51af:13
OperatorSubscriber._this._next @ OperatorSubscriber.js?f44e:11
Subscriber.next @ Subscriber.js?4701:33
ReplaySubject._subscribe @ ReplaySubject.js?0a6a:37
Observable._trySubscribe @ Observable.js?8f2e:68
Subject._trySubscribe @ Subject.js?14ba:74
Observable.subscribe @ Observable.js?8f2e:33
eval @ share.js?1b80:20
eval @ lift.js?60b7:10
Observable.subscribe @ Observable.js?8f2e:28
mergeInternals @ mergeInternals.js?51af:47
eval @ mergeMap.js?f32c:14
eval @ lift.js?60b7:10
Observable.subscribe @ Observable.js?8f2e:28
eval @ take.js?5504:10
eval @ lift.js?60b7:10
Observable.subscribe @ Observable.js?8f2e:28
eval @ catchError.js?fcf9:9
eval @ lift.js?60b7:10
Observable.subscribe @ Observable.js?8f2e:28
eval @ firstValueFrom.js?b254:21
firstValueFrom @ firstValueFrom.js?b254:5
_callee$ @ SettingsSelectNode.vue?5b02:62
tryCatch @ runtime.js?96cf:63
invoke @ runtime.js?96cf:293
eval @ runtime.js?96cf:118
asyncGeneratorStep @ asyncToGenerator.js?c973:3
_next @ asyncToGenerator.js?c973:25
eval @ asyncToGenerator.js?c973:32
eval @ asyncToGenerator.js?c973:21
handleAddNode @ SettingsSelectNode.vue?5b02:62
eval @ SettingsSelectNode.vue?262f:40
eval @ runtime-dom.esm-bundler.js?830f:1208
callWithErrorHandling @ runtime-core.esm-bundler.js?5c40:155
callWithAsyncErrorHandling @ runtime-core.esm-bundler.js?5c40:164
invoker @ runtime-dom.esm-bundler.js?830f:370
Show 30 more frames
createError.js?2d83:16 Uncaught (in promise) Error: Network Error
    at createError (createError.js?2d83:16)
    at XMLHttpRequest.handleError (xhr.js?b50d:117)
createError @ createError.js?2d83:16
handleError @ xhr.js?b50d:117
Promise.then (async)
ResultAsync.then @ index.es.js?2b3d:293
eval @ resultAsync_observable.js?98ed:6
Observable._trySubscribe @ Observable.js?8f2e:68
Observable.subscribe @ Observable.js?8f2e:33
eval @ defer.js?b078:5
Observable._trySubscribe @ Observable.js?8f2e:68
Observable.subscribe @ Observable.js?8f2e:33
eval @ map.js?3a47:6
eval @ lift.js?60b7:10
Observable.subscribe @ Observable.js?8f2e:28
doInnerSub @ mergeInternals.js?51af:18
outerNext @ mergeInternals.js?51af:13
OperatorSubscriber._this._next @ OperatorSubscriber.js?f44e:11
Subscriber.next @ Subscriber.js?4701:33
ReplaySubject._subscribe @ ReplaySubject.js?0a6a:37
Observable._trySubscribe @ Observable.js?8f2e:68
Subject._trySubscribe @ Subject.js?14ba:74
Observable.subscribe @ Observable.js?8f2e:33
eval @ share.js?1b80:20
eval @ lift.js?60b7:10
Observable.subscribe @ Observable.js?8f2e:28
mergeInternals @ mergeInternals.js?51af:47
eval @ mergeMap.js?f32c:14
eval @ lift.js?60b7:10
Observable.subscribe @ Observable.js?8f2e:28
eval @ take.js?5504:10
eval @ lift.js?60b7:10
Observable.subscribe @ Observable.js?8f2e:28
eval @ catchError.js?fcf9:9
eval @ lift.js?60b7:10
Observable.subscribe @ Observable.js?8f2e:28
eval @ firstValueFrom.js?b254:21
firstValueFrom @ firstValueFrom.js?b254:5
_callee$ @ SettingsSelectNode.vue?5b02:62
tryCatch @ runtime.js?96cf:63
invoke @ runtime.js?96cf:293
eval @ runtime.js?96cf:118
asyncGeneratorStep @ asyncToGenerator.js?c973:3
_next @ asyncToGenerator.js?c973:25
eval @ asyncToGenerator.js?c973:32
eval @ asyncToGenerator.js?c973:21
handleAddNode @ SettingsSelectNode.vue?5b02:62
eval @ SettingsSelectNode.vue?262f:40
eval @ runtime-dom.esm-bundler.js?830f:1208
callWithErrorHandling @ runtime-core.esm-bundler.js?5c40:155
callWithAsyncErrorHandling @ runtime-core.esm-bundler.js?5c40:164
invoker @ runtime-dom.esm-bundler.js?830f:370
Show 19 more frames
```
Encountering CORS issues, and an unhandled errors seem to be popping up in `handleAddNode` in `src/views/Settings/SettingsSelectNode.vue`. I've added a global error handler to this view to catch it and present a nice toast, but I don't think it's an ideal solution. 