### PR TITLE
fix: send user to settings page if unable to login

### DIFF
--- a/src/components/ErrorModalGeneric.vue
+++ b/src/components/ErrorModalGeneric.vue
@@ -14,7 +14,7 @@
       <div v-if="errorsCount > 1" class="absolute top-0 right-0">
         <div class="bg-rRed rounded-full inline-block px-2 py-0.5 m-2 text-white text-sm">{{ errorsCount }}</div>
       </div>
-      <p class="mb-5">{{ error }}</p>
+      <p class="whitespace-pre-line mb-5">{{ errorMessage }}</p>
       <div class="flex flex-row space-x-5 justify-center">
         <AppButtonCancel @click="handleClose" class="w-44">{{ $t('errors.closeModal') }}</AppButtonCancel>
         <AppButtonCancel @click="refreshApp" class="w-44">{{ $t('errors.refreshApp') }}</AppButtonCancel>
@@ -53,6 +53,7 @@ export default defineComponent({
     const isVisible: Ref<boolean> = ref(true)
     const updateVisible = () => { isVisible.value = !isVisible.value }
     const error = toRef(props, 'error')
+    const errorMessage = error.value.message
     const router = useRouter()
     const { radix } = useWallet(router)
     const { clearLatestError } = useErrors(radix)
@@ -72,7 +73,8 @@ export default defineComponent({
       handleClose,
       isVisible,
       refreshApp,
-      updateVisible
+      updateVisible,
+      errorMessage
     }
   }
 })

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -291,7 +291,8 @@ const messages = {
       unableToPrepareUnstakingTransactionPointOne: 'Attempting to request an unstake in the same “epoch” (~30 min period) that you staked',
       unableToPrepareUnstakingTransactionPointTwo: 'Attempting to unstake more than you currently have staked to the validator',
       unableToPrepareUnstakingTransactionPointThree: 'Insufficient XRD to pay the required transaction fee',
-      networkError: 'Lost internet connection. Check internet connection before continuing.'
+      networkError: 'Lost internet connection. Check internet connection before continuing.',
+      gatewayError: 'Cannot connect to your currently selected gateway: %{url}. \n \n You may select a different gateway, or refresh the app to try to connect again.'
     },
     apiErrors: {
       unknown: 'Unexpected Error',


### PR DESCRIPTION
This PR fixes an issue where we weren't handling an error on login resulting from being unable to connect to custom nodes, ie https://coinwrap.co, and the error was instead being treated as an invalid password error. The user should now get sent to the settings page with an error modal if they provide a valid password but are unable to connect to their current custom node.

https://www.loom.com/share/d4b83ef722394ead95a9757a9f55fa80