### PR TITLE
chore: filter hidden tokens against current wallet

### DIFF
--- a/src/components/HiddenTokenBalanceListItem.vue
+++ b/src/components/HiddenTokenBalanceListItem.vue
@@ -12,6 +12,7 @@
     </div>
 
     <AppButtonIcon
+      v-if="token"
       @click="$emit('select', token)"
     >
       <svg width="18" height="14" viewBox="0 0 18 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="pointer-events-none mr-1.5 w-5">
@@ -47,7 +48,7 @@ export default defineComponent({
       required: true
     },
     tokenBalance: {
-      type: Object as PropType<Decoded.TokenAmount>,
+      type: Object as PropType<Decoded.TokenAmount | null>,
       required: true
     }
   },
@@ -59,7 +60,9 @@ export default defineComponent({
     const token: Ref<Token | null> = ref(null)
     const { tokenInfoFor } = useTokenBalances(radix)
 
-    token.value = tokenInfoFor(tokenBalance.value.token_identifier.rri)
+    if (tokenBalance.value) {
+      token.value = tokenInfoFor(tokenBalance.value.token_identifier.rri)
+    }
 
     return {
       token

--- a/src/composables/useTokenBalances.ts
+++ b/src/composables/useTokenBalances.ts
@@ -32,6 +32,7 @@ export default function useTokenBalances (radix: ReturnType<typeof Radix.create>
           })
       }
     })
