### PR TITLE
feat: update wallet.json schema to accept multiple accounts per ledger WIP 

### DIFF
--- a/src/actions/electron/data-store.ts
+++ b/src/actions/electron/data-store.ts
@@ -1,6 +1,7 @@
 import { IpcMainInvokeEvent } from 'electron/main'
 import Store from 'electron-store'
 import migrations from '@/electron-store/migrations'
+import { isObject } from '@radixdlt/application';
 
 type MaybeString = string | null;
 export type AccountName = { address: string; name: string; }
@@ -39,6 +40,20 @@ export const saveDerivedAccountsIndex = (event: IpcMainInvokeEvent, data: string
   store.set(`wallets.${network}.derivedAccountsIndex`, num)
 }
 
+export const saveDerivedHardwareAccountsIndex = (event: IpcMainInvokeEvent, data: string): void => {
+  const { num, network, deviceId } = JSON.parse(data) // instead of num, need this to be the new account address
+  const devices: any = store.get(`wallets.${network}.hardwareDevices`, []) 
+  
+  // deviceId should be the new account address
+  const newAddressStruct = {'name': deviceId, 'account': deviceId}  
+  
+  // copy/destructure existing hardwareDevices struct and append new address to end
+  const newAddresses = [{'name': deviceId, addresses: [...devices[0].addresses, newAddressStruct]}] 
+  console.log(newAddresses)
+
+  store.set(`wallets.${network}.hardwareDevices`, newAddresses)
+}
+
 export const getDerivedAccountsIndex = (event: IpcMainInvokeEvent, network: string) => {
   return store.get(`wallets.${network}.derivedAccountsIndex`)
 }
@@ -50,6 +65,22 @@ export const saveHardwareAddress = (event: IpcMainInvokeEvent, data: string) => 
 
 export const getHardwareAddress = (event: IpcMainInvokeEvent, network: string) => {
   return store.get(`wallets.${network}.hardwareAddress`)
+}
+
+export const getHardwareDevices = (event: IpcMainInvokeEvent, network: string) => {
+  const hardwareStoreList: any = store.get(`wallets.${network}.hardwareDevices`)
+  return hardwareStoreList.map((device: { name: string; }) => { return device.name})
+}
+
+export const getHardwareDeviceAccounts = (event: IpcMainInvokeEvent, network: string, deviceId: string) => {
+  const hardwareStoreList: any = store.get(`wallets.${network}.hardwareDevices`)
+  // return hardwareStoreList.map((device: { name: string; addresses: any; }) => {
+  //   if (device.name == deviceId){
+  //     // console.log('----->>>', device.addresses)
+  //     return device.addresses
+  //   }
+  // })
+  return hardwareStoreList
 }
 
 export const deleteHardwareAddress = (event: IpcMainInvokeEvent, network: string) => {

--- a/src/actions/vue/data-store.ts
+++ b/src/actions/vue/data-store.ts
@@ -20,6 +20,10 @@ export const saveDerivedAccountsIndex = (num: number, network: Network): Promise
   resolve(window.ipcRenderer.invoke('save-num-accounts', JSON.stringify({ num, network })))
 })
 
+export const saveDerivedHardwareAccountsIndex = (num: number, network: Network, deviceId: string): Promise<string> => new Promise((resolve) => {
+  resolve(window.ipcRenderer.invoke('save-hw-num-accounts', JSON.stringify({ num, network, deviceId })))
+})
+
 export const getDerivedAccountsIndex = (network: Network): Promise<string> => new Promise((resolve) => {
   resolve(window.ipcRenderer.invoke('get-num-accounts', String(network)))
 })
