### PR TITLE
chore: hide hidden tokens from send dropdown

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -271,7 +271,7 @@ const messages = {
       tabTitlePassword: 'Change Password',
       tabTitlePin: 'Change PIN',
       tabTitleMnemonic: 'Reveal Seed Phrase',
-      tabTitleTokens: 'Balances',
+      tabTitleTokens: 'Tokens',
       tabTitleGateway: 'Choose Gateway'
     },
     errors: {


### PR DESCRIPTION
This PR updates the wallet to exclude hidden token from the dropdown list when sending tokens.

I attempted to take a loom, but it didn't actually show the dropdown in it! So here's some screenshots instead. Note that `wibble` is not an option in the send tokens dropdown while the token is hidden in the 'token' (previously named 'balance') tab.
<img width="1179" alt="Screen Shot 2022-02-10 at 6 21 42 PM" src="https://user-images.githubusercontent.com/8646176/153523898-9ed023cc-f543-48ba-a529-0b749b9b42cd.png">
<img width="1195" alt="Screen Shot 2022-02-10 at 6 21 52 PM" src="https://user-images.githubusercontent.com/8646176/153523895-a8955582-0896-4cf4-b71d-717910a58be0.png">