+    return tokenBalances
   }
 
   return {
@@ -58,6 +59,12 @@ export default function useTokenBalances (radix: ReturnType<typeof Radix.create>
     tokenInfoFor: (rri: ResourceIdentifierT) => {
       if (!relatedTokens.value) return null
       return relatedTokens.value.find((rt) => rt.rri.equals(rri)) || null
+    },
+    filterHiddenTokens: (hiddenTokens: string[]) => {
+      if (!tokenBalances.value) return hiddenTokens
+      const listOfLiquidBalanceRRIs: Array<string> = tokenBalances.value.account_balances.liquid_balances.map((lb) => lb.token_identifier.rri.toString())
+      const newList = hiddenTokens.filter(rri => listOfLiquidBalanceRRIs.includes(rri))
+      return newList
     },
 
     fetchBalancesForAddress

--- a/src/composables/useTokenBalances.ts
+++ b/src/composables/useTokenBalances.ts
@@ -1,32 +1,29 @@
 import { computed, ref, Ref } from 'vue'
-import { Radix, ResourceIdentifierT, Token } from '@radixdlt/application'
-import { mergeMap } from 'rxjs/operators'
-import { Observed } from '@/helpers/typeHelpers'
+import { AccountAddressT, Radix, ResourceIdentifierT, Token } from '@radixdlt/application'
 import { firstValueFrom } from 'rxjs'
+import { AccountBalancesEndpoint } from '@radixdlt/application/dist/api/open-api/_types'
 
 const relatedTokens: Ref<Token[]> = ref([])
+const tokenBalances: Ref<AccountBalancesEndpoint.DecodedResponse | null> = ref(null)
 
 export default function useTokenBalances (radix: ReturnType<typeof Radix.create>) {
-  const tokenBalances: Ref<Observed<ReturnType<typeof radix.ledger.tokenBalancesForAddress>> | null> = ref(null)
-  const tokenBalancesSub = radix.activeAccount
-    .pipe(
-      mergeMap((account) => radix.ledger.tokenBalancesForAddress(account.address))
-    ).subscribe((tokenBalancesRes) => {
-      tokenBalances.value = tokenBalancesRes
+  const fetchBalancesForAddress = async (address: AccountAddressT) => {
+    const res = await firstValueFrom(radix.ledger.tokenBalancesForAddress(address))
+    tokenBalances.value = res
 
-      // Get token info for tokens related to this account and save in memory
-      // Don't save duplicates
-      tokenBalancesRes.account_balances.liquid_balances.map((balance) => {
-        if (!relatedTokens.value.find((t) => t.rri.equals(balance.token_identifier.rri))) {
-          firstValueFrom(radix.ledger.tokenInfo(balance.token_identifier.rri))
-            .then((t) => {
-              if (!relatedTokens.value.find((t) => t.rri.equals(balance.token_identifier.rri))) {
-                relatedTokens.value = [...relatedTokens.value, t]
-              }
-            })
-        }
-      })
+    // Get token info for tokens related to this account and save in memory
+    // Don't save duplicates
+    res.account_balances.liquid_balances.map((balance) => {
+      if (!relatedTokens.value.find((t) => t.rri.equals(balance.token_identifier.rri))) {
+        firstValueFrom(radix.ledger.tokenInfo(balance.token_identifier.rri))
+          .then((t) => {
+            if (!relatedTokens.value.find((t) => t.rri.equals(balance.token_identifier.rri))) {
+              relatedTokens.value = [...relatedTokens.value, t]
+            }
+          })
+      }
     })
+  }
 
   return {
     tokenBalances: computed(() => tokenBalances.value),
@@ -39,7 +36,7 @@ export default function useTokenBalances (radix: ReturnType<typeof Radix.create>
     }),
 
     tokenBalancesUnsub: () => {
-      tokenBalancesSub.unsubscribe()
+      // tokenBalancesSub.unsubscribe()
     },
     tokenBalanceFor: (token: Token) => {
       if (!tokenBalances.value) return null
@@ -52,6 +49,8 @@ export default function useTokenBalances (radix: ReturnType<typeof Radix.create>
     tokenInfoFor: (rri: ResourceIdentifierT) => {
       if (!relatedTokens.value) return null
       return relatedTokens.value.find((rt) => rt.rri.equals(rri)) || null
-    }
+    },
+
+    fetchBalancesForAddress
   }
 }

--- a/src/composables/useTokenBalances.ts
+++ b/src/composables/useTokenBalances.ts
@@ -60,12 +60,6 @@ export default function useTokenBalances (radix: ReturnType<typeof Radix.create>
       if (!relatedTokens.value) return null
       return relatedTokens.value.find((rt) => rt.rri.equals(rri)) || null
     },
-    filterHiddenTokens: (hiddenTokens: string[]) => {
-      if (!tokenBalances.value) return hiddenTokens
-      const listOfLiquidBalanceRRIs: Array<string> = tokenBalances.value.account_balances.liquid_balances.map((lb) => lb.token_identifier.rri.toString())
-      const newList = hiddenTokens.filter(rri => listOfLiquidBalanceRRIs.includes(rri))
-      return newList
-    },
 
     fetchBalancesForAddress
   }

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -74,6 +74,7 @@ const updateAvailable: Ref<boolean> = ref(false)
 const versionNumber: Ref<string> = ref('')
 const wallet: Ref<WalletT | null> = ref(null)
 const latestAddress: Ref<string> = ref('')
+const loadingLatestAddress: Ref<boolean> = ref(true)
 
 const setWallet = (newWallet: WalletT) => {
   wallet.value = newWallet
@@ -121,6 +122,7 @@ interface useWalletInterface {
   readonly updateAvailable: Ref<boolean>;
   readonly versionNumber: Ref<string>;
   readonly walletHasLoaded: ComputedRef<boolean>;
+  readonly loadingLatestAddress: ComputedRef<boolean>;
 
   accountNameFor: (address: AccountAddressT) => string;
   accountRenamed: (newName: string) => void;
@@ -214,6 +216,7 @@ const initWallet = (): void => {
       )
 
       if (foundLatest && !latestIsActive) switchAccount(foundLatest)
+      else loadingLatestAddress.value = false
     }))
 
   subs.add(reloadTrigger.asObservable()
@@ -262,6 +265,7 @@ const switchAccount = (account: AccountT) => {
       saveLatestAccountAddress(newAddress, activeNetwork.value)
     }
     latestAddress.value = newAddress
+    if (loadingLatestAddress.value) loadingLatestAddress.value = false
     reloadSubscriptions()
   }
 }
@@ -399,6 +403,7 @@ export default function useWallet (router: Router): useWalletInterface {
     hardwareInteractionState,
     hasWallet,
     ledgerVerifyError,
+    loadingLatestAddress: computed(() => loadingLatestAddress.value),
     nodeUrl: computed(() => nodeUrl.value),
     showDeleteHWWalletPrompt,
     showLedgerVerify,

--- a/src/views/Settings/SettingsTokens.vue
+++ b/src/views/Settings/SettingsTokens.vue
@@ -76,7 +76,7 @@ export default defineComponent({
     const loading: Ref<boolean> = ref(true)
     const router = useRouter()
     const { activeAddress, activeAccount, radix } = useWallet(router)
-    const { fetchBalancesForAddress, tokenBalances, tokenBalancesUnsub, tokenBalanceForByString, filterHiddenTokens } = useTokenBalances(radix)
+    const { fetchBalancesForAddress, tokenBalances, tokenBalancesUnsub, tokenBalanceForByString } = useTokenBalances(radix)
     if (!activeAccount.value) {
       return
     }
@@ -89,16 +89,7 @@ export default defineComponent({
     })
 
     watch((activeAddress), (newActiveAddress) => {
-      // Update balances when active address changes
       newActiveAddress && fetchBalancesForAddress(newActiveAddress)
-    })
-
-    watch((tokenBalances), () => {
-      getHiddenTokens().then((res) => {
-        loading.value = true
-        hiddenTokens.value = res
-        loading.value = false
-      })
     })
 
     onUnmounted(() => { tokenBalancesUnsub() })
@@ -116,8 +107,7 @@ export default defineComponent({
 
     const tokenBalanceOfHidden: ComputedRef<Decoded.TokenAmount[] | null> = computed(() => {
       if (!tokenBalances.value) return null
-      const x = tokenBalances.value.account_balances.liquid_balances.filter(lb => hiddenTokens.value.includes(lb.token_identifier.rri.toString()))
-      return x
+      return tokenBalances.value.account_balances.liquid_balances.filter(lb => hiddenTokens.value.includes(lb.token_identifier.rri.toString()))
     })
 
     return {

--- a/src/views/Wallet/WalletOverview.vue
+++ b/src/views/Wallet/WalletOverview.vue
@@ -140,11 +140,11 @@ const WalletOverview = defineComponent({
       hasWallet
     } = useWallet(router)
     const {
+      fetchBalancesForAddress,
+      loadingRelatedTokens,
       tokenBalances,
       tokenBalanceFor,
-      tokenBalancesUnsub,
-      loadingRelatedTokens,
-      fetchBalancesForAddress
+      tokenBalancesUnsub
     } = useTokenBalances(radix)
     const { nativeToken } = useNativeToken(radix)
 

--- a/src/views/Wallet/WalletOverview.vue
+++ b/src/views/Wallet/WalletOverview.vue
@@ -98,7 +98,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ComputedRef, ref, Ref, onMounted, onUnmounted } from 'vue'
+import { defineComponent, computed, ComputedRef, ref, Ref, onMounted, onUnmounted, watch } from 'vue'
 import { merge, forkJoin, interval, Subject, Subscription } from 'rxjs'
 import { switchMap, mergeMap } from 'rxjs/operators'
 import { Amount, AmountT, Token } from '@radixdlt/application'
@@ -138,16 +138,17 @@ const WalletOverview = defineComponent({
       verifyHardwareWalletAddress,
       hasWallet
     } = useWallet(router)
-    const { tokenBalances, tokenBalanceFor, tokenBalancesUnsub, loadingRelatedTokens } = useTokenBalances(radix)
+    const { tokenBalances, tokenBalanceFor, tokenBalancesUnsub, loadingRelatedTokens, fetchBalancesForAddress } = useTokenBalances(radix)
 
     const subs = new Subscription()
-
-    const pageTrigger = new Subject<number>()
     const loading = ref(true)
     const hiddenTokens: Ref<string[]> = ref([])
 
+    watch((activeAddress), (newActiveAddress) => {
+      newActiveAddress && fetchBalancesForAddress(newActiveAddress)
+    })
+
     onMounted(() => {
-      pageTrigger.next(Math.random())
       getHiddenTokens().then((res: string[]) => { hiddenTokens.value = res })
     })
 

--- a/src/views/Wallet/WalletOverview.vue
+++ b/src/views/Wallet/WalletOverview.vue
@@ -170,6 +170,8 @@ const WalletOverview = defineComponent({
      */
     onMounted(() => {
       getHiddenTokens().then((res: string[]) => { hiddenTokens.value = res })
+      // fetch latest balances and begin polling
+      activeAddress.value && fetchBalancesForAddress(activeAddress.value)
     })
 
     onUnmounted(() => {
@@ -184,7 +186,7 @@ const WalletOverview = defineComponent({
      *  Side Effects
      */
     watch((activeAddress), (newActiveAddress) => {
-      // Update balances when active address changes and on initial render
+      // Update balances when active address change
       newActiveAddress && fetchBalancesForAddress(newActiveAddress)
     })
 

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -176,6 +176,8 @@ const WalletTransaction = defineComponent({
         hiddenTokens.value = res
       })
       if (nativeToken.value) setXRDByDefault(nativeToken.value)
+      // fetch latest balances and begin polling
+      activeAddress.value && fetchBalancesForAddress(activeAddress.value)
     })
 
     onUnmounted(() => {
@@ -195,7 +197,7 @@ const WalletTransaction = defineComponent({
       // Clear form input and validation errors when switching accounts
       resetForm()
       if (nativeToken.value) setXRDByDefault(nativeToken.value)
-      // Update balances when active address changes and on initial render
+      // Update balances when active address changes
       newActiveAddress && fetchBalancesForAddress(newActiveAddress)
     })
 

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -116,7 +116,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, Ref, ref, ComputedRef, computed, watch, onMounted } from 'vue'
+import { defineComponent, Ref, ref, ComputedRef, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useForm } from 'vee-validate'
 
 import { safelyUnwrapAddress, safelyUnwrapAmount, validateAmountOfType, validateGreaterThanZero } from '@/helpers/validateRadixTypes'
@@ -153,27 +153,50 @@ const WalletTransaction = defineComponent({
   },
 
   setup () {
-    const { errors, values, meta, setErrors, resetForm } = useForm<TransactionForm>()
     const router = useRouter()
-    const { activeAddress, activeAccount, hardwareAccount, networkPreamble, radix, verifyHardwareWalletAddress } = useWallet(router)
-
+    const { errors, values, meta, setErrors, resetForm } = useForm<TransactionForm>()
+    const { activeAddress, activeAccount, hardwareAccount, loadingLatestAddress, networkPreamble, radix, verifyHardwareWalletAddress } = useWallet(router)
     const { setActiveTransactionForm, transferTokens } = useTransactions(radix, router, activeAccount.value, hardwareAccount.value)
+    const { t } = useI18n({ useScope: 'global' })
+    const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
+    const { fetchBalancesForAddress, tokenBalances, tokenBalanceFor, tokenInfoFor, tokenBalancesUnsub } = useTokenBalances(radix)
+
+    const nativeTokenLoaded: Ref<boolean> = ref(false)
+    const currency: Ref<string | null> = ref(null)
+    const tokenOptions: Ref<Decoded.TokenAmount[]> = ref([])
+    const hiddenTokens: Ref<string[]> = ref([])
 
     setActiveTransactionForm('transaction')
 
-    const { t } = useI18n({ useScope: 'global' })
-    const { nativeToken, nativeTokenUnsub } = useNativeToken(radix)
-    const { tokenBalances, tokenBalanceFor, tokenInfoFor, tokenBalancesUnsub } = useTokenBalances(radix)
-    const nativeTokenLoaded: Ref<boolean> = ref(false)
+    /* ------
+     *  Lifecycle Events
+     */
+    onMounted(() => {
+      getHiddenTokens().then((res) => {
+        hiddenTokens.value = res
+      })
+      if (nativeToken.value) setXRDByDefault(nativeToken.value)
+    })
+
+    onUnmounted(() => {
+      tokenBalancesUnsub()
+    })
 
     onBeforeRouteLeave(() => {
       nativeTokenUnsub()
       tokenBalancesUnsub()
     })
 
-    // Clear form input and validation errors when switching accounts
-    watch(activeAddress, () => {
+    /* ------
+     *  Side Effects
+     */
+
+    watch((activeAddress), (newActiveAddress) => {
+      // Clear form input and validation errors when switching accounts
       resetForm()
+      if (nativeToken.value) setXRDByDefault(nativeToken.value)
+      // Update balances when active address changes and on initial render
+      newActiveAddress && fetchBalancesForAddress(newActiveAddress)
     })
 
     // reset currency when required state has loaded. Especially necessary when switching account
@@ -184,37 +207,10 @@ const WalletTransaction = defineComponent({
       }
     })
 
-    type tokenAmountT = Observed<ReturnType<typeof radix.ledger.tokenBalancesForAddress>>;
-
-    const currency: Ref<string | null> = ref(null)
-    const tokenOptions: Ref<Decoded.TokenAmount[]> = ref([])
-    const hiddenTokens: Ref<string[]> = ref([])
-
-    onMounted(() => {
-      getHiddenTokens().then((res) => {
-        hiddenTokens.value = res
-      })
-    })
-
-    // Set XRD as default and move to top of list of options. Ensure native token subscription has returned before doing so
-    const setXRDByDefault = (nativeToken: Token) => {
-      if (!tokenBalances.value || tokenBalances.value.account_balances.liquid_balances.length === 0) return
-      const nativeTokenBalance = tokenBalanceFor(nativeToken)
-      const balances = tokenBalances.value ? tokenBalances.value.account_balances.liquid_balances : []
-
-      currency.value = nativeTokenBalance ? nativeTokenBalance.token_identifier.rri.name : balances[0].token_identifier.rri.name
-
-      const nativeTb = balances.find((b) => b.token_identifier.rri.equals(nativeToken.rri))
-      const remainingTb = balances.filter((b) =>
-        !b.token_identifier.rri.equals(nativeToken.rri) &&
-        !hiddenTokens.value.find((ht) => b.token_identifier.rri.toString() === ht)
-      ) || []
-      tokenOptions.value = nativeTb ? [nativeTb, ...remainingTb] : remainingTb
-    }
-
-    if (nativeToken.value) setXRDByDefault(nativeToken.value)
-
-    const hasTokenBalances = computed(() => {
+    /* ------
+     *  Computed Values
+     */
+    const hasTokenBalances: ComputedRef<boolean> = computed(() => {
       if (!tokenBalances.value?.account_balances.liquid_balances) return false
       return tokenBalances.value?.account_balances.liquid_balances.length > 0
     })
@@ -236,70 +232,94 @@ const WalletTransaction = defineComponent({
     })
 
     const loadedAllData: ComputedRef<boolean> = computed(() => {
-      if (activeAddress && activeAddress.value && nativeToken.value && tokenBalances.value) return true
+      if (activeAddress && activeAddress.value && nativeToken.value && tokenBalances.value && !loadingLatestAddress.value) return true
       return false
     })
 
+    /* ------
+     *  Functions
+     */
+
+    // Set XRD as default and move to top of list of options. Ensure native token subscription has returned before doing so
+    const setXRDByDefault = (nativeToken: Token) => {
+      if (!tokenBalances.value || tokenBalances.value.account_balances.liquid_balances.length === 0) return
+      const nativeTokenBalance = tokenBalanceFor(nativeToken)
+      const balances = tokenBalances.value ? tokenBalances.value.account_balances.liquid_balances : []
+
+      currency.value = nativeTokenBalance ? nativeTokenBalance.token_identifier.rri.name : balances[0].token_identifier.rri.name
+
+      const nativeTb = balances.find((b) => b.token_identifier.rri.equals(nativeToken.rri))
+      const remainingTb = balances.filter((b) =>
+        !b.token_identifier.rri.equals(nativeToken.rri) &&
+        !hiddenTokens.value.find((ht) => b.token_identifier.rri.toString() === ht)
+      ) || []
+      tokenOptions.value = nativeTb ? [nativeTb, ...remainingTb] : remainingTb
+    }
+
+    const handleSubmit = () => {
+      if (!meta.value.valid || !selectedCurrency.value) return false
+      const safeAddress = safelyUnwrapAddress(values.recipient, networkPreamble.value)
+      const safeAmount = safelyUnwrapAmount(Number(values.amount))
+      const token = tokenInfoFor(selectedCurrency.value.token_identifier.rri)
+      if (!token) return false
+      const greaterThanZero = safeAmount && validateGreaterThanZero(safeAmount)
+      // to do: we need to get full token info before we can validate
+      const validAmount = safeAmount && validateAmountOfType(safeAmount, token) && validateGreaterThanZero(safeAmount)
+      if (!greaterThanZero) {
+        setErrors({ amount: t('validations.greaterThanZero') })
+        return
+      }
+      if (!validAmount) {
+        setErrors({
+          amount: t('validations.amountOfType', { granularity: token.granularity.toString() })
+        })
+        return
+      }
+
+      if (!safeAddress) {
+        setErrors({
+          recipient: t('validations.validAddress')
+        })
+        return
+      }
+
+      if (safeAddress && safeAmount) {
+        transferTokens(
+          {
+            to_account: safeAddress,
+            amount: safeAmount,
+            tokenIdentifier: token.rri.toString()
+          },
+          {
+            plaintext: values.message,
+            encrypt: values.encrypt
+          },
+          selectedCurrency.value
+        )
+      }
+    }
+
     return {
-      tokenBalances,
-      errors,
-      values,
-      meta,
-      hasTokenBalances,
-      setErrors,
+      activeAddress,
+      amountPlaceholder,
       currency,
-      tokenOptions,
-      selectedCurrency,
+      errors,
+      hasTokenBalances,
+      meta,
       nativeToken,
       networkPreamble,
-      amountPlaceholder,
-      activeAddress,
+      selectedCurrency,
+      tokenBalances,
+      tokenOptions,
+      values,
+
+      // Functions
       disableSubmit,
+      handleSubmit,
       loadedAllData,
-      verifyHardwareWalletAddress,
+      setErrors,
       tokenInfoFor,
-      handleSubmit () {
-        if (!meta.value.valid || !selectedCurrency.value) return false
-        const safeAddress = safelyUnwrapAddress(values.recipient, networkPreamble.value)
-        const safeAmount = safelyUnwrapAmount(Number(values.amount))
-        const token = tokenInfoFor(selectedCurrency.value.token_identifier.rri)
-        if (!token) return false
-        const greaterThanZero = safeAmount && validateGreaterThanZero(safeAmount)
-        // to do: we need to get full token info before we can validate
-        const validAmount = safeAmount && validateAmountOfType(safeAmount, token) && validateGreaterThanZero(safeAmount)
-        if (!greaterThanZero) {
-          setErrors({ amount: t('validations.greaterThanZero') })
-          return
-        }
-        if (!validAmount) {
-          setErrors({
-            amount: t('validations.amountOfType', { granularity: token.granularity.toString() })
-          })
-          return
-        }
-
-        if (!safeAddress) {
-          setErrors({
-            recipient: t('validations.validAddress')
-          })
-          return
-        }
-
-        if (safeAddress && safeAmount) {
-          transferTokens(
-            {
-              to_account: safeAddress,
-              amount: safeAmount,
-              tokenIdentifier: token.rri.toString()
-            },
-            {
-              plaintext: values.message,
-              encrypt: values.encrypt
-            },
-            selectedCurrency.value
-          )
-        }
-      }
+      verifyHardwareWalletAddress
     }
   }
 })


### PR DESCRIPTION
We're now going to filter the current wallet balance's tokens on SettingsToken page based on which token RRI's are hidden on the active account. I'm running into one issue where on first render, changing to another account which had different hidden tokens than initial account MAY take an additional account switch. Currently investigating but I believe this solves majority of the issue!