### PR TITLE
fix: have all token symbols clickable and redirects to Explorer token page

### DIFF
--- a/src/components/ActionListItemStakeTokens.vue
+++ b/src/components/ActionListItemStakeTokens.vue
@@ -8,9 +8,9 @@
       <div>
         <big-amount :amount="action.amount" class="text-rBlack text-base"/>
         <a :href="nativeRRIUrl" target="_blank" class="group cursor-pointer relative">
-          {{ ` ${nativeToken.symbol.toUpperCase()}` }}
+          {{ ` ${this.action.rri.name.toUpperCase()}` }}
           <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 left-0 rounded-sm shadow border border-solid border-rGrayLight">
-            {{ action.rri.toString() }}
+            {{ this.action.rri.toString() }}
           </div>
         </a>
       </div>

--- a/src/components/ActionListItemStakeTokens.vue
+++ b/src/components/ActionListItemStakeTokens.vue
@@ -7,8 +7,11 @@
       </div>
       <div>
         <big-amount :amount="action.amount" class="text-rBlack text-base"/>
-        <a :href="nativeRRIUrl" target="_blank">
+        <a :href="nativeRRIUrl" target="_blank" class="group cursor-pointer relative">
           {{ ` ${nativeToken.symbol.toUpperCase()}` }}
+          <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 left-0 rounded-sm shadow border border-solid border-rGrayLight">
+            {{ action.rri.toString() }}
+          </div>
         </a>
       </div>
     </div>

--- a/src/components/ActionListItemStakeTokens.vue
+++ b/src/components/ActionListItemStakeTokens.vue
@@ -5,7 +5,12 @@
         <img src="@/assets/stakeTokens.svg" alt="receive tokens" />
         <span class="ml-2 text-sm">{{ $t('history.stakeAction') }}</span>
       </div>
-      <div><big-amount :amount="action.amount" class="text-rBlack text-base"/> {{ nativeToken.symbol.toUpperCase() }}</div>
+      <div>
+        <big-amount :amount="action.amount" class="text-rBlack text-base"/>
+        <a :href="nativeRRIUrl" target="_blank">
+          {{ ` ${nativeToken.symbol.toUpperCase()}` }}
+        </a>
+      </div>
     </div>
     <div class="flex flex-col items-end">
       <div class="flex flex-row flex-1 min-w-0">
@@ -41,12 +46,19 @@ const ActionListItemStakeTokens = defineComponent({
     nativeToken: {
       type: Object as PropType<Token>,
       required: true
+    },
+    explorerUrlBase: {
+      type: String,
+      required: true
     }
   },
 
   computed: {
     displayAddress (): string {
       return formatValidatorAddressForDisplay(this.action.to_validator)
+    },
+    nativeRRIUrl (): string {
+      return `${this.explorerUrlBase}/#/tokens/${this.nativeToken.rri.toString()}`
     }
   }
 })

--- a/src/components/ActionListItemStakeTokens.vue
+++ b/src/components/ActionListItemStakeTokens.vue
@@ -7,12 +7,12 @@
       </div>
       <div>
         <big-amount :amount="action.amount" class="text-rBlack text-base"/>
-        <a :href="nativeRRIUrl" target="_blank" class="group cursor-pointer relative">
-          {{ ` ${this.action.rri.name.toUpperCase()}` }}
-          <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 left-0 rounded-sm shadow border border-solid border-rGrayLight">
-            {{ this.action.rri.toString() }}
-          </div>
-        </a>
+        <token-symbol
+          :symbol="this.action.rri.name.toUpperCase()"
+          :rri="this.action.rri.toString()"
+          :hasGreyBackground="false"
+        >
+        </token-symbol>
       </div>
     </div>
     <div class="flex flex-col items-end">
@@ -30,11 +30,13 @@ import { ExecutedStakeTokensAction, Token } from '@radixdlt/application'
 import ClickToCopy from '@/components/ClickToCopy.vue'
 import { formatValidatorAddressForDisplay } from '@/helpers/formatter'
 import BigAmount from '@/components/BigAmount.vue'
