### PR TITLE
fix: Isolate History Logic

### DIFF
--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -1,23 +1,25 @@
 import useConnectableRadix from './useConnectableRadix'
+import useErrors from './useErrors'
+import useHistory from './useHistory'
 import useHomeModal from './useHomeModal'
 import useNativeToken from './useNativeToken'
-import useErrors from './useErrors'
 import useSettingsTab from './useSettingsTab'
-import useStaking from './useStaking'
 import useSidebar from './useSidebar'
-import useTransactions from './useTransactions'
+import useStaking from './useStaking'
 import useTokenBalances from './useTokenBalances'
+import useTransactions from './useTransactions'
 import useWallet from './useWallet'
 
 export {
   useConnectableRadix,
+  useErrors,
+  useHistory,
   useHomeModal,
   useNativeToken,
-  useErrors,
   useSettingsTab,
-  useStaking,
   useSidebar,
-  useTransactions,
+  useStaking,
   useTokenBalances,
+  useTransactions,
   useWallet
 }

--- a/src/composables/useHistory.ts
+++ b/src/composables/useHistory.ts
@@ -1,0 +1,77 @@
+import { Radix, AccountT, SimpleExecutedTransaction, ExecutedTransaction } from '@radixdlt/application'
+import { computed, ComputedRef, Ref, ref } from 'vue'
+import { firstValueFrom, interval, Subscription } from 'rxjs'
+
+const PAGE_SIZE = 30
+
+const decryptedMessages: Ref<{id: string, message: string}[]> = ref([])
+const cursorStack: Ref<string[]> = ref([])
+const canGoBack: ComputedRef<boolean> = computed(() => cursorStack.value.length > 0)
+const canGoNext: Ref<boolean> = ref(false)
+const loadingHistory: Ref<boolean> = ref(true)
+
+const activeCursor: Ref<string> = ref('')
+
+const transactions: Ref<SimpleExecutedTransaction[]> = ref([])
+
+export default function useHistory (radix: ReturnType<typeof Radix.create>, activeAccount: AccountT) {
+  let transactionSub: Subscription | null
+
+  const fetchTransactions = async (cursor?: string) => {
+    const params = { size: PAGE_SIZE, address: activeAccount.address, cursor }
+    const data = await firstValueFrom(radix.ledger.transactionHistory(params))
+    transactions.value = data.transactions
+    loadingHistory.value = false
+    activeCursor.value = data.cursor
+    canGoNext.value = !!data.cursor && data.transactions.length === PAGE_SIZE
+    if (!transactionSub) {
+      transactionSub = interval(15000).subscribe(() => fetchTransactions(cursor))
+    }
+  }
+
+  const resetHistory = () => {
+    if (transactionSub) transactionSub.unsubscribe()
+    loadingHistory.value = true
+    cursorStack.value = []
+    transactions.value = []
+    fetchTransactions()
+  }
+
+  const decryptMessage = (tx: ExecutedTransaction) => {
+    firstValueFrom(radix.decryptTransaction(tx)).then((val) => {
+      decryptedMessages.value.push({ id: tx.txID.toString(), message: val })
+    })
+  }
+
+  const previousPage = () => {
+    if (transactionSub) transactionSub.unsubscribe()
+    loadingHistory.value = true
+    cursorStack.value.pop()
+    fetchTransactions(cursorStack.value.length > 0 ? cursorStack.value[cursorStack.value.length - 1] : '')
+  }
+
+  const nextPage = () => {
+    if (transactionSub) transactionSub.unsubscribe()
+    loadingHistory.value = true
+    cursorStack.value.push(activeCursor.value)
+    fetchTransactions(activeCursor.value)
+  }
+
+  const leavingHistory = () => {
+    if (transactionSub) transactionSub.unsubscribe()
+  }
+
+  return {
+    canGoBack,
+    canGoNext,
+    decryptedMessages,
+    loadingHistory,
+    transactions,
+    decryptMessage,
+    fetchTransactions,
+    leavingHistory,
+    nextPage,
+    previousPage,
+    resetHistory
+  }
+}

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -1,26 +1,19 @@
-import { computed, ComputedRef, ref, Ref } from 'vue'
+import { ref, Ref } from 'vue'
 import {
-  combineLatest,
-  firstValueFrom,
   interval,
   merge,
-  of,
   ReplaySubject,
   Subject,
-  Subscription,
-  timer
+  Subscription
 } from 'rxjs'
