### PR TITLE
Feat: fix renaming device functionality and add new device popup 

### DIFF
--- a/src/actions/electron/data-store.ts
+++ b/src/actions/electron/data-store.ts
@@ -67,7 +67,6 @@ export const getDerivedAccountsIndex = (event: IpcMainInvokeEvent, network: stri
 
 export const saveHardwareDevices = (event: IpcMainInvokeEvent, data: string): void => {
   const { network, encodedDevices } = JSON.parse(data)
-  const devices = store.get(`wallets.${network}.hardwareDevices`)
   store.set(`wallets.${network}.hardwareDevices`, encodedDevices)
 }
 

--- a/src/actions/electron/data-store.ts
+++ b/src/actions/electron/data-store.ts
@@ -23,7 +23,7 @@ export const saveDeviceName = (event: IpcMainInvokeEvent, data: string) => {
   const device = hardwareDevices[deviceIndex]
   const renamedDeviceObject = {"name": prettyName, "addresses":[...device.addresses]}
   hardwareDevices.splice(deviceIndex, 1, renamedDeviceObject)
-  store.set(`wallets.${network}.hardwareDevices`, [renamedDeviceObject])
+  store.set(`wallets.${network}.hardwareDevices`, hardwareDevices)
 }
 
 export const getLatestAccountAddress = (event: IpcMainInvokeEvent, network: string): string => {
@@ -67,6 +67,7 @@ export const getDerivedAccountsIndex = (event: IpcMainInvokeEvent, network: stri
 
 export const saveHardwareDevices = (event: IpcMainInvokeEvent, data: string): void => {
   const { network, encodedDevices } = JSON.parse(data)
+  const devices = store.get(`wallets.${network}.hardwareDevices`)
   store.set(`wallets.${network}.hardwareDevices`, encodedDevices)
 }
 

--- a/src/actions/vue/data-store.ts
+++ b/src/actions/vue/data-store.ts
@@ -36,12 +36,12 @@ export const getDerivedAccountsIndex = (network: Network): Promise<string> => ne
 
 export const saveHardwareDevices = async (network: Network, hardwareDevices: HardwareDevice[]) => new Promise((resolve) => {
   const data = hardwareDevices.map((hw: HardwareDevice) => {
+    const name = hw.name.length < 50 ? hw.name : 'hardware device'
     return {
-      name: hw.name,
+      name: name,
       addresses: hw.addresses.map(({ index, address }) => ({ index, address: address.toString() }))
     }
   }) as EncodedHardwareDevice[]
-
   resolve(window.ipcRenderer.invoke('save-hw-devices', JSON.stringify({ network: String(network), encodedDevices: data })))
 })
 

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -322,6 +322,7 @@ const createNewHardwareAccount = async () => {
       hardwareAccount.value = connectedDeviceAccount
       hardwareDevices.value = newHardwareDevices
       saveHardwareDevices(activeNetwork.value, newHardwareDevices)
+      hardwareDevices.value = await getHardwareDevices(activeNetwork.value)
       router.push(`/wallet/${connectedDeviceAccount.address.toString()}`)
       setShowNewDevicePopup(true)
     }

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -116,6 +116,8 @@ const messages = {
       network: 'Network',
       update: 'Update Available',
       disconnected: 'Disconnected',
+      newHardwareAccountBody: 'You’ve derived an account from a new ledger device, a new hardware wallet was added.',
+      newHardwareAccountConfirm: 'Got it!',
       hideSoftwareAccountModalBody: 'Are you sure you want to hide this software account? This account can be unhidden in settings.',
       hideHardwareAccountModalBody: 'Are you sure you want to hide this hardware account? This account can be unhidden in settings.',
       hideAccountModalSubmit: 'Hide Account',

--- a/src/views/Wallet/WalletDeviceEditName.vue
+++ b/src/views/Wallet/WalletDeviceEditName.vue
@@ -78,7 +78,7 @@ const WalletDeviceEditName = defineComponent({
     const handleSubmit = () => {
       selectedDeviceIndex()
         .then((idx) => {
-          if (!activeNetwork.value || idx) return
+          if (!activeNetwork.value || idx === undefined) return
           saveDeviceName(idx, activeNetwork.value, name.value)
           deviceRenamed()
         })

--- a/src/views/Wallet/WalletHideAccountModal.vue
+++ b/src/views/Wallet/WalletHideAccountModal.vue
@@ -47,13 +47,9 @@ const WalletHideAccountModal = defineComponent({
 
     return {
       handleSubmit: () => {
-        // add account to hiddenAccounts in wallet.json
-        // switch to first derived
         setHideAccountModal(false)
       },
       handleClose: () => {
-        // add account to hiddenAccounts in wallet.json
-        // switch to first derived
         setHideAccountModal(false)
       },
       connectHardwareWallet,

--- a/src/views/Wallet/WalletNewDevicePopup.vue
+++ b/src/views/Wallet/WalletNewDevicePopup.vue
@@ -28,8 +28,6 @@ const WalletNewDevicePopup = defineComponent({
 
     return {
       handleClose: () => {
-        // add account to hiddenAccounts in wallet.json
-        // switch to first derived
         setShowNewDevicePopup(false)
       }
     }

--- a/src/views/Wallet/WalletNewDevicePopup.vue
+++ b/src/views/Wallet/WalletNewDevicePopup.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="fixed w-screen h-screen z-20 flex items-center justify-center">
+    <div class="bg-white rounded-md w-72 absolute top-2/3 left-1/4 transform -translate-x-1/3 -translate-y-1/2 border border-rBlue bg-rGrayLight">
+      <div class="text-center px-2 pt-4 text-rGrayDark">{{ $t('wallet.newHardwareAccountBody') }}</div>
+      <div class="py-2 flex justify-center">
+        <AppButtonSubmit @click="handleClose" class="w-1/2 ">{{ $t('wallet.newHardwareAccountConfirm') }}</AppButtonSubmit>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import { useRouter } from 'vue-router'
+import { useWallet } from '@/composables'
+import AppButtonSubmit from '@/components/AppButtonSubmit.vue'
+
+const WalletNewDevicePopup = defineComponent({
+  components: {
+    AppButtonSubmit
+  },
+
+  setup () {
+    const router = useRouter()
+    const {
+      setShowNewDevicePopup
+    } = useWallet(router)
+
+    return {
+      handleClose: () => {
+        // add account to hiddenAccounts in wallet.json
+        // switch to first derived
+        setShowNewDevicePopup(false)
+      }
+    }
+  }
+})
+
+export default WalletNewDevicePopup
+</script>

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -23,6 +23,7 @@
     <wallet-ledger-interaction-modal v-if="hardwareInteractionState && hardwareInteractionState.length > 0" />
     <wallet-ledger-delete-modal v-if="showDeleteHWWalletPrompt" />
     <wallet-hide-account-modal v-if="showHideAccountModal"/>
+    <wallet-new-device-popup v-if="showNewDevicePopup"/>
   </div>
 </template>
 
@@ -35,6 +36,7 @@ import WalletLoading from './WalletLoading.vue'
 import WalletLedgerVerifyAddressModal from '@/views/Wallet/WalletLedgerVerifyAddressModal.vue'
 import WalletLedgerDeleteModal from '@/views/Wallet/WalletLedgerDeleteModal.vue'
 import WalletHideAccountModal from '@/views/Wallet/WalletHideAccountModal.vue'
+import WalletNewDevicePopup from '@/views/Wallet/WalletNewDevicePopup.vue'
 import { useRouter, onBeforeRouteUpdate, onBeforeRouteLeave, useRoute } from 'vue-router'
 import { useTransactions, useWallet } from '@/composables'
 
@@ -46,6 +48,7 @@ const WalletIndex = defineComponent({
     WalletLedgerVerifyAddressModal,
     WalletLedgerDeleteModal,
     WalletHideAccountModal,
+    WalletNewDevicePopup,
     WalletLoading
   },
 
@@ -62,6 +65,7 @@ const WalletIndex = defineComponent({
       radix,
       showDeleteHWWalletPrompt,
       showHideAccountModal,
+      showNewDevicePopup,
       showLedgerVerify,
       setActiveAddress,
       walletLoaded,
@@ -104,6 +108,7 @@ const WalletIndex = defineComponent({
       shouldShowConfirmation,
       showDeleteHWWalletPrompt,
       showHideAccountModal,
+      showNewDevicePopup,
       showLedgerVerify,
       isTestNet,
       walletLoaded


### PR DESCRIPTION
The title explains this one for the most part. In the addition to multiple devices, my original method of saving renamed devices had a bug that came to the surface. Also when a new account is made with a new device, a small popup modal will appear alerting the user that a new device has been connected and saved. 

### 🎥🎥🎥
![rename](https://user-images.githubusercontent.com/72633467/164480199-fe227cdb-dd3a-48a5-800a-b16daa840063.gif)

