### PR TITLE
fix: Update disconnect hardware device error shape for new component

### DIFF
--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -165,7 +165,13 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
     // To Do: Nicely handle hardware device error when full error is returned from API
     // For now: pattern match on transaction errors that return a "No device found" string or "DisconnectedDevice"
     if (err.toString().indexOf('Error: No device found') >= 0 || err.toString().indexOf('DisconnectedDevice') >= 0) {
-      setError({ ...err, type: 'HARDWARE' })
+      setError({
+        ...err,
+        type: 'HARDWARE',
+        error: {
+          category: ''
+        }
+      })
     // Catch encypted message is too long error
     } else if (err.toString().indexOf('Plaintext is too long') >= 0) {
       setError({


### PR DESCRIPTION
This PR updates the error shape that's returned when disconnecting a hardware ledger to include the category attribute that was added in this other PR https://github.com/radixdlt/olympia-wallet/pull/438/files