### PR TITLE
chore: create parsing helper fn to parse transaction states

### DIFF
--- a/src/helpers/formatter.ts
+++ b/src/helpers/formatter.ts
@@ -28,6 +28,10 @@ export const truncateRRIStringForDisplay = function (rriString: string): string 
   return rriString.substring(0, prefixLength) + '...' + rriString.substring(rriString.length - 9)
 }
 
+export const parseUnderscoresToSpaces = function (message: string): string {
+  return message.replaceAll('_', ' ')
+}
+
 const getSortedHRPKeys = function (): string[] {
   const allHRPKeys = []
   for (const [key, val] of Object.entries(HRP)) {

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -133,7 +133,7 @@
           <div class="text-center mt-8 text-rGrayDark text-lg">
             {{ $t('transaction.submittingMessage') }}
           </div>
-          <div class="text-center mt-4 text-rGrayDark text-sm">{{ transactionState }}</div>
+          <div class="text-center mt-4 text-rGrayDark text-sm">{{ parsedTransactionState }}</div>
         </div>
       </div>
     </div>
@@ -149,6 +149,7 @@ import BigAmount from '@/components/BigAmount.vue'
 import PinInput from '@/components/PinInput.vue'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
 import { validatePin } from '@/actions/vue/create-wallet'
+import { parseUnderscoresToSpaces } from '@/helpers/formatter'
 import { useRouter } from 'vue-router'
 import { useNativeToken, useHomeModal, useTransactions, useWallet, useTokenBalances } from '@/composables'
 import { useI18n } from 'vue-i18n'
@@ -284,6 +285,10 @@ const WalletConfirmTransactionModal = defineComponent({
       transactionState.value === 'hw-signing' || transactionState.value === 'confirm' || transactionState.value === 'CONFIRMED'
     )
 
+    const parsedTransactionState: ComputedRef<string> = computed(() =>
+      parseUnderscoresToSpaces(transactionState.value)
+    )
+
     const handleConfirm = () => {
       canCancel.value = false
       confirmTransaction()
@@ -359,6 +364,7 @@ const WalletConfirmTransactionModal = defineComponent({
       meta,
       nativeToken,
       pinAttempts,
+      parsedTransactionState,
       resetForm,
       selectedCurrency,
       selectedCurrencyToken,


### PR DESCRIPTION
[Demo](https://www.loom.com/share/20d6ece30c384ac0aae9bbdb897f77a7)

This PR creates a helper function `parseUnderscoresToSpaces` and parses every `transactionState`. Previously the state `UPDATE_OF_STATUS_PENDING_TX` was displaying as is. It seems we are actually just displaying whatever comes from the API, and coincidentally this transaction state is the only multi-word state we're surfacing to the User.

Current list of transaction related messages we're receiving from API:
![image](https://user-images.githubusercontent.com/10618376/151099284-512be4fe-d730-4add-9572-abe68779cbaa.png)
