### PR TITLE
Fix: clear caps warning on pw field on focus lost

### DIFF
--- a/src/components/PasswordField.vue
+++ b/src/components/PasswordField.vue
@@ -10,6 +10,7 @@
       :label="label"
       :validateOnInput="validateOnInput"
       :validateOnBlur="validateOnBlur"
+      @blur="clearCapsLockStatus"
       @keyup="checkCapsLock"
       @keydown.caps-lock="checkCapsLock"
     >
@@ -43,6 +44,9 @@ const PasswordField = defineComponent({
   methods: {
     checkCapsLock (event: KeyboardEvent) {
       this.isCapsEnabled = event.getModifierState('CapsLock')
+    },
+    clearCapsLockStatus () {
+      this.isCapsEnabled = false
     }
   },
 


### PR DESCRIPTION
This PR updates the password field to clear the caps lock warning when the field loses focus. This helps with screens where there are multiple password fields (ie password update, where you have current, new, and confirm new password fields); previously each individual field would track the caps lock status independently, resulting in some odd looking states. Now, the caps lock warning clears when you change fields and shouldnt display in multiple places.