### PR TITLE
fix: bug tokens with same symbols are incorrectly grouping 

### DIFF
--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -220,7 +220,7 @@ const WalletTransaction = defineComponent({
     const selectedCurrency: ComputedRef<Decoded.TokenAmount | null> = computed(() => {
       if (!tokenBalances.value || tokenBalances.value.account_balances.liquid_balances.length <= 0) return null
 
-      const selectedCurrency = tokenBalances.value.account_balances.liquid_balances.find((tokenBalance) => tokenBalance.token_identifier.rri.name === currency.value)
+      const selectedCurrency = tokenBalances.value.account_balances.liquid_balances.find((tokenBalance) => tokenBalance.token_identifier.rri.toString() === currency.value)
       return selectedCurrency || null
     })
 
@@ -248,7 +248,7 @@ const WalletTransaction = defineComponent({
       const nativeTokenBalance = tokenBalanceFor(nativeToken)
       const balances = tokenBalances.value ? tokenBalances.value.account_balances.liquid_balances : []
 
-      currency.value = nativeTokenBalance ? nativeTokenBalance.token_identifier.rri.name : balances[0].token_identifier.rri.name
+      currency.value = nativeTokenBalance ? nativeTokenBalance.token_identifier.rri.toString() : balances[0].token_identifier.rri.toString()
 
       const nativeTb = balances.find((b) => b.token_identifier.rri.equals(nativeToken.rri))
       const remainingTb = balances.filter((b) =>

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -76,8 +76,8 @@
                 >
                   <option
                     v-for="token in tokenOptions"
-                    :key="token.token_identifier.rri.name"
-                    :value="token.token_identifier.rri.name"
+                    :key="token.token_identifier.rri.toString()"
+                    :value="token.token_identifier.rri.toString()"
                   >
                     {{ tokenInfoFor(token.token_identifier.rri).symbol.toUpperCase() }}
                   </option>


### PR DESCRIPTION
This bug happens on the off chance of two (or more) tokens having the same name and different rris. the app incorrectly grouped them in the token select dropdown. This prevents the user from selecting the second token with the same symbol and won't display an accurate amount in the amount placeholder. 

The bug was caused by the currency dropdown selecting and passing on the `rri.name` for each currency, which is a less detailed string ID of the token. Changing the dropdown values `rri.toString()` passed along a more specific string ID, explicitly differentiating tokens with the same name but different rris. 

### 📸📸📸📸📸
*in this video, I have two tokens named `5H5M3U` with separate rris - you can see the amount placeholder change on token change, indicating it is in fact choosing between two different tokens*
![dualtoken](https://user-images.githubusercontent.com/72633467/156857639-3b85fa1e-b96b-4134-ace7-47b5cc53a81f.gif)
