### PR TITLE
fix: decrypt errors while switching accounts on history page

### DIFF
--- a/src/composables/useHistory.ts
+++ b/src/composables/useHistory.ts
@@ -33,7 +33,7 @@ export default function useHistory (radix: ReturnType<typeof Radix.create>, acco
     }
   }
 
-  const cleanupHistorySub = () => {
+  const cleanupTransactionSub = () => {
     if (transactionSub) {
       transactionSub.unsubscribe()
       transactionSub = null
@@ -41,7 +41,7 @@ export default function useHistory (radix: ReturnType<typeof Radix.create>, acco
   }
 
   const resetHistory = () => {
-    cleanupHistorySub()
+    cleanupTransactionSub()
     loadingHistory.value = true
     cursorStack.value = []
     transactions.value = []
@@ -60,21 +60,21 @@ export default function useHistory (radix: ReturnType<typeof Radix.create>, acco
   }
 
   const previousPage = () => {
-    cleanupHistorySub()
+    cleanupTransactionSub()
     loadingHistory.value = true
     cursorStack.value.pop()
     fetchTransactions(cursorStack.value.length > 0 ? cursorStack.value[cursorStack.value.length - 1] : '')
   }
 
   const nextPage = () => {
-    cleanupHistorySub()
+    cleanupTransactionSub()
     loadingHistory.value = true
     cursorStack.value.push(activeCursor.value)
     fetchTransactions(activeCursor.value)
   }
 
   const leavingHistory = () => {
-    cleanupHistorySub()
+    cleanupTransactionSub()
   }
 
   return {

--- a/src/composables/useHistory.ts
+++ b/src/composables/useHistory.ts
@@ -16,8 +16,9 @@ const transactions: Ref<SimpleExecutedTransaction[]> = ref([])
 
 const isDecrypting: Ref<boolean> = ref(false)
 
-export default function useHistory (radix: ReturnType<typeof Radix.create>, activeAccount: AccountT) {
+export default function useHistory (radix: ReturnType<typeof Radix.create>, account: AccountT) {
   let transactionSub: Subscription | null
+  let activeAccount: AccountT = account
 
   const fetchTransactions = async (cursor?: string) => {
     const params = { size: PAGE_SIZE, address: activeAccount.address, cursor }
@@ -39,10 +40,17 @@ export default function useHistory (radix: ReturnType<typeof Radix.create>, acti
     fetchTransactions()
   }
 
+  const updateActiveAccount = (acct: AccountT) => {
+    activeAccount = acct
+  }
+
   const decryptMessage = (tx: ExecutedTransaction) => {
     isDecrypting.value = true
+    console.log(activeAccount.address.toString())
     firstValueFrom(radix.decryptTransaction(tx)).then((val) => {
       decryptedMessages.value.push({ id: tx.txID.toString(), message: val })
+    }).catch(err => {
+      console.log(err)
     }).finally(() => { isDecrypting.value = false })
   }
 
@@ -76,6 +84,7 @@ export default function useHistory (radix: ReturnType<typeof Radix.create>, acti
     nextPage,
     previousPage,
     resetHistory,
-    isDecrypting
+    isDecrypting,
+    updateActiveAccount
   }
 }

--- a/src/composables/useHistory.ts
+++ b/src/composables/useHistory.ts
@@ -46,10 +46,10 @@ export default function useHistory (radix: ReturnType<typeof Radix.create>, acco
 
   const decryptMessage = (tx: ExecutedTransaction) => {
     isDecrypting.value = true
-    console.log(activeAccount.address.toString())
     firstValueFrom(radix.decryptTransaction(tx)).then((val) => {
       decryptedMessages.value.push({ id: tx.txID.toString(), message: val })
     }).catch(err => {
+      // Maybe this can be surfaced to User with a new modal?
       console.log(err)
     }).finally(() => { isDecrypting.value = false })
   }

--- a/src/composables/useHistory.ts
+++ b/src/composables/useHistory.ts
@@ -18,10 +18,10 @@ const isDecrypting: Ref<boolean> = ref(false)
 
 export default function useHistory (radix: ReturnType<typeof Radix.create>, account: AccountT) {
   let transactionSub: Subscription | null
-  let activeAccount: AccountT = account
+  const activeAccount: Ref<AccountT> = ref(account)
 
   const fetchTransactions = async (cursor?: string) => {
-    const params = { size: PAGE_SIZE, address: activeAccount.address, cursor }
+    const params = { size: PAGE_SIZE, address: activeAccount.value.address, cursor }
     const data = await firstValueFrom(radix.ledger.transactionHistory(params))
     transactions.value = data.transactions
     loadingHistory.value = false
@@ -41,7 +41,7 @@ export default function useHistory (radix: ReturnType<typeof Radix.create>, acco
   }
 
   const updateActiveAccount = (acct: AccountT) => {
-    activeAccount = acct
+    activeAccount.value = acct
   }
 
   const decryptMessage = (tx: ExecutedTransaction) => {

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -274,6 +274,7 @@ const accountNameFor = (accountAddress: AccountAddressT): string => {
 const connectHardwareWallet = () => {
   if (hardwareAccount.value) {
     switchAccount(hardwareAccount.value)
+    activeAccount.value = hardwareAccount.value
     return
   }
   hardwareError.value = null

--- a/src/views/Wallet/WalletHistory.vue
+++ b/src/views/Wallet/WalletHistory.vue
@@ -131,6 +131,7 @@ const WalletHistory = defineComponent({
       nextPage,
       previousPage,
       resetHistory,
+      updateActiveAccount,
       isDecrypting
     } = useHistory(radix, activeAccount.value)
 
@@ -152,7 +153,12 @@ const WalletHistory = defineComponent({
     )
 
     // Fetch new history when active account changes
-    watch((activeAccount), () => { resetHistory() })
+    watch((activeAccount), () => {
+      if (activeAccount.value) {
+        updateActiveAccount(activeAccount.value)
+      }
+      resetHistory()
+    })
 
     // Fetch initial history on route load
     onMounted(() => {


### PR DESCRIPTION
[Demo showcasing freely switching between accounts on History Page](https://www.loom.com/share/8dcd1a5547aa491f8ead3949c45e4236)

Joint effort by @saminakh & I! https://github.com/radixdlt/olympia-wallet/pull/454/files

This PR updates account switching logic in `useHistory` composeable, and updates the `account` value before resetting History Page transactions while switching accounts. We're also making sure to restart polling of subscriptions properly upon account changing.

The issue previously was that the incorrect `publicKey` was being used from the incorrect account, while it seemed like the `to_address` public key and `from_address` public key was correct.

We're also now handling hardware-account-specific account changing. Previously, certain modals such as decrypt on hardware device modal would not fire off on History page.