### PR TITLE
feat: Add disclaimer to wallet recovery

### DIFF
--- a/src/views/CreateWallet/MultipleAccountsDisclaimer.vue
+++ b/src/views/CreateWallet/MultipleAccountsDisclaimer.vue
@@ -1,13 +1,16 @@
 <template>
-  <div>
-    <svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <circle cx="25" cy="25" r="24" stroke="#052CC0" stroke-width="1.5"/>
-    <path d="M25 14V36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M14 25H36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  </div>
+    <div class="bg-rGrayLight text-center pt-8 pb-7">
+      <div class="mb-4 flex flex-row justify-center">
+        <svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="25" cy="25" r="24" stroke="#052CC0" stroke-width="1.5"/>
+          <path d="M25 14V36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          <path d="M14 25H36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </div>
+      <div class="text-rBlue text-2xl font-light px-8">Re-adding Accounts</div>
+    </div>
 
-  <div>
+  <div class="text-center">
     <p class="text-justify p-6">If you previously used multiple accounts in the wallet, all of these accounts are associated to your seed phrase and will be recovered in the order you added them. However, the Desktop Wallet app cannot tell from the seed phrase how many accounts you had before or what you named them.<br><br>
       On the next screen you will be asked to provide a new name for the first account you used previously. After this, please use the "Add Account" feature to re-add, name, and access your other previous accounts. They will be re-added in exactly the same order as before, and will hold any tokens you held there previously.</p>
     <ButtonSubmit class="w-50 my-5" :disabled="false" @click="$emit('understood', true) ">

--- a/src/views/CreateWallet/MultipleAccountsDisclaimer.vue
+++ b/src/views/CreateWallet/MultipleAccountsDisclaimer.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    <svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="25" cy="25" r="24" stroke="#052CC0" stroke-width="1.5"/>
+    <path d="M25 14V36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M14 25H36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  </div>
+
+  <div>
+    <p class="text-justify p-6">If you previously used multiple accounts in the wallet, all of these accounts are associated to your seed phrase and will be recovered in the order you added them. However, the Desktop Wallet app cannot tell from the seed phrase how many accounts you had before or what you named them.<br><br>
+      On the next screen you will be asked to provide a new name for the first account you used previously. After this, please use the "Add Account" feature to re-add, name, and access your other previous accounts. They will be re-added in exactly the same order as before, and will hold any tokens you held there previously.</p>
+    <ButtonSubmit class="w-50 my-5" :disabled="false" @click="$emit('understood', true) ">
+      I understand
+    </ButtonSubmit>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, Ref, ref } from 'vue'
+import ButtonSubmit from '@/components/ButtonSubmit.vue'
+export default defineComponent({
+  components: {
+    ButtonSubmit
+  },
+  setup () {
+    const isVisible: Ref<boolean> = ref(true)
+    const handleClose = () => {
+      isVisible.value = false
+    }
+    return {
+      handleClose,
+      isVisible
+    }
+  },
+  emits: ['understood']
+})
+
+</script>

--- a/src/views/CreateWallet/MultipleAccountsDisclaimer.vue
+++ b/src/views/CreateWallet/MultipleAccountsDisclaimer.vue
@@ -11,9 +11,9 @@
     </div>
 
   <div class="text-center">
-    <p class="text-justify p-6">If you previously used multiple accounts in the wallet, all of these accounts are associated to your seed phrase and will be recovered in the order you added them. However, the Desktop Wallet app cannot tell from the seed phrase how many accounts you had before or what you named them.<br><br>
+    <p class="text-justify py-16 px-32">If you previously used multiple accounts in the wallet, all of these accounts are associated to your seed phrase and will be recovered in the order you added them. However, the Desktop Wallet app cannot tell from the seed phrase how many accounts you had before or what you named them.<br><br>
       On the next screen you will be asked to provide a new name for the first account you used previously. After this, please use the "Add Account" feature to re-add, name, and access your other previous accounts. They will be re-added in exactly the same order as before, and will hold any tokens you held there previously.</p>
-    <ButtonSubmit class="w-50 my-5" :disabled="false" @click="$emit('understood', true) ">
+    <ButtonSubmit class="w-50 my-10" :disabled="false" @click="$emit('understood', true) ">
       I understand
     </ButtonSubmit>
   </div>

--- a/src/views/RestoreWallet/index.vue
+++ b/src/views/RestoreWallet/index.vue
@@ -24,7 +24,6 @@
       >
       </wizard-heading>
       <div class="border border-white rounded p-3 mb-8" v-if="step === 1">{{ $t('restoreWallet.passwordHelp') }}</div>