+import TokenSymbol from '@/components/TokenSymbol.vue'
 
 const ActionListItemStakeTokens = defineComponent({
   components: {
     BigAmount,
-    ClickToCopy
+    ClickToCopy,
+    TokenSymbol
   },
 
   props: {
@@ -49,19 +51,12 @@ const ActionListItemStakeTokens = defineComponent({
     nativeToken: {
       type: Object as PropType<Token>,
       required: true
-    },
-    explorerUrlBase: {
-      type: String,
-      required: true
     }
   },
 
   computed: {
     displayAddress (): string {
       return formatValidatorAddressForDisplay(this.action.to_validator)
-    },
-    nativeRRIUrl (): string {
-      return `${this.explorerUrlBase}/#/tokens/${this.nativeToken.rri.toString()}`
     }
   }
 })

--- a/src/components/ActionListItemTransferTokens.vue
+++ b/src/components/ActionListItemTransferTokens.vue
@@ -11,12 +11,12 @@
       </div>
       <div>
         <big-amount :amount="action.amount" class="text-rBlack text-base"/>
-        <a :href="tokenExplorerUrl" target="_blank" class="group cursor-pointer relative">
-          {{ ` ${this.action.rri.name.toUpperCase()}` }}
-          <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 left-0 rounded-sm shadow border border-solid border-rGrayLight">
-            {{ this.action.rri.toString() }}
-          </div>
-        </a>
+        <token-symbol
+          :symbol="this.action.rri.name.toUpperCase()"
+          :rri="this.action.rri.toString()"
+          :hasGreyBackground="false"
+        >
+        </token-symbol>
       </div>
     </div>
     <div class="flex flex-col items-end">
@@ -38,11 +38,13 @@ import { ExecutedTransferTokensAction, AccountAddressT } from '@radixdlt/applica
 import ClickToCopy from '@/components/ClickToCopy.vue'
 import { formatWalletAddressForDisplay } from '@/helpers/formatter'
 import BigAmount from '@/components/BigAmount.vue'
+import TokenSymbol from '@/components/TokenSymbol.vue'
 
 const ActionListItemTransferTokens = defineComponent({
   components: {
     BigAmount,
-    ClickToCopy
+    ClickToCopy,
+    TokenSymbol
   },
 
   props: {
@@ -57,10 +59,6 @@ const ActionListItemTransferTokens = defineComponent({
     index: {
       type: Number,
       required: true
-    },
-    explorerUrlBase: {
-      type: String,
-      required: true
     }
   },
 
@@ -68,9 +66,6 @@ const ActionListItemTransferTokens = defineComponent({
     isRecipient (): boolean {
       if (!this.activeAddress) return false
       return this.action.to_account.equals(this.activeAddress)
-    },
-    tokenExplorerUrl (): string {
-      return `${this.explorerUrlBase}/#/tokens/${this.action.rri.toString()}`
     }
   },
 

--- a/src/components/ActionListItemTransferTokens.vue
+++ b/src/components/ActionListItemTransferTokens.vue
@@ -11,8 +11,11 @@
       </div>
       <div>
         <big-amount :amount="action.amount" class="text-rBlack text-base"/>
-        <a :href="tokenExplorerUrl" target="_blank">
+        <a :href="tokenExplorerUrl" target="_blank" class="group cursor-pointer relative">
           {{ ` ${this.action.rri.name.toUpperCase()}` }}
+          <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 left-0 rounded-sm shadow border border-solid border-rGrayLight">
+            {{ this.action.rri.toString() }}
+          </div>
         </a>
       </div>
     </div>

--- a/src/components/ActionListItemTransferTokens.vue
+++ b/src/components/ActionListItemTransferTokens.vue
@@ -9,7 +9,12 @@
         <img src="@/assets/sendTokens.svg" alt="send tokens" class="w-6 h-auto" />
         <span class="ml-2 text-sm">{{ $t('history.sentAction') }}</span>
       </div>
-      <div><big-amount :amount="action.amount" class="text-rBlack text-base"/> {{ this.action.rri.name.toUpperCase() }}</div>
+      <div>
+        <big-amount :amount="action.amount" class="text-rBlack text-base"/>
+        <a :href="tokenExplorerUrl" target="_blank">
+          {{ ` ${this.action.rri.name.toUpperCase()}` }}
+        </a>
+      </div>
     </div>
     <div class="flex flex-col items-end">
       <div v-if="!isRecipient" class="flex flex-row flex-1 min-w-0">
@@ -49,6 +54,10 @@ const ActionListItemTransferTokens = defineComponent({
     index: {
       type: Number,
       required: true
+    },
+    explorerUrlBase: {
+      type: String,
+      required: true
     }
   },
 
@@ -56,6 +65,9 @@ const ActionListItemTransferTokens = defineComponent({
     isRecipient (): boolean {
       if (!this.activeAddress) return false
       return this.action.to_account.equals(this.activeAddress)
+    },
+    tokenExplorerUrl (): string {
+      return `${this.explorerUrlBase}/#/tokens/${this.action.rri.toString()}`
     }
   },
 

--- a/src/components/ActionListItemUnstakeTokens.vue
+++ b/src/components/ActionListItemUnstakeTokens.vue
@@ -5,7 +5,12 @@
         <img src="@/assets/unstakeTokens.svg" alt="receive tokens" />
         <span class="ml-2 text-sm">{{ $t('history.unstakeAction') }}</span>
       </div>
-      <div v-if="action.amount && nativeToken"><big-amount :amount="action.amount" class="text-rBlack text-base"/> {{ nativeToken.symbol.toUpperCase() }}</div>
+      <div v-if="action.amount && nativeToken">
+        <big-amount :amount="action.amount" class="text-rBlack text-base"/>
+         <a :href="nativeRRIUrl" target="_blank">
+          {{ ` ${nativeToken.symbol.toUpperCase()}` }}
+        </a>
+      </div>
     </div>
     <div class="flex flex-col items-end">
       <div class="flex flex-row flex-1 min-w-0 items-center">
@@ -41,11 +46,18 @@ const ActionListItemUnstakeTokens = defineComponent({
     nativeToken: {
       type: Object as PropType<Token>,
       required: true
+    },
+    explorerUrlBase: {
+      type: String,
+      required: true
     }
   },
   computed: {
     displayAddress (): string {
       return formatValidatorAddressForDisplay(this.action.from_validator)
+    },
+    nativeRRIUrl (): string {
+      return `${this.explorerUrlBase}/#/tokens/${this.nativeToken.rri.toString()}`
     }
   }
 })

--- a/src/components/ActionListItemUnstakeTokens.vue
+++ b/src/components/ActionListItemUnstakeTokens.vue
@@ -7,12 +7,12 @@
       </div>
       <div v-if="action.amount && nativeToken">
         <big-amount :amount="action.amount" class="text-rBlack text-base"/>
-         <a :href="nativeRRIUrl" target="_blank" class="group cursor-pointer relative">
-          {{ ` ${nativeToken.symbol.toUpperCase()}` }}
-          <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 left-0 rounded-sm shadow border border-solid border-rGrayLight">
-            {{ action.rri.toString() }}
-          </div>
-        </a>
+        <token-symbol
+          :symbol="nativeToken.symbol.toUpperCase()"
+          :rri="action.rri.toString()"
+          :hasGreyBackground="false"
+        >
+        </token-symbol>
       </div>
     </div>
     <div class="flex flex-col items-end">
@@ -30,11 +30,13 @@ import { ExecutedUnstakeTokensAction, Token } from '@radixdlt/application'
 import ClickToCopy from '@/components/ClickToCopy.vue'
 import { formatValidatorAddressForDisplay } from '@/helpers/formatter'
 import BigAmount from '@/components/BigAmount.vue'
+import TokenSymbol from '@/components/TokenSymbol.vue'
 
 const ActionListItemUnstakeTokens = defineComponent({
   components: {
     BigAmount,
-    ClickToCopy
+    ClickToCopy,
+    TokenSymbol
   },
 
   props: {
@@ -49,18 +51,11 @@ const ActionListItemUnstakeTokens = defineComponent({
     nativeToken: {
       type: Object as PropType<Token>,
       required: true
-    },
-    explorerUrlBase: {
-      type: String,
-      required: true
     }
   },
   computed: {
     displayAddress (): string {
       return formatValidatorAddressForDisplay(this.action.from_validator)
-    },
-    nativeRRIUrl (): string {
-      return `${this.explorerUrlBase}/#/tokens/${this.nativeToken.rri.toString()}`
     }
   }
 })

--- a/src/components/ActionListItemUnstakeTokens.vue
+++ b/src/components/ActionListItemUnstakeTokens.vue
@@ -7,8 +7,11 @@
       </div>
       <div v-if="action.amount && nativeToken">
         <big-amount :amount="action.amount" class="text-rBlack text-base"/>
-         <a :href="nativeRRIUrl" target="_blank">
+         <a :href="nativeRRIUrl" target="_blank" class="group cursor-pointer relative">
           {{ ` ${nativeToken.symbol.toUpperCase()}` }}
+          <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 left-0 rounded-sm shadow border border-solid border-rGrayLight">
+            {{ action.rri.toString() }}
+          </div>
         </a>
       </div>
     </div>

--- a/src/components/HiddenTokenBalanceListItem.vue
+++ b/src/components/HiddenTokenBalanceListItem.vue
@@ -2,7 +2,13 @@
   <div v-if="tokenBalance" class="border border-rGray rounded-md p-6 mb-5 flex flex-row items-center justify-between">
     <div class="flex flex-row items-center flex-1">
       <BigAmount :amount="tokenBalance.value" class="text-4xl font-light mr-4 text-rBlack" />
-      <TokenSymbol v-if="token">{{ token.symbol.toUpperCase() }}</TokenSymbol>
+      <token-symbol
+        v-if="token"
+        :symbol="token.symbol.toUpperCase()"
+        :rri="token.rri.toString()"
+        :hasGreyBackground="true"
+      >
+      </token-symbol>
     </div>
 
     <AppButtonIcon

--- a/src/components/OtherTokenBalanceListItem.vue
+++ b/src/components/OtherTokenBalanceListItem.vue
@@ -38,7 +38,12 @@
       <div class="flex flex-row py-1 mt-6">
         <div class="flex-1 flex flex-row items-center px-6 py-3">
           <big-amount :amount="tokenBalance.value" class="text-2xl font-light mr-4 text-rBlack" />
-          <token-symbol v-if="token">{{ token.symbol.toUpperCase() }}</token-symbol>
+          <token-symbol
+            v-if="token"
+            :rriUrl="rriUrl"
+          >
+            {{ token.symbol.toUpperCase() }}
+          </token-symbol>
         </div>
       </div>
     </div>

--- a/src/components/OtherTokenBalanceListItem.vue
+++ b/src/components/OtherTokenBalanceListItem.vue
@@ -42,7 +42,8 @@
             v-if="token"
             :rriUrl="rriUrl"
           >
-            {{ token.symbol.toUpperCase() }}
+            <template v-slot:symbol>{{ token.symbol.toUpperCase() }}</template>
+            <template v-slot:hoverText>{{ token.rri.toString() }}</template>
           </token-symbol>
         </div>
       </div>

--- a/src/components/OtherTokenBalanceListItem.vue
+++ b/src/components/OtherTokenBalanceListItem.vue
@@ -40,10 +40,10 @@
           <big-amount :amount="tokenBalance.value" class="text-2xl font-light mr-4 text-rBlack" />
           <token-symbol
             v-if="token"
-            :rriUrl="rriUrl"
+            :symbol="token.symbol.toUpperCase()"
+            :rri="token.rri.toString()"
+            :hasGreyBackground="true"
           >
-            <template v-slot:symbol>{{ token.symbol.toUpperCase() }}</template>
-            <template v-slot:hoverText>{{ token.rri.toString() }}</template>
           </token-symbol>
         </div>
       </div>

--- a/src/components/StakeListItem.vue
+++ b/src/components/StakeListItem.vue
@@ -64,8 +64,11 @@
             <div class="mb-1 w-26 flex-grow-0 text-rGrayMed text-xs">{{ $t('staking.pendingStakeLabel') }}:</div>
             <div class="mb-1 flex-1 text-rBlack">
               <big-amount :amount="pendingStakeAmount" />
-              <a :href="nativeTokenRRIUrl" target="_blank">
+              <a :href="nativeTokenRRIUrl" target="_blank" class="group cursor-pointer relative">
                 <span class="text-rGrayDark ml-1 uppercase">{{ nativeToken.symbol }}</span>
+                <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight">
+                  <span>{{ nativeToken && nativeToken.rri.toString() }}</span>
+                </div>
               </a>
             </div>
           </div>
@@ -73,8 +76,11 @@
             <div class="mb-1 w-26 flex-grow-0 text-rGrayMed text-xs">{{ $t('staking.stakedLabel') }}:</div>
             <div class="mb-1 flex-1 text-rBlack">
               <big-amount :amount="getActiveStakeAmountForValidator(validatorAddress)" />
-              <a :href="nativeTokenRRIUrl" target="_blank">
+              <a :href="nativeTokenRRIUrl" target="_blank" class="group cursor-pointer relative">
                 <span class="text-rGrayDark ml-1 uppercase">{{ nativeToken.symbol }}</span>
+                <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight">
+                  <span>{{ nativeToken && nativeToken.rri.toString() }}</span>
+                </div>
               </a>
             </div>
           </div>
@@ -82,8 +88,11 @@
             <div class="mb-1 w-26 flex-grow-0 text-rGrayMed text-xs">{{ $t('staking.unstakingLabel') }}:</div>
             <div class="mb-1 flex-1 text-rBlack">
               <big-amount :amount="unstakeAmount" />
-              <a :href="nativeTokenRRIUrl" target="_blank">
+              <a :href="nativeTokenRRIUrl" target="_blank" class="group cursor-pointer relative">
                 <span class="text-rGrayDark ml-1 uppercase">{{ nativeToken.symbol }}</span>
+                <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight">
+                  <span>{{ nativeToken && nativeToken.rri.toString() }}</span>
+                </div>
               </a>
             </div>
           </div>

--- a/src/components/StakeListItem.vue
+++ b/src/components/StakeListItem.vue
@@ -62,15 +62,30 @@
         <dl class="mt-1">
           <div v-if="validateGreaterThanZero(pendingStakeAmount)" class="flex items-center flex-wrap">
             <div class="mb-1 w-26 flex-grow-0 text-rGrayMed text-xs">{{ $t('staking.pendingStakeLabel') }}:</div>
-            <div class="mb-1 flex-1 text-rBlack"><big-amount :amount="pendingStakeAmount" /> <span class="text-rGrayDark ml-1 uppercase">{{ nativeToken.symbol }}</span></div>
+            <div class="mb-1 flex-1 text-rBlack">
+              <big-amount :amount="pendingStakeAmount" />
+              <a :href="nativeTokenRRIUrl" target="_blank">
+                <span class="text-rGrayDark ml-1 uppercase">{{ nativeToken.symbol }}</span>
+              </a>
+            </div>
           </div>
           <div class="flex items-center flex-wrap">
             <div class="mb-1 w-26 flex-grow-0 text-rGrayMed text-xs">{{ $t('staking.stakedLabel') }}:</div>
-            <div class="mb-1 flex-1 text-rBlack"><big-amount :amount="getActiveStakeAmountForValidator(validatorAddress)" /> <span class="text-rGrayDark ml-1 uppercase">{{ nativeToken.symbol }}</span></div>
+            <div class="mb-1 flex-1 text-rBlack">
+              <big-amount :amount="getActiveStakeAmountForValidator(validatorAddress)" />
+              <a :href="nativeTokenRRIUrl" target="_blank">
+                <span class="text-rGrayDark ml-1 uppercase">{{ nativeToken.symbol }}</span>
+              </a>
+            </div>
           </div>
           <div v-if="validateGreaterThanZero(unstakeAmount)" class="flex items-center flex-wrap">
             <div class="mb-1 w-26 flex-grow-0 text-rGrayMed text-xs">{{ $t('staking.unstakingLabel') }}:</div>
-            <div class="mb-1 flex-1 text-rBlack"><big-amount :amount="unstakeAmount" /> <span class="text-rGrayDark ml-1 uppercase">{{ nativeToken.symbol }}</span></div>
+            <div class="mb-1 flex-1 text-rBlack">
+              <big-amount :amount="unstakeAmount" />
+              <a :href="nativeTokenRRIUrl" target="_blank">
+                <span class="text-rGrayDark ml-1 uppercase">{{ nativeToken.symbol }}</span>
+              </a>
+            </div>
           </div>
         </dl>
       </div>
@@ -163,9 +178,14 @@ const StakeListItem = defineComponent({
     const unstakeAmount: ComputedRef<AmountT> = computed(() => getUnstakeAmountForValidator(props.validatorAddress))
     const pendingStakeAmount: ComputedRef<AmountT> = computed(() => getPendingStakeAmountForValidator(props.validatorAddress))
 
+    const nativeTokenRRIUrl: ComputedRef<string> = computed(() => {
+      return `${props.explorerUrlBase}/#/tokens/${props.nativeToken.rri.toString()}`
+    })
+
     return {
       explorerUrl,
       inTopOneHundred,
+      nativeTokenRRIUrl,
       pendingStakeAmount,
       unstakeAmount,
       validateGreaterThanZero,

--- a/src/components/StakeListItem.vue
+++ b/src/components/StakeListItem.vue
@@ -64,36 +64,36 @@
             <div class="mb-1 w-26 flex-grow-0 text-rGrayMed text-xs">{{ $t('staking.pendingStakeLabel') }}:</div>
             <div class="mb-1 flex-1 text-rBlack">
               <big-amount :amount="pendingStakeAmount" />
-              <a :href="nativeTokenRRIUrl" target="_blank" class="group cursor-pointer relative">
-                <span class="text-rGrayDark ml-1 uppercase">{{ nativeToken.symbol }}</span>
-                <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight">
-                  <span>{{ nativeToken && nativeToken.rri.toString() }}</span>
-                </div>
-              </a>
+              <token-symbol
+                :symbol="nativeToken.symbol"
+                :rri="nativeToken.rri.toString()"
+                :hasGreyBackground="false"
+              >
+              </token-symbol>
             </div>
           </div>
           <div class="flex items-center flex-wrap">
             <div class="mb-1 w-26 flex-grow-0 text-rGrayMed text-xs">{{ $t('staking.stakedLabel') }}:</div>
             <div class="mb-1 flex-1 text-rBlack">
               <big-amount :amount="getActiveStakeAmountForValidator(validatorAddress)" />
-              <a :href="nativeTokenRRIUrl" target="_blank" class="group cursor-pointer relative">
-                <span class="text-rGrayDark ml-1 uppercase">{{ nativeToken.symbol }}</span>
-                <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight">
-                  <span>{{ nativeToken && nativeToken.rri.toString() }}</span>
-                </div>
-              </a>
+              <token-symbol
+                :symbol="nativeToken.symbol"
+                :rri="nativeToken.rri.toString()"
+                :hasGreyBackground="false"
+              >
+              </token-symbol>
             </div>
           </div>
           <div v-if="validateGreaterThanZero(unstakeAmount)" class="flex items-center flex-wrap">
             <div class="mb-1 w-26 flex-grow-0 text-rGrayMed text-xs">{{ $t('staking.unstakingLabel') }}:</div>
             <div class="mb-1 flex-1 text-rBlack">
               <big-amount :amount="unstakeAmount" />
-              <a :href="nativeTokenRRIUrl" target="_blank" class="group cursor-pointer relative">
-                <span class="text-rGrayDark ml-1 uppercase">{{ nativeToken.symbol }}</span>
-                <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight">
-                  <span>{{ nativeToken && nativeToken.rri.toString() }}</span>
-                </div>
-              </a>
+              <token-symbol
+                :symbol="nativeToken.symbol"
+                :rri="nativeToken.rri.toString()"
+                :hasGreyBackground="false"
+              >
+              </token-symbol>
             </div>
           </div>
         </dl>
@@ -131,11 +131,13 @@ import { useStaking, useWallet } from '@/composables'
 import { useRouter } from 'vue-router'
 import { Observed } from '@/helpers/typeHelpers'
 import { validateGreaterThanZero } from '@/helpers/validateRadixTypes'
+import TokenSymbol from '@/components/TokenSymbol.vue'
 
 const StakeListItem = defineComponent({
   components: {
     BigAmount,
     ClickToCopy,
+    TokenSymbol,
     Tooltip
   },
 
@@ -187,14 +189,9 @@ const StakeListItem = defineComponent({
     const unstakeAmount: ComputedRef<AmountT> = computed(() => getUnstakeAmountForValidator(props.validatorAddress))
     const pendingStakeAmount: ComputedRef<AmountT> = computed(() => getPendingStakeAmountForValidator(props.validatorAddress))
 
-    const nativeTokenRRIUrl: ComputedRef<string> = computed(() => {
-      return `${props.explorerUrlBase}/#/tokens/${props.nativeToken.rri.toString()}`
-    })
-
     return {
       explorerUrl,
       inTopOneHundred,
-      nativeTokenRRIUrl,
       pendingStakeAmount,
       unstakeAmount,
       validateGreaterThanZero,

--- a/src/components/TokenSymbol.vue
+++ b/src/components/TokenSymbol.vue
@@ -1,5 +1,9 @@
 <template>
-  <a :href="rriUrl" target="_blank" class="group cursor-pointer relative">
+  <a
+    :href="rriUrl"
+    target="_blank"
+    class="group cursor-pointer relative"
+  >
     <div class="font-light text-rGrayMark bg-rGrayLight border border-rGray py-0.5 px-1 rounded borderself-end uppercase">
       <slot name="symbol"></slot>
       <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight">
@@ -10,13 +14,42 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { useWallet } from '@/composables'
+import { ExecutedStakeTokensAction } from '@radixdlt/application'
+import { Token } from '@radixdlt/networking'
+import { computed, defineComponent, PropType } from 'vue'
+import { useRouter } from 'vue-router'
 
 export default defineComponent({
   props: {
-    rriUrl: {
+    // rriUrl: {
+    //   type: String,
+    //   required: true
+    // }
+    // token: {
+    //   type: Object as PropType<ExecutedStakeTokensAction | Token>,
+    //   required: false
+    // },
+    symbol: {
       type: String,
       required: true
+    },
+    rri: {
+      type: String,
+      required: true
+    }
+  },
+
+  setup (props) {
+    const router = useRouter()
+    const { explorerUrlBase } = useWallet(router)
+
+    const rriUrl = computed(() => {
+      return `${explorerUrlBase}/${props.rri}` // todo: fix alex's thing
+    })
+
+    return {
+      rriUrl
     }
   }
 })

--- a/src/components/TokenSymbol.vue
+++ b/src/components/TokenSymbol.vue
@@ -1,7 +1,10 @@
 <template>
-  <a :href="rriUrl" target="_blank">
+  <a :href="rriUrl" target="_blank" class="group cursor-pointer relative">
     <div class="font-light text-rGrayMark bg-rGrayLight border border-rGray py-0.5 px-1 rounded borderself-end uppercase">
-      <slot></slot>
+      <slot name="symbol"></slot>
+      <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight">
+        <slot name="hoverText"></slot>
+      </div>
     </div>
   </a>
 </template>

--- a/src/components/TokenSymbol.vue
+++ b/src/components/TokenSymbol.vue
@@ -2,40 +2,33 @@
   <a
     :href="rriUrl"
     target="_blank"
-    class="group cursor-pointer relative"
+    class="group cursor-pointer relative font-light text-rGrayMark py-0.5 px-1 rounded borderself-end uppercase"
+    :class="{'bg-rGrayLight border border-rGray': hasGreyBackground}"
   >
-    <div class="font-light text-rGrayMark bg-rGrayLight border border-rGray py-0.5 px-1 rounded borderself-end uppercase">
-      <slot name="symbol"></slot>
-      <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight">
-        <slot name="hoverText"></slot>
-      </div>
+    {{ symbol }}
+    <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 rounded-sm shadow border border-solid border-rGrayLight">
+      {{ rri }}
     </div>
   </a>
 </template>
 
 <script lang="ts">
 import { useWallet } from '@/composables'
-import { ExecutedStakeTokensAction } from '@radixdlt/application'
-import { Token } from '@radixdlt/networking'
-import { computed, defineComponent, PropType } from 'vue'
+import { computed, defineComponent } from 'vue'
 import { useRouter } from 'vue-router'
 
 export default defineComponent({
   props: {
-    // rriUrl: {
-    //   type: String,
-    //   required: true
-    // }
-    // token: {
-    //   type: Object as PropType<ExecutedStakeTokensAction | Token>,
-    //   required: false
-    // },
     symbol: {
       type: String,
       required: true
     },
     rri: {
       type: String,
+      required: true
+    },
+    hasGreyBackground: {
+      type: Boolean,
       required: true
     }
   },
@@ -45,7 +38,7 @@ export default defineComponent({
     const { explorerUrlBase } = useWallet(router)
 
     const rriUrl = computed(() => {
-      return `${explorerUrlBase}/${props.rri}` // todo: fix alex's thing
+      return `${explorerUrlBase.value}#/tokens/${props.rri}`
     })
 
     return {

--- a/src/components/TokenSymbol.vue
+++ b/src/components/TokenSymbol.vue
@@ -1,14 +1,20 @@
 <template>
-  <div class="font-light text-rGrayMark bg-rGrayLight border border-rGray py-0.5 px-1 rounded borderself-end uppercase">
-    <slot></slot>
-  </div>
+  <a :href="rriUrl" target="_blank">
+    <div class="font-light text-rGrayMark bg-rGrayLight border border-rGray py-0.5 px-1 rounded borderself-end uppercase">
+      <slot></slot>
+    </div>
+  </a>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue'
 
-const TokenSymbol = defineComponent({
+export default defineComponent({
+  props: {
+    rriUrl: {
+      type: String,
+      required: true
+    }
+  }
 })
-
-export default TokenSymbol
 </script>

--- a/src/components/TransactionListItem.vue
+++ b/src/components/TransactionListItem.vue
@@ -32,21 +32,18 @@
             :action="action"
             :index="i"
             :nativeToken="nativeToken"
-            :explorerUrlBase="explorerUrlBase"
           />
           <action-list-item-unstake-tokens
             v-else-if="action.type === 'UnstakeTokens'"
             :action="action"
             :index="i"
             :nativeToken="nativeToken"
-            :explorerUrlBase="explorerUrlBase"
           />
           <action-list-item-transfer-tokens
             v-else-if="action.type === 'TokenTransfer'"
             :action="action"
             :index="i"
             :activeAddress="activeAddress"
-            :explorerUrlBase="explorerUrlBase"
           />
           <action-list-item-other
             v-else

--- a/src/components/TransactionListItem.vue
+++ b/src/components/TransactionListItem.vue
@@ -32,18 +32,21 @@
             :action="action"
             :index="i"
             :nativeToken="nativeToken"
+            :explorerUrlBase="explorerUrlBase"
           />
           <action-list-item-unstake-tokens
             v-else-if="action.type === 'UnstakeTokens'"
             :action="action"
             :index="i"
             :nativeToken="nativeToken"
+            :explorerUrlBase="explorerUrlBase"
           />
           <action-list-item-transfer-tokens
             v-else-if="action.type === 'TokenTransfer'"
             :action="action"
             :index="i"
             :activeAddress="activeAddress"
+            :explorerUrlBase="explorerUrlBase"
           />
           <action-list-item-other
             v-else
@@ -142,6 +145,10 @@ export default defineComponent({
       `${props.explorerUrlBase}/#/transactions/${props.transaction.txID}`
     )
 
+    // const explorerTokenUrl: ComputedRef<string> = computed(() =>
+    //   props.explorerUrlBase.toString()
+    // )
+
     const relatedActions: ComputedRef<ExecutedAction[]> = computed(() => {
       return props.transaction.actions.filter((action: ExecutedAction) => {
         let related
@@ -173,6 +180,7 @@ export default defineComponent({
     return {
       customTxnDisplayType,
       explorerUrl,
+      // explorerUrlBase,
       relatedActions
     }
   },

--- a/src/components/TransactionListItem.vue
+++ b/src/components/TransactionListItem.vue
@@ -145,10 +145,6 @@ export default defineComponent({
       `${props.explorerUrlBase}/#/transactions/${props.transaction.txID}`
     )
 
-    // const explorerTokenUrl: ComputedRef<string> = computed(() =>
-    //   props.explorerUrlBase.toString()
-    // )
-
     const relatedActions: ComputedRef<ExecutedAction[]> = computed(() => {
       return props.transaction.actions.filter((action: ExecutedAction) => {
         let related
@@ -180,7 +176,6 @@ export default defineComponent({
     return {
       customTxnDisplayType,
       explorerUrl,
-      // explorerUrlBase,
       relatedActions
     }
   },

--- a/src/views/Wallet/WalletOverview.vue
+++ b/src/views/Wallet/WalletOverview.vue
@@ -22,7 +22,10 @@
           <div class="flex flex-row items-end">
             <div v-if="loading" class="text-2xl font-light mr-4 text-rGreen">--</div>
             <big-amount :amount="availablePlusStakedAndUnstakedXRD" class="text-2xl font-light mr-4 text-rGreen" v-else />
-            <token-symbol :rriUrl="nativeTokenRRIUrl">{{ nativeToken && nativeToken.symbol }}</token-symbol>
+            <token-symbol :rriUrl="nativeTokenRRIUrl">
+              <template v-slot:symbol>{{ nativeToken && nativeToken.symbol }}</template>
+              <template v-slot:hoverText>{{ nativeToken && nativeToken.rri.toString() }}</template>
+            </token-symbol>
           </div>
         </div>
         <div class="flex flex-col my-3 px-5 border-r border-rGray flex-1">
@@ -30,7 +33,10 @@
           <div class="flex flex-row items-end">
             <div v-if="loading" class="text-2xl font-light mr-4 text-rBlack">--</div>
             <big-amount :amount="totalXRD" class="text-2xl font-light mr-4 text-rBlack" v-else />
-            <token-symbol :rriUrl="nativeTokenRRIUrl">{{ nativeToken && nativeToken.symbol }}</token-symbol>
+            <token-symbol :rriUrl="nativeTokenRRIUrl">
+              <template v-slot:symbol>{{ nativeToken && nativeToken.symbol }}</template>
+              <template v-slot:hoverText>{{ nativeToken && nativeToken.rri.toString() }}</template>
+            </token-symbol>
           </div>
         </div>
         <div class="flex flex-col my-3 px-5 flex-1">
@@ -38,7 +44,10 @@
           <div class="flex flex-row items-end">
             <div v-if="loading" class="text-2xl font-light mr-4 text-rBlack">--</div>
             <big-amount :amount="totalStakedAndUnstaked" class="text-2xl font-light mr-4 text-rBlack" v-else />
-            <token-symbol :rriUrl="nativeTokenRRIUrl">{{ nativeToken && nativeToken.symbol }}</token-symbol>
+            <token-symbol :rriUrl="nativeTokenRRIUrl">
+              <template v-slot:symbol>{{ nativeToken && nativeToken.symbol }}</template>
+              <template v-slot:hoverText>{{ nativeToken && nativeToken.rri.toString() }}</template>
+            </token-symbol>
           </div>
         </div>
       </div>

--- a/src/views/Wallet/WalletOverview.vue
+++ b/src/views/Wallet/WalletOverview.vue
@@ -233,14 +233,6 @@ const WalletOverview = defineComponent({
       })
     })
 
-    const nativeTokenRRIUrl: ComputedRef<string> = computed(() => {
-      if (nativeToken.value && explorerUrlBase) {
-        return `${explorerUrlBase.value}/#/tokens/${nativeToken.value.rri.toString()}`
-      } else {
-        return `${explorerUrlBase}/#/`
-      }
-    })
-
     return {
       activeAddress,
       activeStakes,
@@ -250,7 +242,6 @@ const WalletOverview = defineComponent({
       loading,
       loadingRelatedTokens,
       nativeToken,
-      nativeTokenRRIUrl,
       tokenBalances,
       tokenToHide,
       totalXRD,

--- a/src/views/Wallet/WalletOverview.vue
+++ b/src/views/Wallet/WalletOverview.vue
@@ -22,9 +22,12 @@
           <div class="flex flex-row items-end">
             <div v-if="loading" class="text-2xl font-light mr-4 text-rGreen">--</div>
             <big-amount :amount="availablePlusStakedAndUnstakedXRD" class="text-2xl font-light mr-4 text-rGreen" v-else />
-            <token-symbol :rriUrl="nativeTokenRRIUrl">
-              <template v-slot:symbol>{{ nativeToken && nativeToken.symbol }}</template>
-              <template v-slot:hoverText>{{ nativeToken && nativeToken.rri.toString() }}</template>
+            <token-symbol
+              v-if="nativeToken"
+              :symbol="nativeToken.symbol"
+              :rri="nativeToken.rri.toString()"
+              :hasGreyBackground="true"
+            >
             </token-symbol>
           </div>
         </div>
@@ -33,9 +36,12 @@
           <div class="flex flex-row items-end">
             <div v-if="loading" class="text-2xl font-light mr-4 text-rBlack">--</div>
             <big-amount :amount="totalXRD" class="text-2xl font-light mr-4 text-rBlack" v-else />
-            <token-symbol :rriUrl="nativeTokenRRIUrl">
-              <template v-slot:symbol>{{ nativeToken && nativeToken.symbol }}</template>
-              <template v-slot:hoverText>{{ nativeToken && nativeToken.rri.toString() }}</template>
+            <token-symbol
+              v-if="nativeToken"
+              :symbol="nativeToken.symbol"
+              :rri="nativeToken.rri.toString()"
+              :hasGreyBackground="true"
+            >
             </token-symbol>
           </div>
         </div>
@@ -44,9 +50,12 @@
           <div class="flex flex-row items-end">
             <div v-if="loading" class="text-2xl font-light mr-4 text-rBlack">--</div>
             <big-amount :amount="totalStakedAndUnstaked" class="text-2xl font-light mr-4 text-rBlack" v-else />
-            <token-symbol :rriUrl="nativeTokenRRIUrl">
-              <template v-slot:symbol>{{ nativeToken && nativeToken.symbol }}</template>
-              <template v-slot:hoverText>{{ nativeToken && nativeToken.rri.toString() }}</template>
+            <token-symbol
+              v-if="nativeToken"
+              :symbol="nativeToken.symbol"
+              :rri="nativeToken.rri.toString()"
+              :hasGreyBackground="true"
+            >
             </token-symbol>
           </div>
         </div>

--- a/src/views/Wallet/WalletOverview.vue
+++ b/src/views/Wallet/WalletOverview.vue
@@ -22,7 +22,7 @@
           <div class="flex flex-row items-end">
             <div v-if="loading" class="text-2xl font-light mr-4 text-rGreen">--</div>
             <big-amount :amount="availablePlusStakedAndUnstakedXRD" class="text-2xl font-light mr-4 text-rGreen" v-else />
-            <token-symbol>{{ nativeToken && nativeToken.symbol }}</token-symbol>
+            <token-symbol :rriUrl="nativeTokenRRIUrl">{{ nativeToken && nativeToken.symbol }}</token-symbol>
           </div>
         </div>
         <div class="flex flex-col my-3 px-5 border-r border-rGray flex-1">
@@ -30,7 +30,7 @@
           <div class="flex flex-row items-end">
             <div v-if="loading" class="text-2xl font-light mr-4 text-rBlack">--</div>
             <big-amount :amount="totalXRD" class="text-2xl font-light mr-4 text-rBlack" v-else />
-            <token-symbol>{{ nativeToken && nativeToken.symbol }}</token-symbol>
+            <token-symbol :rriUrl="nativeTokenRRIUrl">{{ nativeToken && nativeToken.symbol }}</token-symbol>
           </div>
         </div>
         <div class="flex flex-col my-3 px-5 flex-1">
@@ -38,7 +38,7 @@
           <div class="flex flex-row items-end">
             <div v-if="loading" class="text-2xl font-light mr-4 text-rBlack">--</div>
             <big-amount :amount="totalStakedAndUnstaked" class="text-2xl font-light mr-4 text-rBlack" v-else />
-            <token-symbol>{{ nativeToken && nativeToken.symbol }}</token-symbol>
+            <token-symbol :rriUrl="nativeTokenRRIUrl">{{ nativeToken && nativeToken.symbol }}</token-symbol>
           </div>
         </div>
       </div>
@@ -215,6 +215,14 @@ const WalletOverview = defineComponent({
       })
     })
 
+    const nativeTokenRRIUrl: ComputedRef<string> = computed(() => {
+      if (nativeToken.value && explorerUrlBase) {
+        return `${explorerUrlBase.value}/#/tokens/${nativeToken.value.rri.toString()}`
+      } else {
+        return `${explorerUrlBase}/#/`
+      }
+    })
+
     return {
       activeAddress,
       activeStakes,
@@ -224,6 +232,7 @@ const WalletOverview = defineComponent({
       loading,
       loadingRelatedTokens,
       nativeToken,
+      nativeTokenRRIUrl,
       tokenBalances,
       tokenToHide,
       totalXRD,


### PR DESCRIPTION
[Demo](https://www.loom.com/share/5cae67112bad4a1ea17d073a1411919a)

This PR adds the feature of clicking on any token symbol Olympia-wide and being directed to respective token's Explorer page. We are also exposing the token RRI by hovering over the token symbol.

We've adjusted `TokenSymbol.vue` to take required attributes `rri`, `symbol`, and `hasGreyBackground`. We initially wanted to pass the entire `Token`, but it seems that we're sometimes passing an `Action`. It may be better to pass these two strings `symbol` and `rri`, which both entities own as opposed to having the component figure out which of the Types it's extracting data from.