### PR TITLE
fix: Watch active address instead of active account

### DIFF
--- a/src/composables/useTokenBalances.ts
+++ b/src/composables/useTokenBalances.ts
@@ -8,9 +8,9 @@ const relatedTokens: Ref<Token[]> = ref([])
 
 export default function useTokenBalances (radix: ReturnType<typeof Radix.create>) {
   const tokenBalances: Ref<Observed<ReturnType<typeof radix.ledger.tokenBalancesForAddress>> | null> = ref(null)
-  const tokenBalancesSub = radix.activeAccount
+  const tokenBalancesSub = radix.activeAddress
     .pipe(
-      mergeMap((account) => radix.ledger.tokenBalancesForAddress(account.address))
+      mergeMap((address) => radix.ledger.tokenBalancesForAddress(address))
     ).subscribe((tokenBalancesRes) => {
       tokenBalances.value = tokenBalancesRes
 


### PR DESCRIPTION
Now that we know radix.activeAddress isn't updating fast enough, I thought I'd try relying on radix.activeAccount instead. It looks like it fixes the UI bug. However, if you switch around accounts with the balances view open on this branch and on main, the wallet makes exponentially more calls to the balances endpoint each time!