### PR TITLE
fix: display error modal on failed hardware decryption

### DIFF
--- a/src/composables/useHistory.ts
+++ b/src/composables/useHistory.ts
@@ -6,6 +6,7 @@ import { formatWalletAddressForDisplay } from '@/helpers/formatter'
 const PAGE_SIZE = 30
 
 const decryptedMessages: Ref<{id: string, message: string}[]> = ref([])
+const displayLedgerErrorModal: Ref<boolean> = ref(false)
 const cursorStack: Ref<string[]> = ref([])
 const canGoBack: ComputedRef<boolean> = computed(() => cursorStack.value.length > 0)
 const canGoNext: Ref<boolean> = ref(false)
@@ -54,9 +55,18 @@ export default function useHistory (radix: ReturnType<typeof Radix.create>, acco
 
   const decryptMessage = (tx: ExecutedTransaction) => {
     isDecrypting.value = true
-    firstValueFrom(radix.decryptTransaction(tx)).then((val) => {
-      decryptedMessages.value.push({ id: tx.txID.toString(), message: val })
-    }).finally(() => { isDecrypting.value = false })
+    firstValueFrom(radix.decryptTransaction(tx))
+      .then((val) => {
+        decryptedMessages.value.push({ id: tx.txID.toString(), message: val })
+      })
+      .catch(() => {
+        displayHardwareError()
+      })
+      .finally(() => { isDecrypting.value = false })
+  }
+
+  const displayHardwareError = () => {
+    displayLedgerErrorModal.value = true
   }
 
   const previousPage = () => {
@@ -81,6 +91,7 @@ export default function useHistory (radix: ReturnType<typeof Radix.create>, acco
     canGoBack,
     canGoNext,
     decryptedMessages,
+    displayLedgerErrorModal,
     loadingHistory,
     transactions,
     decryptMessage,

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -114,7 +114,12 @@ const messages = {
       disconnected: 'Disconnected',
       hideBalanceModalTitle: 'Hide Balance',
       hideBalanceModalContent: 'Are you sure you want to hide this %{tokenName} balance? This balance can be unhidden in settings.',
-      hideBalanceModalSubmit: 'Hide Balance'
+      hideBalanceModalSubmit: 'Hide Balance',
+      ledgerModal: {
+        title: 'Ledger Device Disconnected',
+        content: 'Unable to decrypt message. Ensure your device is connected or switch accounts to continue.',
+        buttonText: 'Dismiss'
+      }
     },
     hardware: {
       disclaimer: 'Whenever copying a hardware wallet address, it is strongly recommended to verify it on the hardware device. To copy and verify this address, please switch to the hardware address first by selecting it in the account picker.',

--- a/src/views/Wallet/WalletHistory.vue
+++ b/src/views/Wallet/WalletHistory.vue
@@ -16,7 +16,10 @@
         </div>
       </div>
     </div>
-
+    <wallet-ledger-disconnected-modal
+      :shouldShow="displayLedgerErrorModal"
+      :handleClose="closeLedgerErrorModal"
+    />
     <div class="text-rBlack py-6 min-h-full text-sm">
       <div v-if="loadingHistory || !nativeToken" class="p-4 flex items-center justify-center">
         <loading-icon class="text-rGrayDark" />
@@ -93,6 +96,7 @@ import { computed, ComputedRef, defineComponent, onMounted, watch } from 'vue'
 import TransactionListItem from '@/components/TransactionListItem.vue'
 import LoadingIcon from '@/components/LoadingIcon.vue'
 import ClickToCopy from '@/components/ClickToCopy.vue'
+import WalletLedgerDisconnectedModal from '@/views/Wallet/WalletLedgerDisconnectedModal.vue'
 import { useNativeToken, useWallet, useHistory } from '@/composables'
 import { useRouter, onBeforeRouteLeave } from 'vue-router'
 import WalletLedgerVerifyDecryptModal from './WalletLedgerVerifyDecryptModal.vue'
@@ -102,6 +106,7 @@ const WalletHistory = defineComponent({
     LoadingIcon,
     ClickToCopy,
     TransactionListItem,
+    WalletLedgerDisconnectedModal,
     WalletLedgerVerifyDecryptModal
   },
 
@@ -124,6 +129,7 @@ const WalletHistory = defineComponent({
       canGoBack,
       canGoNext,
       decryptedMessages,
+      displayLedgerErrorModal,
       loadingHistory,
       transactions,
       decryptMessage,
@@ -152,6 +158,11 @@ const WalletHistory = defineComponent({
       activeAccount.value === hardwareAccount.value
     )
 
+    const closeLedgerErrorModal = () => {
+      // switchAccount(localAccounts.value[0])
+      displayLedgerErrorModal.value = false
+    }
+
     // Fetch new history when active account changes
     watch((activeAccount), () => {
       if (activeAccount.value) {
@@ -176,8 +187,10 @@ const WalletHistory = defineComponent({
       canGoBack,
       canGoNext,
       decryptMessage,
+      displayLedgerErrorModal,
       explorerUrlBase,
       decryptedMessages,
+      closeLedgerErrorModal,
       loadingHistory,
       nativeToken,
       nextPage,

--- a/src/views/Wallet/WalletLedgerDisconnectedModal.vue
+++ b/src/views/Wallet/WalletLedgerDisconnectedModal.vue
@@ -1,0 +1,43 @@
+<template>
+  <AppModal
+    :visible="shouldShow"
+    :title="$t('wallet.ledgerModal.title')"
+  >
+    <template v-slot:icon>
+      <svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg" class="transform rotate-45">
+      <circle cx="25" cy="25" r="24" stroke="#052CC0" stroke-width="1.5"/>
+      <path d="M25 14V36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M14 25H36" stroke="#052CC0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </template>
+    <template v-slot:content>
+      <p class="mb-5">{{ $t('wallet.ledgerModal.content') }}</p>
+      <div class="flex flex-row space-x-5 justify-center">
+        <AppButtonCancel @click="handleClose" class="w-44">{{ $t('wallet.ledgerModal.buttonText') }}</AppButtonCancel>
+      </div>
+    </template>
+  </AppModal>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import AppButtonCancel from '@/components/AppButtonCancel.vue'
+import AppModal from '@/components/AppModal.vue'
+const WalletLedgerDisconnectedModal = defineComponent({
+  components: {
+    AppModal,
+    AppButtonCancel
+  },
+  props: {
+    shouldShow: {
+      type: Boolean,
+      required: true
+    },
+    handleClose: {
+      type: Function,
+      required: true
+    }
+  }
+})
+export default WalletLedgerDisconnectedModal
+</script>


### PR DESCRIPTION
When a user is logged in to a hardware account, and the ledger device is disconnected, unhandled console errors would appear when the user tried to decrypt an encrypted message on the transaction history page. Now when a user encounters this situation, an error modal will pop up and inform the user of an error that is most likely occurred from a disconnected ledger.

[Here is an example of the pop-up in action.](https://www.loom.com/share/f80e68f7b041486d9548a54121c9ddfc)

📸📸📸📸
![Screen Shot 2022-03-16 at 8 30 38 AM](https://user-images.githubusercontent.com/72633467/158627320-521fdb79-a2f0-4cc8-b2a4-179e0d1be976.png)
 