-
       <wizard-heading
         :name="$t('restoreWallet.pinTitle')"
         :isActiveStep="step === 2"
@@ -36,8 +35,9 @@
         }"
       >
       </wizard-heading>
-      <div class="border border-white rounded p-3 mb-8" v-if="step === 2">{{ $t('restoreWallet.pinHelpOne') }}</div>
-      <div class="border border-white rounded p-3 mb-8" v-if="step === 3">{{ $t('restoreWallet.pinHelpTwo') }}</div>
+      <div class="border border-white rounded p-3 mb-8" v-if="step === 2 && !pinIsSet">{{ $t('restoreWallet.pinHelpOne') }}</div>
+      <div class="border border-white rounded p-3 mb-8" v-if="step === 3 && !pinIsSet">{{ $t('restoreWallet.pinHelpTwo') }}</div>
+      <div class="border border-white rounded p-3 mb-8" v-if="step === 3 && pinIsSet">Please confirm you understand the disclaimer</div>
 
       <router-link
         to="/"
@@ -51,14 +51,15 @@
         {{ $t('createWallet.startOver') }}
       </router-link>
     </div>
-
-    <div class="bg-white pt-headerHeight pb-8 px-11 flex-1 overflow-y-scroll">
+    <div class="bg-white pb-8" v-if="pinIsSet">
+      <multiple-accounts-disclaimer v-if="pinIsSet" @understood="completeWalletRestore"/>
+    </div>
+    <div v-else  class="bg-white pt-headerHeight pb-8 px-11 flex-1 overflow-y-scroll" >
       <restore-wallet-enter-mnemonic
         v-if="step == 0"
         @confirm="captureMnemonic"
       >
       </restore-wallet-enter-mnemonic>
-
       <create-wallet-create-passcode
         v-if="step == 1"
         @confirm="createWallet"
@@ -71,8 +72,6 @@
         @enteredPin="handleEnterPin"
       >
       </create-wallet-create-pin>
-
-      <multiple-accounts-disclaimer v-if="pinIsSet" @understood="completeWalletRestore"/>
     </div>
   </div>
 </template>

--- a/src/views/RestoreWallet/index.vue
+++ b/src/views/RestoreWallet/index.vue
@@ -8,7 +8,10 @@
         :name="$t('restoreWallet.recoveryTitle')"
         :isActiveStep="step === 0"
         :isCompleted="step > 1"
-        @click="step = 0"
+        @click="() => {
+          step = 0
+          pinIsSet = false
+        }"
       >
       </wizard-heading>
       <div v-if="step === 0">
@@ -20,7 +23,10 @@
         :isActiveStep="step === 1"
         :isCompleted="step > 1"
         :disabled="step < 1"
-        @click="step = 1"
+        @click="() => {
+          step = 1
+          pinIsSet = false
+        }"
       >
       </wizard-heading>
       <div class="border border-white rounded p-3 mb-8" v-if="step === 1">{{ $t('restoreWallet.passwordHelp') }}</div>
@@ -31,6 +37,7 @@
         :disabled="step < 2"
         @click="() => {
           step = 2
+          pinIsSet = false
           resetPinTrigger = resetPinTrigger + 1
         }"
       >
@@ -51,10 +58,10 @@
         {{ $t('createWallet.startOver') }}
       </router-link>
     </div>
-    <div class="bg-white pb-8" v-if="pinIsSet">
-      <multiple-accounts-disclaimer v-if="pinIsSet" @understood="completeWalletRestore"/>
+    <div class="bg-white flex-1 overflow-y-scroll" v-if="pinIsSet">
+      <multiple-accounts-disclaimer v-if="pinIsSet && step == 3" @understood="completeWalletRestore"/>
     </div>
-    <div v-else  class="bg-white pt-headerHeight pb-8 px-11 flex-1 overflow-y-scroll" >
+    <div v-else class="bg-white pt-headerHeight pb-8 px-11 flex-1 overflow-y-scroll" >
       <restore-wallet-enter-mnemonic
         v-if="step == 0"
         @confirm="captureMnemonic"
@@ -67,7 +74,7 @@
       </create-wallet-create-passcode>
 
       <create-wallet-create-pin
-        v-if="step == 2 || step == 3 && !pinIsSet"
+        v-if="(step == 2 || step == 3) && !pinIsSet"
         @confirm="handleCreatePin"
         @enteredPin="handleEnterPin"
       >


### PR DESCRIPTION
This PR adds an interstitial screen to remind users to re-add multiple accounts after recovery.

- Change of logic implemented so end of flow isn't on PIN confirmation
- New View added, wallet creation set to `I Understand` button now