### PR TITLE
fix: Proper precision for user-entered amounts.

### DIFF
--- a/src/helpers/validateRadixTypes.ts
+++ b/src/helpers/validateRadixTypes.ts
@@ -19,7 +19,7 @@ export const safelyUnwrapValidator = (validatorString: string): ValidatorAddress
   return validatorAddressRes.value
 }
 
-export const safelyUnwrapAmount = (amount: number): AmountT | null => {
+export const safelyUnwrapAmount = (amount: string): AmountT | null => {
   const bigAmount = new BigNumber(amount)
   const amountInput = bigAmount.shiftedBy(18) // Atto
   const amountResult = Amount.fromUnsafe(amountInput.toFixed())

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -51,7 +51,7 @@ defineRule('validAmount', (amountString: string) => {
   const amountMatch = /^\d*\.?\d*$/
   const amount = Number(amountString)
   if (amount && amountString.match(amountMatch)) {
-    const safeAmount = safelyUnwrapAmount(amount)
+    const safeAmount = safelyUnwrapAmount(amountString)
     return !!safeAmount
   }
   return false

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -155,7 +155,7 @@ import { Decoded, AccountBalancesEndpoint } from '@radixdlt/application/dist/api
 
 interface StakeForm {
   validator: string;
-  amount: number;
+  amount: string;
 }
 const refreshSub: Ref<Subscription | null> = ref(null)
 
@@ -344,7 +344,7 @@ const WalletStaking = defineComponent({
       if (!tokenBalances.value || !nativeToken.value) return
       if (!meta.value.valid || !nativeTokenBalance.value) return
       const safeAddress = safelyUnwrapValidator(values.validator)
-      const safeAmount = safelyUnwrapAmount(Number(values.amount))
+      const safeAmount = safelyUnwrapAmount(values.amount)
       const greaterThanZero = safeAmount && validateGreaterThanZero(safeAmount)
       const validAmount = safeAmount && validateAmountOfType(safeAmount, nativeToken.value)
 
@@ -380,14 +380,12 @@ const WalletStaking = defineComponent({
     const handleMaxSubmitUnstake = () => {
       const safeAddress = safelyUnwrapValidator(values.validator)
       if (!safeAddress) return
-      const safeOneHundredPercent = safelyUnwrapAmount(Number('0.0000000000000001'))
-      if (!safeOneHundredPercent) return
 
       activateAccount((client) => {
         if (!nativeToken.value) return
         unstake(client, {
           from_validator: safeAddress,
-          unstake_percentage: safeOneHundredPercent,
+          unstake_percentage: 100,
           tokenIdentifier: nativeToken.value.rri
         })
       }).catch((e) => {

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -137,7 +137,7 @@ import { getHiddenTokens } from '@/actions/vue/data-store'
 
 interface TransactionForm {
   recipient: string;
-  amount: number;
+  amount: string;
   message: string;
   encrypt: boolean;
 }
@@ -289,7 +289,7 @@ const WalletTransaction = defineComponent({
     const handleSubmit = async () => {
       if (!meta.value.valid || !selectedCurrency.value) return false
       const safeAddress = safelyUnwrapAddress(values.recipient, networkPreamble.value)
-      const safeAmount = safelyUnwrapAmount(Number(values.amount))
+      const safeAmount = safelyUnwrapAmount(values.amount)
       const token = tokenInfoFor(selectedCurrency.value.token_identifier.rri)
       if (!token) return false
       const greaterThanZero = safeAmount && validateGreaterThanZero(safeAmount)


### PR DESCRIPTION
To reproduce the bug, try to enter `11.111111111111111111` when sending the transaction.
This gets converted to `11111111111111110000` attos, while should be sent as "11111111111111111111".
Looks like this fixes the leftover dust when unstaking too.