### PR TITLE
fix: Default to Mainnet for new wallets

### DIFF
--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -346,7 +346,7 @@ const fetchSavedNodeUrl = async (signingKeychain: SigningKeychainT): Promise<str
   const { selectedNode, selectedNodeHash } = await fetchSelectedNodeFromStore()
   if (!selectedNode) {
     // set a default node, one did not exist.
-    const defaultToMainnet = 'https://stokenet-gateway.radixdlt.com'
+    const defaultToMainnet = 'https://mainnet.radixdlt.com'
     const hash = await hashNodeUrl(defaultToMainnet, signingKeychain)
     const saveToStore = await persistNodeSelection(defaultToMainnet, hash)
     return defaultToMainnet

--- a/src/helpers/network.ts
+++ b/src/helpers/network.ts
@@ -26,7 +26,7 @@ export const network = (networkName: Network): ChosenNetworkT => {
   return response
 }
 
-export const defaultNetwork = 'https://stokenet-gateway.radixdlt.com'
+export const defaultNetwork = 'https://mainnet.radixdlt.com'
 
 export const defaultNetworks: ChosenNetworkT[] = [
   {
@@ -36,7 +36,7 @@ export const defaultNetworks: ChosenNetworkT[] = [
   },
   {
     network: Network.STOKENET,
-    networkURL: 'https://stokenet-gateway.radixdlt.com',
+    networkURL: 'https://mainnet.radixdlt.com',
     preamble: HRP[Network.STOKENET].account
   }
 ]


### PR DESCRIPTION
New Wallets or wallets without a custom node url should default to mainnet,  we had changed this value while the SDK / API were being updated.  This can be restored to it's original value now that the mainnet gateway is live.