@@ -30,6 +34,14 @@ export const saveHardwareWalletAddress = (address: string, network: Network): Pr
 
 export const getHardwareWalletAddress = (network: Network): Promise<string> => new Promise((resolve) => {
   resolve(window.ipcRenderer.invoke('get-hw-address', String(network)))
+})
+
+export const getHardwareDevices = (network: Network): Promise<string> => new Promise((resolve) => {
+  resolve(window.ipcRenderer.invoke('get-hw-devices', String(network)))
+})
+
+export const getHardwareDeviceAccounts = (network: Network, deviceId: string): Promise<any> => new Promise((resolve) => {
+  resolve(window.ipcRenderer.invoke('get-hw-device-accounts', String(network), deviceId))
 })
 
 export const deleteHardwareWalletAddress = (network: Network): Promise<string> => new Promise((resolve) => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -12,12 +12,15 @@ import {
   saveAccountName,
   getDerivedAccountsIndex,
   saveDerivedAccountsIndex,
+  saveDerivedHardwareAccountsIndex,
   saveHardwareAddress,
   saveLatestAccountAddress,
   getAcceptedTos,
   setAcceptedTos,
   getHardwareAddress,
   deleteHardwareAddress,
+  getHardwareDevices,
+  getHardwareDeviceAccounts,
   resetStore,
   persistNodeSelection,
   fetchSelectedNode,
@@ -126,11 +129,14 @@ ipcMain.handle('get-account-names', getAccountNames)
 ipcMain.handle('get-latest-account-address', getLatestAccountAddress)
 ipcMain.handle('save-latest-account-address', saveLatestAccountAddress)
 ipcMain.handle('save-num-accounts', saveDerivedAccountsIndex)
+ipcMain.handle('save-hw-num-accounts', saveDerivedHardwareAccountsIndex)
 ipcMain.handle('get-num-accounts', getDerivedAccountsIndex)
 ipcMain.handle('validate-pin-message', validatePin)
 ipcMain.handle('save-hw-address', saveHardwareAddress)
 ipcMain.handle('get-hw-address', getHardwareAddress)
 ipcMain.handle('delete-hw-address', deleteHardwareAddress)
+ipcMain.handle('get-hw-devices', getHardwareDevices)
+ipcMain.handle('get-hw-device-accounts', getHardwareDeviceAccounts)
 ipcMain.handle('send-apdu', sendAPDU)
 ipcMain.handle('reset-store', resetStore)
 ipcMain.handle('persist-node-selection', persistNodeSelection)

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -26,9 +26,12 @@ import {
   deleteHardwareWalletAddress,
   getDerivedAccountsIndex,
   getHardwareWalletAddress,
+  getHardwareDevices,
+  getHardwareDeviceAccounts,
   resetStore,
   saveAccountName,
   saveDerivedAccountsIndex,
+  saveDerivedHardwareAccountsIndex,
   saveHardwareWalletAddress,
   saveLatestAccountAddress,
   getAccountNames,
@@ -125,6 +128,7 @@ interface useWalletInterface {
   accountNameFor: (address: AccountAddressT) => string;
   accountRenamed: (newName: string) => void;
   addAccount: () => Promise<AccountT | false>;
+  addHardwareAccount: () => void;
   connectHardwareWallet: () => void;
   createWallet: (mnemonic: MnemomicT, pass: string, network: Network) => Promise<WalletT>;
   deleteLocalHardwareAddress: () => void;
@@ -227,6 +231,24 @@ const addAccount = async () : Promise<AccountT | false> => {
   fetchAccountsForNetwork(activeNetwork.value)
   accounts.value = await firstValueFrom(radix.accounts)
   return newAccount
+}
+
+const addHardwareAccount = async () => {
+  if (!activeNetwork.value) return
+  getDerivedAccountsIndex(activeNetwork.value)
+    .then((index: string) => {
+      if (!activeNetwork.value) return
+      saveDerivedHardwareAccountsIndex(Number(index) + 1, activeNetwork.value, 'tdx1qsps3cs7dkhhpgrvulm32222cgrekn99d9sqke48e0vw0echs9w2hysn46mcy')
+
+      // radix.deriveNextAccount({ alsoSwitchTo: true })
+    })
+  console.log('add a hw account!')
+  const network = await firstValueFrom(radix.ledger.networkId())
+  const devices = await getHardwareDevices(network)
+  const firstHwDeviceId = devices[0]
+  const ledgerAccounts = await getHardwareDeviceAccounts(network, firstHwDeviceId)
+  console.log('-ledgerId->', devices, firstHwDeviceId)
+  console.log('-accounts->', ledgerAccounts[0].addresses)
 }
 
 const switchAddress = (address: AccountAddressT) => {
@@ -428,6 +450,7 @@ export default function useWallet (router: Router): useWalletInterface {
     accountNameFor,
     accountRenamed,
     addAccount,
+    addHardwareAccount,
     connectHardwareWallet,
     createWallet,
     deleteLocalHardwareAddress,

--- a/src/electron-store/migrations.ts
+++ b/src/electron-store/migrations.ts
@@ -35,6 +35,28 @@ const migrations = {
 
     if (!store.get('wallets.MAINNET.latestAddress')) store.set('wallets.MAINNET.latestAddress', '')
     if (!store.get('wallets.STOKENET.latestAddress')) store.set('wallets.STOKENET.latestAddress', '')
+  },
+  '1.3.4': (store: Record<string, any>) => {
+    const existingMainnetHardwareAddress = store.get('wallets.mainnet.hardwareAddress')
+    if (!store.get('wallets.mainnet.hardwareDevices')) store.set('wallets.mainnet.hardwareDevices', [])
+
+    if (existingMainnetHardwareAddress) {
+      const primaryStokenetAccount: any = {}
+      primaryStokenetAccount["name"] = existingMainnetHardwareAddress
+      primaryStokenetAccount["addresses"] = [{"name": existingMainnetHardwareAddress, "address": existingMainnetHardwareAddress}]
+      store.set(`wallets.mainnet.hardwareDevices`, [primaryStokenetAccount])
+    }
+
+    // ------------------------------------------------------------------------------------------------------------
+    const existingStokenetHardwareAddress = store.get('wallets.stokenet.hardwareAddress')
+    if (!store.get('wallets.stokenet.hardwareDevices')) store.set('wallets.stokenet.hardwareDevices', [])
+
+    if (existingStokenetHardwareAddress) {
+      const primaryStokenetAccount: any = {}
+      primaryStokenetAccount["name"] = existingStokenetHardwareAddress
+      primaryStokenetAccount["addresses"] = [{"name": existingStokenetHardwareAddress, "address": existingStokenetHardwareAddress}]
+      store.set(`wallets.stokenet.hardwareDevices`, [primaryStokenetAccount])
+    }
   }
 }
 

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -119,7 +119,8 @@ const messages = {
         title: 'Ledger Device Disconnected',
         content: 'Unable to decrypt message. Ensure your device is connected or switch accounts to continue.',
         buttonText: 'Dismiss'
-      }
+      },
+      hardwareWalletAccounts: 'Hardware Wallet Accounts:'
     },
     hardware: {
       disclaimer: 'Whenever copying a hardware wallet address, it is strongly recommended to verify it on the hardware device. To copy and verify this address, please switch to the hardware address first by selecting it in the account picker.',

--- a/src/views/Wallet/WalletSidebarAccounts.vue
+++ b/src/views/Wallet/WalletSidebarAccounts.vue
@@ -30,8 +30,8 @@
 
     <div class="border-t border-rGray border-opacity-50 pt-4">
       <div v-if="hardwareAddress" class="mt-2">
-        <div class="flex justify-between">
-
+          <span class="mt-3 mb-6 font-semibold">{{ $t('wallet.hardwareWalletAccounts') }}</span>
+        <div class="flex justify-between mt-4">
           <a class="flex cursor-pointer"
             @click="hardwareSwitch(hardwareAddress)">
             <svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg" class="text-rGreen" :class="{'fill-current': isHardwareWalletActive}">
@@ -53,9 +53,13 @@
         </div>
 
         <div class="text-xs text-white relative z-20 flex justify-between mt-4">
-          <span class="mr-2">{{ $t('wallet.addressLabel') }}</span>
-          <span class="flex-1 w-full truncate font-mono">{{ displayHardwareAddress }}</span>
-          <click-to-copy :address="hardwareAddress" />
+          <!-- <span class="mr-2">{{ $t('wallet.addressLabel') }}</span> -->
+          <span class="flex-1 w-full font-mono">{{ displayHardwareAddress }}</span>
+          <click-to-copy
+              :address="hardwareAddress"
+              :checkForHardwareAddress=true
+              @verifyHardwareAddress="verifyHardwareWalletAddress"
+            />
         </div>
       </div>
 
@@ -71,6 +75,9 @@
           <p class="w-48">Please ensure your Ledger is connected and the Radix application is selected.</p>
         </div>
       </div>
+        <div @click="addHardwareAccount" class="mt-3 mb-4 inline-flex flex-row items-center cursor-pointer hover:text-rGreen transition-colors">
+         {{ $t('wallet.addAccount') }}
+        </div>
     </div>
   </div>
 </template>
@@ -96,6 +103,7 @@ const WalletSidebarAccounts = defineComponent({
       activeAddress,
       addAccount,
       switchAddress,
+      addHardwareAccount,
       connectHardwareWallet,
       setDeleteHWWalletPrompt,
       hardwareAccount,
@@ -144,6 +152,7 @@ const WalletSidebarAccounts = defineComponent({
         })
       },
       switchAddress,
+      addHardwareAccount,
       isHardwareWalletActive,
       debugSwitch (account: AccountT) {
         const name = router.currentRoute.value.name || 'WalletOverview'


### PR DESCRIPTION
The wallet.json schema now features a `hardwareDevices` block which will allow us to store multiple ledgers (their identified by their first derived account address). Along with multiple accounts per wallet. The schema looks like the following 

```JSON
"hardwareDevices":[
   {
      "name":"tdx1qsps3cs7dkhhpgrvulm32222cgrekn99d9sqke48e0vw0echs9w2hysn46mcy",
      "addresses":[
         {
            "name":"tdx1qsps3cs7dkhhpgrvulm32222cgrekn99d9sqke48e0vw0echs9w2hysn46mcy",
            "address":"tdx1qsps3cs7dkhhpgrvulm32222cgrekn99d9sqke48e0vw0echs9w2hysn46mcy"
         },
         {
            "name":"...",
            "account":"...."
         }
      ]
   }

```