### PR TITLE
chore: Present users with a better error experience if they loose network connectivity

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -302,6 +302,7 @@ const messages = {
       unableToPrepareUnstakingTransactionPointTwo: 'Attempting to unstake more than you currently have staked to the validator',
       unableToPrepareUnstakingTransactionPointThree: 'Insufficient XRD to pay the required transaction fee',
       networkError: 'Lost internet connection. Check internet connection before continuing.',
+      networkErrorWarning: 'Remember to check if any pending transactions were successful before re-attempting them',
       gatewayError: 'Cannot connect to your currently selected gateway: %{url}. \n \n You may select a different gateway, or refresh the app to try to connect again.'
     },
     apiErrors: {


### PR DESCRIPTION
<img width="1312" alt="Screen Shot 2022-02-16 at 2 05 29 PM" src="https://user-images.githubusercontent.com/4480888/154337742-bd149024-0d05-4043-915f-e978d2c10917.png">

While we wait for better network connectivity error messages from the SDK, we are pinging the network every 10 seconds and showing users a warning if the network cannot be reached. In this PR, we are removing the cancel button and added some warning text encouraging users not to re-attempt transactions that may have succeeded before connection was lost. Removing the cancel button will prevent users from continuing to use the app when it's not connected to the network.