### PR TITLE
chore: Don’t show validator uptime for validators below top 100

### DIFF
--- a/src/components/StakeListItem.vue
+++ b/src/components/StakeListItem.vue
@@ -55,7 +55,7 @@
               class="mb-1 flex-1 text-rBlack"
               :class="{'text-rRed': Number(validator.uptimePercentage) <= 98}"
             >
-              {{validator.uptimePercentage}}%
+              {{ validatorUptimeContent }}
             </div>
           </div>
         </dl>
@@ -186,6 +186,10 @@ const StakeListItem = defineComponent({
       return checkValidatorUrlExploitable(validator.value.infoURL.toString())
     })
 
+    const validatorUptimeContent: ComputedRef<string> = computed(() => {
+      return inTopOneHundred.value && validator.value ? `${validator.value.uptimePercentage}%` : '-'
+    })
+
     const unstakeAmount: ComputedRef<AmountT> = computed(() => getUnstakeAmountForValidator(props.validatorAddress))
     const pendingStakeAmount: ComputedRef<AmountT> = computed(() => getPendingStakeAmountForValidator(props.validatorAddress))
 
@@ -195,6 +199,7 @@ const StakeListItem = defineComponent({
       pendingStakeAmount,
       unstakeAmount,
       validateGreaterThanZero,
+      validatorUptimeContent,
       validatedValidatorUrl,
       validator,
       validatorAddressForDisplay,


### PR DESCRIPTION
<img width="1312" alt="Screen Shot 2022-02-17 at 8 12 03 AM" src="https://user-images.githubusercontent.com/4480888/154488738-f578163f-c171-4acd-bfb9-3ddcbfdb971d.png">

We already had this feature in the explorer. Now, we will also hide recent uptime for validators not in the top 100 for the wallet.