### PR TITLE
Fix Latest builds by bumping the version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radix-olympia-desktop-wallet",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "description": "Radix Olympia Desktop Wallet",
   "author": "Radix Tokens Jersey Limited",


### PR DESCRIPTION
The store migrations won't run on latest because it's still locked to the same version.