### PR TITLE
fix: staking prematurely displays error

### DIFF
--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -51,7 +51,6 @@
               :placeholder="$t('staking.validatorPlaceholder')"
               rules="required|validValidator"
               :validateOnInput="true"
-              :validateOnBlur="false"
             />
             <FormErrorMessage name="validator" class="text-sm text-red-400" />
           </div>
@@ -67,7 +66,6 @@
                   :placeholder="amountPlaceholder"
                   rules="required|validAmount"
                   :validateOnInput="true"
-                  :validateOnBlur="false"
                 />
                 <FormErrorMessage name="amount" class="text-sm text-red-400" errorClass="w-120" />
               </div>
@@ -147,7 +145,7 @@ const WalletStaking = defineComponent({
   setup () {
     const router = useRouter()
     const { t } = useI18n({ useScope: 'global' })
-    const { errors, values, meta, setErrors, resetForm, validate } = useForm<StakeForm>()
+    const { errors, values, meta, setErrors, resetForm, validateField } = useForm<StakeForm>()
     const {
       activeAddress,
       activeAccount,
@@ -259,15 +257,17 @@ const WalletStaking = defineComponent({
     const handleAddToValidator = (validator: ValidatorAddressT) => {
       setActiveForm('STAKING')
       setActiveTransactionForm('stake')
+      resetForm()
       values.validator = validator.toString()
-      if (values.amount) validate()
+      validateField('validator')
     }
 
     const handleReduceFromValidator = (validator: ValidatorAddressT) => {
       setActiveForm('UNSTAKING')
       setActiveTransactionForm('unstake')
+      resetForm()
       values.validator = validator.toString()
-      if (values.amount) validate()
+      validateField('validator')
     }
 
     const handleSubmitStake = () => {

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -50,6 +50,8 @@
               class="w-full text-sm font-mono placeholder-sans"
               :placeholder="$t('staking.validatorPlaceholder')"
               rules="required|validValidator"
+              :validateOnInput="true"
+              :validateOnBlur="false"
             />
             <FormErrorMessage name="validator" class="text-sm text-red-400" />
           </div>
@@ -65,6 +67,7 @@
                   :placeholder="amountPlaceholder"
                   rules="required|validAmount"
                   :validateOnInput="true"
+                  :validateOnBlur="false"
                 />
                 <FormErrorMessage name="amount" class="text-sm text-red-400" errorClass="w-120" />
               </div>


### PR DESCRIPTION
[Extension of this pull request ](https://github.com/radixdlt/olympia-wallet/pull/466)

We found an additional premature form field error popping up when a user clicks into either 'address' or 'amount', clicking out of the form field component entirely causes an error message to appear even when `add/reduce stake` is clicked. An easy way around this was to disable validation on blur - and as an extra level of protection, add `validateOnInput = true` to the address field.


📸 - *notice at end I delete a character from the address and the error message appears*
![radixValidFix](https://user-images.githubusercontent.com/72633467/156462844-4ce086e4-25f9-4abe-9742-51cb230b84ca.gif)
 