### PR TITLE
chore: add ledger decrypt message modal

### DIFF
--- a/src/composables/useHistory.ts
+++ b/src/composables/useHistory.ts
@@ -14,6 +14,8 @@ const activeCursor: Ref<string> = ref('')
 
 const transactions: Ref<SimpleExecutedTransaction[]> = ref([])
 
+const isDecrypting: Ref<boolean> = ref(false)
+
 export default function useHistory (radix: ReturnType<typeof Radix.create>, activeAccount: AccountT) {
   let transactionSub: Subscription | null
 
@@ -38,9 +40,10 @@ export default function useHistory (radix: ReturnType<typeof Radix.create>, acti
   }
 
   const decryptMessage = (tx: ExecutedTransaction) => {
+    isDecrypting.value = true
     firstValueFrom(radix.decryptTransaction(tx)).then((val) => {
       decryptedMessages.value.push({ id: tx.txID.toString(), message: val })
-    })
+    }).finally(() => { isDecrypting.value = false })
   }
 
   const previousPage = () => {
@@ -72,6 +75,7 @@ export default function useHistory (radix: ReturnType<typeof Radix.create>, acti
     leavingHistory,
     nextPage,
     previousPage,
-    resetHistory
+    resetHistory,
+    isDecrypting
   }
 }

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -136,7 +136,8 @@ const messages = {
       noHistory: 'Sorry, but you don\'t have transaction history for this account.',
       unknownTransaction: 'Unknown transaction',
       complexTransactionSomeUnrelated: 'Complex transaction, additional actions not shown',
-      complexTransaction: 'Complex Transaction'
+      complexTransaction: 'Complex Transaction',
+      hardwareDecryptLabel: 'Please confirm decryption on your Ledger.'
     },
     transaction: {
       transactionHeading: 'Send Tokens',

--- a/src/views/Wallet/WalletHistory.vue
+++ b/src/views/Wallet/WalletHistory.vue
@@ -1,4 +1,5 @@
 <template>
+  <wallet-ledger-verify-decrypt-modal v-if="shouldShowDecryptModal" />
   <div class="flex flex-col flex-1 min-w-0 overflow-y-auto bg-white">
     <div class="bg-rGrayLightest py-6 px-8 bg-gray">
       <div class="flex justify-between">
@@ -88,18 +89,20 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, watch } from 'vue'
+import { computed, ComputedRef, defineComponent, onMounted, watch } from 'vue'
 import TransactionListItem from '@/components/TransactionListItem.vue'
 import LoadingIcon from '@/components/LoadingIcon.vue'
 import ClickToCopy from '@/components/ClickToCopy.vue'
 import { useNativeToken, useWallet, useHistory } from '@/composables'
 import { useRouter, onBeforeRouteLeave } from 'vue-router'
+import WalletLedgerVerifyDecryptModal from './WalletLedgerVerifyDecryptModal.vue'
 
 const WalletHistory = defineComponent({
   components: {
     LoadingIcon,
     ClickToCopy,
-    TransactionListItem
+    TransactionListItem,
+    WalletLedgerVerifyDecryptModal
   },
 
   setup () {
@@ -108,6 +111,7 @@ const WalletHistory = defineComponent({
       activeAddress,
       activeAccount,
       explorerUrlBase,
+      hardwareAccount,
       radix,
       verifyHardwareWalletAddress
     } = useWallet(router)
@@ -126,7 +130,8 @@ const WalletHistory = defineComponent({
       leavingHistory,
       nextPage,
       previousPage,
-      resetHistory
+      resetHistory,
+      isDecrypting
     } = useHistory(radix, activeAccount.value)
 
     const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
@@ -140,6 +145,11 @@ const WalletHistory = defineComponent({
         }
       })
     })
+
+    const shouldShowDecryptModal: ComputedRef<boolean> = computed(() =>
+      isDecrypting.value && activeAccount && hardwareAccount &&
+      activeAccount.value === hardwareAccount.value
+    )
 
     // Fetch new history when active account changes
     watch((activeAccount), () => { resetHistory() })
@@ -167,6 +177,7 @@ const WalletHistory = defineComponent({
       nextPage,
       previousPage,
       resetHistory,
+      shouldShowDecryptModal,
       transactionsWithMessages,
       verifyHardwareWalletAddress
     }

--- a/src/views/Wallet/WalletLedgerVerifyDecryptModal.vue
+++ b/src/views/Wallet/WalletLedgerVerifyDecryptModal.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="fixed w-screen h-screen z-20 flex items-center justify-center bg-translucent-black">
+    <div class="h-modalMedium bg-white rounded-md py-7 px-7 w-full max-w-3xl absolute top-1/2 left-1/4 transform -translate-x-1/4 -translate-y-1/2">
+      <div>
+        <div class="bg-white h-full flex flex-col flex-1 w-full justify-around box-border mt-52">
+          <svg width="40" height="40" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" class="container animate-spin">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M77.8789 52.8857C72.5168 68.6526 57.5862 80.0002 40.0001 80.0002C29.2115 80.0002 19.417 75.7265 12.2241 68.7838L14.9924 65.9158C21.4721 72.1701 30.2851 76.0141 40.0001 76.0141C55.8278 76.0141 69.2758 65.8025 74.1051 51.6023L77.8789 52.8857Z" fill="#052CC0"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M0 40C0 22.4565 11.2928 7.55578 26.9998 2.16064L28.2947 5.9305C14.1483 10.7896 3.98605 24.2106 3.98605 40C3.98605 46.5378 5.72622 52.663 8.76754 57.9442L5.31331 59.9334C1.93284 54.0632 0 47.2544 0 40Z" fill="#052CC0"/>
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M38.0078 0H40.0008C62.0924 0 80.0008 17.9088 80.0008 40V41.993H38.0078V0ZM41.9939 4.04026V38.007H75.9606C74.9622 19.7039 60.2972 5.03859 41.9939 4.04026Z" fill="#00C389"/>
+          </svg>
+          <div class="text-center mt-8 text-rGrayDark text-lg">
+            {{ $t('history.hardwareDecryptLabel') }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+const WalletLedgerVerifyDecryptModal = defineComponent({})
+
+export default WalletLedgerVerifyDecryptModal
+</script>


### PR DESCRIPTION
This PR updates the wallet history page to include a modal when:
1) the current active account is a hardware account, and
2) when the wallet is waiting on the hardware ledger to confirm decryption

See loom demo:
https://www.loom.com/share/526c0941717d46adb1c7df48948f132e