-import { catchError, mergeMap, retryWhen, take, delayWhen, tap, filter, mapTo } from 'rxjs/operators'
+import { mergeMap, take, filter, mapTo } from 'rxjs/operators'
 import {
   AmountT,
-  ExecutedTransaction,
   IntendedAction,
   ManualUserConfirmTX,
   MessageInTransaction,
   Radix,
   StakeTokensInput,
-  TransactionHistory,
-  TransactionHistoryOfKnownAddressRequestInput,
   TransactionIntent,
   TransactionStateSuccess,
   TransactionTracking,
@@ -42,7 +35,6 @@ interface useTransactionsInterface {
   readonly activeTransaction: Ref<TransactionTracking | null>;
   readonly activeTransactionForm: Ref<string | null>;
   readonly confirmationMode: Ref<string | null>;
-  readonly decryptedMessages: Ref<{id: string, message: string}[]>;
   readonly selectedCurrency: Ref<Decoded.TokenAmount | null>;
   readonly shouldShowConfirmation: Ref<boolean>;
   readonly stakeInput: Ref<StakeTokensInput | null>;
@@ -51,52 +43,32 @@ interface useTransactionsInterface {
   readonly transactionError: Ref<Error | null>;
   readonly transferInput: Ref<TransferTokensInput | null>;
   readonly transactionFee: Ref<AmountT | null>;
-  readonly transactionHistory: Ref<TransactionHistory>;
   readonly transactionErrorMessage: Ref<string | null>;
   readonly pendingTransactions: Ref<Array<TransactionIntent>>;
-  readonly canGoBack: ComputedRef<boolean>;
-  readonly canGoNext: Ref<boolean>;
-  readonly loadingHistory: Ref<boolean>;
 
   cancelTransaction: () => void;
   confirmTransaction: () => void;
-  decryptMessage: (tx: ExecutedTransaction) => void;
-  nextPage: () => void;
-  previousPage: () => void;
-  refreshHistory: () => void;
   setActiveTransactionForm: (val: string) => void;
   stakeTokens: (input: StakeTokensInput) => void;
   transferTokens: (input: TransferTokensInput, message: MessageInTransaction, sc: Decoded.TokenAmount) => void;
   unstakeTokens: (input: UnstakeTokensInput) => void;
-  transactionUnsub: () => void;
 }
 
 const transactionSubs = new Subscription()
-
-const PAGE_SIZE = 30
 
 const activeMessage: Ref<string> = ref('')
 const activeMessageInTransaction: Ref<MessageInTransaction | null> = ref(null)
 const activeTransaction: Ref<TransactionTracking | null> = ref(null)
 const activeTransactionForm: Ref<string | null> = ref(null)
-const ledgerTxError: Ref<Error | null> = ref(null)
-const loadingHistory: Ref<boolean> = ref(true)
-const loadingHistoryPage: Ref<boolean> = ref(true)
 
 const selectedCurrency: Ref<Decoded.TokenAmount | null> = ref(null)
 const shouldShowConfirmation: Ref<boolean> = ref(false)
-const canGoNext: Ref<boolean> = ref(false)
 const confirmationMode: Ref<string | null> = ref(null)
-const cursorStack: Ref<string[]> = ref([])
-const decryptedMessages: Ref<{id: string, message: string}[]> = ref([])
-const draftTransaction: Ref<TransactionIntent | null> = ref(null)
 const pendingTransactions: Ref<PendingTransaction[]> = ref([])
 const stakeInput: Ref<StakeTokensInput | null> = ref(null)
 const unstakeInput: Ref<UnstakeTokensInput | null> = ref(null)
 const transactionErrorMessage: Ref<string | null> = ref(null)
 const transactionFee: Ref<AmountT | null> = ref(null)
-const transactionHistory: Ref<TransactionHistory> = ref({ transactions: [], cursor: '' })
-const transactionToConfirm: Ref<ManualUserConfirmTX | null> = ref(null)
 const transferInput: Ref<TransferTokensInput | null> = ref(null)
 
 // can be building, confirm, submitting
@@ -105,7 +77,6 @@ const transactionError: Ref<Error | null> = ref(null)
 const userDidConfirm = new Subject<boolean>()
 const userDidCancel = new Subject<boolean>()
 const userConfirmation = new ReplaySubject<ManualUserConfirmTX>()
-const historyPagination = new Subject<TransactionHistoryOfKnownAddressRequestInput>()
 
 userConfirmation
   .pipe(
@@ -123,65 +94,6 @@ userConfirmation
 
 export default function useTransactions (radix: ReturnType<typeof Radix.create>, router: Router, activeAccount: AccountT | null, hardwareAccount: AccountT | null): useTransactionsInterface {
   const { setError } = useErrors(radix)
-  const refreshHistory = () => {
-    loadingHistory.value = true
-    historyPagination.next({ size: PAGE_SIZE })
-  }
-
-  const canGoBack = computed(() => cursorStack.value.length > 0)
-
-  const nextPage = () => {
-    loadingHistoryPage.value = true
-    cursorStack.value.push(transactionHistory.value.cursor)
-    historyPagination.next({
-      size: PAGE_SIZE,
-      cursor: cursorStack.value[cursorStack.value.length - 1]
-    })
-  }
-
-  const previousPage = () => {
-    loadingHistoryPage.value = true
-    cursorStack.value.pop()
-    historyPagination.next({
-      size: PAGE_SIZE,
-      cursor: cursorStack.value.length > 0 ? cursorStack.value[cursorStack.value.length - 1] : ''
-    })
-  }
-
-  const decryptMessage = (tx: ExecutedTransaction) => {
-    firstValueFrom(radix.decryptTransaction(tx)).then((val) => {
-      decryptedMessages.value.push({ id: tx.txID.toString(), message: val })
-    })
-  }
-
-  // Fetch history when user navigates to next page and every 15 seconds
-  const fetchTXHistoryTrigger = combineLatest<[TransactionHistoryOfKnownAddressRequestInput, number]>([
-    historyPagination.asObservable(),
-    interval(15 * 1_000)
-  ])
-  let tries = 0
-  // Fetch history when user navigates to next page
-  const historySub = fetchTXHistoryTrigger
-    .pipe(
-      mergeMap(([params]: [TransactionHistoryOfKnownAddressRequestInput, number]) =>
-        radix.transactionHistory(params).pipe(
-          retryWhen(error => error.pipe(
-            tap(() => tries++),
-            delayWhen(() => timer(100 * 2 ** tries)),
-            take(1),
-            catchError(e => of(e))
-          )),
-          tap(() => { tries = 0 })
-        )
-      )
-    )
-    .subscribe((history: TransactionHistory) => {
-      loadingHistory.value = false
-      loadingHistoryPage.value = false
-      if (history.cursor && history.transactions.length === PAGE_SIZE) canGoNext.value = true
-      else canGoNext.value = false
-      transactionHistory.value = history
-    })
 
   // Cleanup subscriptions on cancel and complete
   const cleanupTransactionSubs = () => {
@@ -335,17 +247,11 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
     )
   }
 
-  const transactionUnsub = () => {
-    historySub.unsubscribe()
-    cursorStack.value = []
-  }
-
   return {
     activeMessageInTransaction,
     activeTransaction,
     activeTransactionForm,
     confirmationMode,
-    decryptedMessages,
     selectedCurrency,
     shouldShowConfirmation,
     stakeInput,
@@ -354,23 +260,14 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
     transactionState,
     transferInput,
     transactionFee,
-    transactionHistory,
     transactionErrorMessage,
     pendingTransactions,
-    canGoBack,
-    canGoNext,
-    loadingHistory,
 
     cancelTransaction,
     confirmTransaction,
-    decryptMessage,
-    nextPage,
-    previousPage,
-    refreshHistory,
     setActiveTransactionForm,
     stakeTokens,
     transferTokens,
-    transactionUnsub,
     unstakeTokens
   }
 }

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -210,7 +210,6 @@ const WalletConfirmTransactionModal = defineComponent({
       transactionFee,
       transactionState,
       transferInput,
-      transactionUnsub,
       selectedCurrency
     } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value)
 
@@ -234,7 +233,6 @@ const WalletConfirmTransactionModal = defineComponent({
 
     onUnmounted(() => {
       nativeTokenUnsub()
-      transactionUnsub()
       window.removeEventListener('keydown', escapeListener)
     })
 

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -153,7 +153,7 @@ const WalletStaking = defineComponent({
       radix
     } = useWallet(router)
     const { activeForm, setActiveForm, activeStakes, activeUnstakes, loadingAnyStaking, stakingUnsub, validators } = useStaking(radix)
-    const { stakeTokens, unstakeTokens, transactionUnsub, setActiveTransactionForm, transactionErrorMessage } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value)
+    const { stakeTokens, unstakeTokens, setActiveTransactionForm, transactionErrorMessage } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value)
     const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
     const { tokenBalances, tokenBalanceFor, tokenInfoFor, tokenBalancesUnsub } = useTokenBalances(radix)
 
@@ -161,7 +161,6 @@ const WalletStaking = defineComponent({
       nativeTokenUnsub()
       tokenBalancesUnsub()
       stakingUnsub()
-      transactionUnsub()
     })
 
     // default active form is stake

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -156,7 +156,7 @@ const WalletTransaction = defineComponent({
     const router = useRouter()
     const { activeAddress, activeAccount, hardwareAccount, networkPreamble, radix, verifyHardwareWalletAddress } = useWallet(router)
 
-    const { transactionUnsub, setActiveTransactionForm, transferTokens } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value)
+    const { setActiveTransactionForm, transferTokens } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value)
 
     setActiveTransactionForm('transaction')
 
@@ -168,7 +168,6 @@ const WalletTransaction = defineComponent({
     onBeforeRouteLeave(() => {
       nativeTokenUnsub()
       tokenBalancesUnsub()
-      transactionUnsub()
     })
 
     // Clear form input and validation errors when switching accounts

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -63,15 +63,11 @@ const WalletIndex = defineComponent({
       waitUntilAllLoaded
     } = useWallet(router)
 
-    const { shouldShowConfirmation, transactionUnsub } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value)
+    const { shouldShowConfirmation } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value)
 
     onBeforeRouteUpdate(async () => {
       await waitUntilAllLoaded()
       return true
-    })
-
-    onBeforeRouteLeave(() => {
-      transactionUnsub()
     })
 
     // Return home if wallet is undefined


### PR DESCRIPTION
This PR isolates the logic for the History UI into an independent composeable that manages a single, interval driven subscription.

There have been a significant number of recent performance problems specifically with the history page.  We suspect that this may be due to rxjs subscriptions that were not completely cleaned up on route transitions or pagination logic.  

This works also replaces the `radix.transactionHistory` call with a collection of rxjs manipulations with a single api `radix.ledger.transactionHistory` call that returns a promised result on a `interval` subscription.  This should help eliminate the internal side effects of the main `radix` subscribe-ables and cleans up the responsibility of watching for changes in dependent values by isolating those responsibilities to the Vue app. 