### PR TITLE
fix: Don't load account 1 balances when first opening wallet

### DIFF
--- a/src/composables/useTokenBalances.ts
+++ b/src/composables/useTokenBalances.ts
@@ -1,13 +1,13 @@
 import { computed, ref, Ref } from 'vue'
 import { Radix, ResourceIdentifierT, Token } from '@radixdlt/application'
 import { mergeMap } from 'rxjs/operators'
-import { Observed } from '@/helpers/typeHelpers'
 import { firstValueFrom } from 'rxjs'
+import { AccountBalancesEndpoint } from '@radixdlt/application/src/api/open-api/_types'
 
 const relatedTokens: Ref<Token[]> = ref([])
+const tokenBalances: Ref<AccountBalancesEndpoint.DecodedResponse | null> = ref(null)
 
 export default function useTokenBalances (radix: ReturnType<typeof Radix.create>) {
-  const tokenBalances: Ref<Observed<ReturnType<typeof radix.ledger.tokenBalancesForAddress>> | null> = ref(null)
   const tokenBalancesSub = radix.activeAccount
     .pipe(
       mergeMap((account) => radix.ledger.tokenBalancesForAddress(account.address))

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -262,6 +262,7 @@ const switchAccount = (account: AccountT) => {
       saveLatestAccountAddress(newAddress, activeNetwork.value)
     }
     latestAddress.value = newAddress
+    activeAccount.value = account
     reloadSubscriptions()
   }
 }


### PR DESCRIPTION
This PR includes a collection of findings from @SK-Sam @alexandreaco and myself.  

The original UI was not handling changes to the `activeAccount` vue ref in the `useWallet` composable on the wallet overview.  This meant that when the `initWallet` function was called and it switched accounts there was a race condition that resulted in conflicting `activeAccount` values. _I think_.

This PR fixes these problems by updating the `WalletOverview` to delay displaying values until half a second after the balances observable has emitted an event.  This gives the UI enough time to correctly calculate and render the real balance values while the wallet switches and persists account values to the store and does... other things.