### PR TITLE
fix: staking amount error prematurely displays

### DIFF
--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -257,16 +257,14 @@ const WalletStaking = defineComponent({
       setActiveForm('STAKING')
       setActiveTransactionForm('stake')
       values.validator = validator.toString()
-      if (values.amount === undefined) return
-      validate()
+      if (values.amount) validate()
     }
 
     const handleReduceFromValidator = (validator: ValidatorAddressT) => {
       setActiveForm('UNSTAKING')
       setActiveTransactionForm('unstake')
       values.validator = validator.toString()
-      if (values.amount === undefined) return
-      validate()
+      if (values.amount) validate()
     }
 
     const handleSubmitStake = () => {

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -257,6 +257,7 @@ const WalletStaking = defineComponent({
       setActiveForm('STAKING')
       setActiveTransactionForm('stake')
       values.validator = validator.toString()
+      if (values.amount === undefined) return
       validate()
     }
 
@@ -264,6 +265,7 @@ const WalletStaking = defineComponent({
       setActiveForm('UNSTAKING')
       setActiveTransactionForm('unstake')
       values.validator = validator.toString()
+      if (values.amount === undefined) return
       validate()
     }
 

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -64,6 +64,7 @@
                   class="w-full text-sm"
                   :placeholder="amountPlaceholder"
                   rules="required|validAmount"
+                  :validateOnInput="true"
                 />
                 <FormErrorMessage name="amount" class="text-sm text-red-400" errorClass="w-120" />
               </div>


### PR DESCRIPTION
See [original error ](https://www.loom.com/share/3d2b142dcc7c49d29f4b618592e5bc9b) here.

When in the staking view, if a user chose to stake / unstake without preemptively filling out the amount form field, a `valid amount` error would occur, and would not disappear until the user clicked out of the form component (IE on `blur`). The chances of a user filling out the amount form field before choosing whether to stake or unstake were unlikely so the error no longer appears. 

This was caused by the stake/unstake buttons triggering a validation function that checks the values of both the automatically populated `validator address` and the `amount` value. The validation assumes that a value will be passed for `values.amount` and raises an error when the amount is left undefined. Now if the `values.amount === undefined` we bypass the validation and then `validateOnInput` of the form field.   


![radix-slow](https://user-images.githubusercontent.com/72633467/156033499-1a1f1c2b-873d-4b9f-915b-7916336c852c.gif)
