### PR TITLE
chore: Add max button for unstaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@headlessui/vue": "^1.3.0",
     "@ledgerhq/hw-transport-node-hid": "^6.0.2",
     "@nopr3d/vue-next-rx": "^1.0.6",
-    "@radixdlt/application": "4.0.14",
+    "@radixdlt/application": "4.0.15",
     "@radixdlt/crypto": "^2.1.12",
     "@radixdlt/hardware-ledger": "^2.1.31",
     "@radixdlt/networking": "^2.1.14",

--- a/src/components/BigAmount.vue
+++ b/src/components/BigAmount.vue
@@ -1,5 +1,8 @@
 <template>
-  <span class="relative inline-flex flex-col items-center group cursor-pointer" @click.stop="copyText">
+  <span v-if="showMaxUnstakeText">
+    <span>MAX</span>
+  </span>
+  <span v-else class="relative inline-flex flex-col items-center group cursor-pointer" @click.stop="copyText">
     <span>{{numberForDisplay}}</span>
     <div class="absolute invisible group-hover:visible -mt-full bg-rGrayLightest text-rBlack bottom-full text-xs p-1 left-0 rounded-sm shadow border border-solid border-rGrayLight">
       {{fullNumber}}
@@ -105,6 +108,11 @@ const BigAmount = defineComponent({
     amount: {
       type: Object as PropType<AmountT>,
       required: true
+    },
+    showMaxUnstakeText: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
 

--- a/src/components/BigAmount.vue
+++ b/src/components/BigAmount.vue
@@ -1,6 +1,6 @@
 <template>
   <span v-if="showMaxUnstakeText">
-    <span>MAX</span>
+    {{ $t('staking.maxUnstakeCapitalized') }}
   </span>
   <span v-else class="relative inline-flex flex-col items-center group cursor-pointer" @click.stop="copyText">
     <span>{{numberForDisplay}}</span>
@@ -16,6 +16,7 @@ import { defineComponent, PropType } from 'vue'
 import { AmountT } from '@radixdlt/application'
 import BigNumber from 'bignumber.js'
 import { useToast } from 'vue-toastification'
+import { useI18n } from 'vue-i18n'
 
 BigNumber.set({
   ROUNDING_MODE: BigNumber.ROUND_HALF_UP,
@@ -118,6 +119,7 @@ const BigAmount = defineComponent({
 
   setup () {
     const toast = useToast()
+    const { t } = useI18n({ useScope: 'global' })
     return { toast }
   },
 

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -46,6 +46,7 @@ interface useTransactionsInterface {
   readonly transactionFee: Ref<AmountT | null>;
   readonly transactionErrorMessage: Ref<string | null>;
   readonly pendingTransactions: Ref<Array<TransactionIntent>>;
+  readonly shouldShowMaxUnstakeConfirmation: Ref<boolean>;
 
   cancelTransaction: () => void;
   confirmTransaction: () => void;
@@ -64,6 +65,7 @@ const activeTransactionForm: Ref<string | null> = ref(null)
 
 const selectedCurrency: Ref<Decoded.TokenAmount | null> = ref(null)
 const shouldShowConfirmation: Ref<boolean> = ref(false)
+const shouldShowMaxUnstakeConfirmation: Ref<boolean> = ref(false)
 const confirmationMode: Ref<string | null> = ref(null)
 const pendingTransactions: Ref<PendingTransaction[]> = ref([])
 const stakeInput: Ref<StakeTokensInput | null> = ref(null)
@@ -106,6 +108,7 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
     if (didCancel) {
       cleanupTransactionSubs()
       shouldShowConfirmation.value = false
+      shouldShowMaxUnstakeConfirmation.value = false
       activeMessage.value = ''
       ledgerState.value = ''
       transactionState.value = 'PENDING'
@@ -137,6 +140,7 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
   // Navigate user to history view
   const handleTransactionCompleted = () => {
     shouldShowConfirmation.value = false
+    shouldShowMaxUnstakeConfirmation.value = false
     cleanupTransactionSubs()
     activeMessage.value = ''
     ledgerState.value = ''
@@ -246,6 +250,9 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
     })
 
     shouldShowConfirmation.value = true
+    if (unstakeInput.value.unstake_percentage) {
+      shouldShowMaxUnstakeConfirmation.value = true
+    }
 
     transactionSubs.add(
       completion.subscribe(handleTransactionCompleted, errorHandler)
@@ -285,6 +292,7 @@ export default function useTransactions (radix: ReturnType<typeof Radix.create>,
     ledgerState,
     selectedCurrency,
     shouldShowConfirmation,
+    shouldShowMaxUnstakeConfirmation,
     stakeInput,
     unstakeInput,
     transactionError,

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -194,7 +194,9 @@ const messages = {
       validatorFeeLabel: 'Validator Fee',
       recentUptimeLabel: 'Recent Uptime',
       unregistered: 'Unregistered',
-      notTopOneHundred: 'Not in top 100 validators'
+      notTopOneHundred: 'Not in top 100 validators',
+      unstakeMaxDisclaimer: "You're unstaking all tokens from",
+      maxUnstakeButton: 'max'
     },
     confirmation: {
       transferFromLabel: 'Your address',

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -196,7 +196,8 @@ const messages = {
       unregistered: 'Unregistered',
       notTopOneHundred: 'Not in top 100 validators',
       unstakeMaxDisclaimer: "You're unstaking all tokens from",
-      maxUnstakeButton: 'max'
+      maxUnstakeButton: 'max',
+      maxUnstakeCapitalized: 'MAX'
     },
     confirmation: {
       transferFromLabel: 'Your address',
@@ -205,6 +206,7 @@ const messages = {
       stakeToLabel: 'Stake to',
       unstakeFromLabel: 'Your address',
       unstakeToLabel: 'Unstake from',
+      maxUnstakeDisclaimer: 'MAX AMOUNT',
       transactionState: {
         PENDING: 'Pending',
         INITIATED: 'Initiated',

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -254,10 +254,10 @@ const WalletConfirmTransactionModal = defineComponent({
       return ''
     })
 
-    const amount: ComputedRef<AmountOrUnsafeInput | undefined> = computed(() => {
+    const amount: ComputedRef<AmountOrUnsafeInput> = computed(() => {
       if (stakeInput.value) {
         return stakeInput.value.amount
-      } else if (unstakeInput.value) {
+      } else if (unstakeInput.value && unstakeInput.value.amount) {
         return unstakeInput.value.amount
       } else if (transferInput.value) {
         return transferInput.value.amount

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -266,7 +266,7 @@ const WalletConfirmTransactionModal = defineComponent({
     const amount: ComputedRef<AmountOrUnsafeInput> = computed(() => {
       if (stakeInput.value) {
         return stakeInput.value.amount
-      } else if (unstakeInput.value && unstakeInput.value.amount) {
+      } else if (unstakeInput.value?.amount) {
         return unstakeInput.value.amount
       } else if (transferInput.value) {
         return transferInput.value.amount

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -53,8 +53,17 @@
           <div class="border-b border-rGray py-3.5 flex items-center">
             <div class="w-26 text-right text-rGrayDark mr-6">{{ $t('transaction.amountLabel') }}</div>
             <div class="flex-1 flex flex-row items-center">
-              <span v-if="shouldShowMaxUnstakeConfirmation" class="mr-1">MAX</span>
-              <big-amount v-else :amount="amount" class="mr-1"/>
+              <span
+                v-if="shouldShowMaxUnstakeConfirmation"
+                class="mr-1"
+              >
+                {{ $t('confirmation.maxUnstakeDisclaimer') }}
+              </span>
+              <big-amount
+                v-else
+                :amount="amount"
+                class="mr-1"
+              />
               <span class="uppercase" v-if="(stakeInput || unstakeInput) && nativeToken">{{ nativeToken.symbol }}</span>
               <span class="uppercase" v-else-if="selectedCurrencyToken">{{ selectedCurrencyToken.symbol }}</span>
             </div>

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -80,7 +80,7 @@
 
           <div class="py-4 flex items-center">
             <div class="w-26 text-right text-rGrayDark mr-8">{{ $t('transaction.feeLabel') }}</div>
-            <div class="flex-1 flex flex-row items-center" v-if="transactionFee && !shouldShowMaxUnstakeConfirmation">
+            <div class="flex-1 flex flex-row items-center" v-if="transactionFee">
               <big-amount :amount="transactionFee"  class="mr-1" />
               <span class="uppercase" v-if="nativeToken">{{ nativeToken.symbol }}</span>
             </div>

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -53,8 +53,8 @@
           <div class="border-b border-rGray py-3.5 flex items-center">
             <div class="w-26 text-right text-rGrayDark mr-6">{{ $t('transaction.amountLabel') }}</div>
             <div class="flex-1 flex flex-row items-center">
-              <big-amount v-if="!shouldShowMaxUnstakeConfirmation" :amount="amount" class="mr-1" />
-              <span v-else class="mr-1">MAX</span>
+              <span v-if="shouldShowMaxUnstakeConfirmation" class="mr-1">MAX</span>
+              <big-amount v-else :amount="amount" class="mr-1"/>
               <span class="uppercase" v-if="(stakeInput || unstakeInput) && nativeToken">{{ nativeToken.symbol }}</span>
               <span class="uppercase" v-else-if="selectedCurrencyToken">{{ selectedCurrencyToken.symbol }}</span>
             </div>

--- a/src/views/Wallet/WalletConfirmTransactionModal.vue
+++ b/src/views/Wallet/WalletConfirmTransactionModal.vue
@@ -53,7 +53,8 @@
           <div class="border-b border-rGray py-3.5 flex items-center">
             <div class="w-26 text-right text-rGrayDark mr-6">{{ $t('transaction.amountLabel') }}</div>
             <div class="flex-1 flex flex-row items-center">
-              <big-amount :amount="amount" class="mr-1" />
+              <big-amount v-if="!shouldShowMaxUnstakeConfirmation" :amount="amount" class="mr-1" />
+              <span v-else class="mr-1">MAX</span>
               <span class="uppercase" v-if="(stakeInput || unstakeInput) && nativeToken">{{ nativeToken.symbol }}</span>
               <span class="uppercase" v-else-if="selectedCurrencyToken">{{ selectedCurrencyToken.symbol }}</span>
             </div>
@@ -79,7 +80,7 @@
 
           <div class="py-4 flex items-center">
             <div class="w-26 text-right text-rGrayDark mr-8">{{ $t('transaction.feeLabel') }}</div>
-            <div class="flex-1 flex flex-row items-center" v-if="transactionFee">
+            <div class="flex-1 flex flex-row items-center" v-if="transactionFee && !shouldShowMaxUnstakeConfirmation">
               <big-amount :amount="transactionFee"  class="mr-1" />
               <span class="uppercase" v-if="nativeToken">{{ nativeToken.symbol }}</span>
             </div>
@@ -207,6 +208,7 @@ const WalletConfirmTransactionModal = defineComponent({
       confirmTransaction,
       ledgerState,
       stakeInput,
+      shouldShowMaxUnstakeConfirmation,
       unstakeInput,
       transactionFee,
       transactionState,
@@ -252,7 +254,7 @@ const WalletConfirmTransactionModal = defineComponent({
       return ''
     })
 
-    const amount: ComputedRef<AmountOrUnsafeInput> = computed(() => {
+    const amount: ComputedRef<AmountOrUnsafeInput | undefined> = computed(() => {
       if (stakeInput.value) {
         return stakeInput.value.amount
       } else if (unstakeInput.value) {
@@ -367,6 +369,7 @@ const WalletConfirmTransactionModal = defineComponent({
       setErrors,
       shouldShowBuildingModal,
       shouldShowLedgerModal,
+      shouldShowMaxUnstakeConfirmation,
       stakeInput,
       unstakeInput,
       toContent,

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -334,7 +334,6 @@ const WalletStaking = defineComponent({
       if (!nativeToken.value) return
       const safeAddress = safelyUnwrapValidator(values.validator)
       if (!safeAddress) return
-      // const safeAmount = safelyUnwrapAmount(Number(0.0000000000000001))
       const safeAmount = safelyUnwrapAmount(Number('0.0000000000000001'))
       if (!safeAmount) return
 

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -334,12 +334,12 @@ const WalletStaking = defineComponent({
       if (!nativeToken.value) return
       const safeAddress = safelyUnwrapValidator(values.validator)
       if (!safeAddress) return
-      const safeAmount = safelyUnwrapAmount(Number('0.0000000000000001'))
-      if (!safeAmount) return
+      const safeOneHundredPercent = safelyUnwrapAmount(Number('0.0000000000000001'))
+      if (!safeOneHundredPercent) return
 
       unstakeTokens({
         from_validator: safeAddress,
-        unstake_percentage: safeAmount,
+        unstake_percentage: safeOneHundredPercent,
         tokenIdentifier: nativeToken.value.rri
       })
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,10 +1531,10 @@
     prelude-ts "^1.0.2"
     rxjs "7.0.0"
 
-"@radixdlt/application@4.0.14":
-  version "4.0.14"
-  resolved "https://registry.yarnpkg.com/@radixdlt/application/-/application-4.0.14.tgz#ce3dce62dc097b447fc3b0e99e8a59ae7e6edbdd"
-  integrity sha512-WAm6QuCJVsWfcdf74h8yr3NKWkWg0y8aknQmjWD/vvCqr58/r0Na6G416xuQ/MgjwYH8vUiv4k3bQhc2qvmCXw==
+"@radixdlt/application@4.0.15":
+  version "4.0.15"
+  resolved "https://registry.yarnpkg.com/@radixdlt/application/-/application-4.0.15.tgz#91e41c282495d516f7d52c3e89184b9194875aa9"
+  integrity sha512-NL3pCE2A4fqJ4S86D2iuBaThwJF+8wr4KEdyToFVxIls4R7i3qE92SwWk2Wh4/h3qcVoMMHmjrgsdEAXt9+lDQ==
   dependencies:
     "@open-rpc/mock-server" "1.7.2"
     "@open-rpc/schema-utils-js" "1.14.3"


### PR DESCRIPTION
[Demo](https://www.loom.com/share/3aaa659c442e4e2c9efa2afdcd6d18d3)

This PR implements a new button which allows User to unstake 100% of their XRD from validators. We add extra logic in order to switch between "Max Unstake Mode" and regular unstake mode.

No unique step has to be taken to unstake via Max Mode, User simply hits the same `Request Unstake` button as I was able to implement a function that decides which unstake mode to use.

![Screen Shot 2022-03-03 at 9 22 40 AM](https://user-images.githubusercontent.com/10618376/156583421-72718162-2342-47ca-bdc6-96e1dd8ad68d.png)

![Screen Shot 2022-03-03 at 9 22 55 AM](https://user-images.githubusercontent.com/10618376/156583484-c651951b-06ba-4e07-8a98-d7a39ecb6c93.png)

![Screen Shot 2022-03-03 at 10 18 51 AM](https://user-images.githubusercontent.com/10618376/156594446-ae9baff8-995e-40a1-8df0-b93699d671c0.png)

