### PR TITLE
fix: network versions

### DIFF
--- a/src/helpers/network.ts
+++ b/src/helpers/network.ts
@@ -11,13 +11,13 @@ export const network = (networkName: Network): ChosenNetworkT => {
   if (networkName === Network.STOKENET) {
     response = {
       network: Network.STOKENET,
-      networkURL: 'https://stokenet-gateway.radixdlt.com',
+      networkURL: 'https://stokenet.radixdlt.com',
       preamble: HRP[Network.STOKENET].account
     }
   } else if (networkName === Network.MAINNET) {
     response = {
       network: Network.MAINNET,
-      networkURL: 'https://mainnet-gateway.radixdlt.com',
+      networkURL: 'https://mainnet.radixdlt.com',
       preamble: HRP[Network.MAINNET].account
     }
   } else {
@@ -31,12 +31,12 @@ export const defaultNetwork = 'https://mainnet.radixdlt.com'
 export const defaultNetworks: ChosenNetworkT[] = [
   {
     network: Network.MAINNET,
-    networkURL: 'https://mainnet-gateway.radixdlt.com',
+    networkURL: 'https://mainnet.radixdlt.com',
     preamble: HRP[Network.MAINNET].account
   },
   {
     network: Network.STOKENET,
-    networkURL: 'https://mainnet.radixdlt.com',
+    networkURL: 'https://stokenet.radixdlt.com',
     preamble: HRP[Network.STOKENET].account
   }
 ]

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -5,7 +5,7 @@
     <div class="flex flex-col w-full">
       <router-view v-if="walletLoaded"/>
       <wallet-loading v-else />
-      <div v-if="activeNetwork && activeNetwork !== 'MAINNET'" class="bg-white py-5 text-center flex flex-row items-center justify-center px-28 border-t border-rRed">
+      <div v-if="isTestNet" class="bg-white py-5 text-center flex flex-row items-center justify-center px-28 border-t border-rRed">
         <div>
           <svg width="36" height="30" viewBox="0 0 36 30" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M15.2687 2.11167L1.74022 24.5C1.46129 24.9788 1.31371 25.5217 1.31215 26.0747C1.31058 26.6276 1.4551 27.1713 1.73132 27.6517C2.00753 28.132 2.40582 28.5324 2.88656 28.8128C3.36729 29.0932 3.91372 29.2439 4.47147 29.25H31.5284C32.0862 29.2439 32.6326 29.0932 33.1133 28.8128C33.5941 28.5324 33.9923 28.132 34.2686 27.6517C34.5448 27.1713 34.6893 26.6276 34.6877 26.0747C34.6862 25.5217 34.5386 24.9788 34.2597 24.5L20.7312 2.11167C20.4465 1.64634 20.0455 1.26161 19.5671 0.9946C19.0887 0.727594 18.549 0.587323 17.9999 0.587323C17.4509 0.587323 16.9112 0.727594 16.4328 0.9946C15.9543 1.26161 15.5534 1.64634 15.2687 2.11167V2.11167Z" stroke="#EF4136" stroke-linecap="round" stroke-linejoin="round"/>
@@ -26,7 +26,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, computed } from 'vue'
 
 import WalletConfirmTransactionModal from './WalletConfirmTransactionModal.vue'
 import WalletSidebar from './WalletSidebar.vue'
@@ -82,6 +82,10 @@ const WalletIndex = defineComponent({
       router.push({ name: 'Home', query: { modal: '' } })
     })
 
+    const isTestNet = computed(() => {
+      return activeNetwork.value && activeNetwork.value !== 'mainnet'
+    })
+
     return {
       hardwareInteractionState,
       hasWallet,
@@ -89,6 +93,7 @@ const WalletIndex = defineComponent({
       shouldShowConfirmation,
       showDeleteHWWalletPrompt,
       showLedgerVerify,
+      isTestNet,
       walletLoaded
     }
   }


### PR DESCRIPTION
This PR makes two small changes:
* The network helpers used for the default list of available gateways was incorrect
* The case of the string representing the activeNetwork has changed in the latest SDK so the test network warning was showing even when connected to mainnet.