### PR TITLE
feat: toggle show hide software hardware accounts

### DIFF
--- a/src/actions/vue/data-store.ts
+++ b/src/actions/vue/data-store.ts
@@ -35,8 +35,8 @@ export const getDerivedAccountsIndex = (network: Network): Promise<string> => ne
 })
 
 export const saveHardwareDevices = async (network: Network, hardwareDevices: HardwareDevice[]) => new Promise((resolve) => {
-  const data = hardwareDevices.map((hw: HardwareDevice) => {
-    const name = hw.name.length < 50 ? hw.name : 'hardware device'
+  const data = hardwareDevices.map((hw: HardwareDevice, i) => {
+    const name = hw.name.length < 50 ? hw.name : `hardware device ${i}`
     return {
       name: name,
       addresses: hw.addresses.map(({ index, address }) => ({ index, address: address.toString() }))

--- a/src/actions/vue/data-store.ts
+++ b/src/actions/vue/data-store.ts
@@ -35,10 +35,9 @@ export const getDerivedAccountsIndex = (network: Network): Promise<string> => ne
 })
 
 export const saveHardwareDevices = async (network: Network, hardwareDevices: HardwareDevice[]) => new Promise((resolve) => {
-  const data = hardwareDevices.map((hw: HardwareDevice, i) => {
-    const name = hw.name.length < 50 ? hw.name : `hardware device ${i}`
+  const data = hardwareDevices.map((hw: HardwareDevice) => {
     return {
-      name: name,
+      name: hw.name,
       addresses: hw.addresses.map(({ index, address }) => ({ index, address: address.toString() }))
     }
   }) as EncodedHardwareDevice[]

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -316,7 +316,8 @@ const createNewHardwareAccount = async () => {
       router.push(`/wallet/${newAccount.address.toString()}`)
     } else {
       const newAddr = connectedDeviceAccount.address.toString()
-      const newHardwareDevices = [...hardwareDevices.value, { name: newAddr, addresses: [{ name: newAddr, address: connectedDeviceAccount.address, index: 0 }] }]
+      const deviceNumber = hardwareDevices.value.length + 1
+      const newHardwareDevices = [...hardwareDevices.value, { name: `Hardware Device ${deviceNumber}`, addresses: [{ name: newAddr, address: connectedDeviceAccount.address, index: 0 }] }]
       hardwareAddress.value = newAddr
       activeAccount.value = connectedDeviceAccount
       hardwareAccount.value = connectedDeviceAccount

--- a/src/views/Wallet/WalletSidebarAccounts.vue
+++ b/src/views/Wallet/WalletSidebarAccounts.vue
@@ -116,7 +116,6 @@
                 :key="address.index"
                 :address="address.address"
                 :shouldShowEdit="true"
-                :id="address.address.toString()"
                 @click="hardwareSwitch(address.address.toString())"
                 class="mb-8"
               />

--- a/src/views/Wallet/WalletSidebarAccounts.vue
+++ b/src/views/Wallet/WalletSidebarAccounts.vue
@@ -95,13 +95,13 @@
                   </svg>
                 </div>
                 <div @click="toggleHardwareAccounts(hardwareDevice)" class="flex pt-1 pr-1 text-rGrayDark hover:text-rGreen transition-colors cursor-pointer">
-                  <svg v-if="deviceHidden(hardwareDevice.name)" width="17" height="17" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <svg v-if="deviceAccountsHidden(hardwareDevice.name)" width="17" height="17" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path class="stroke-current" d="M2 7H5V10" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
                     <path class="stroke-current" d="M10 5H7V2" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
                     <path class="stroke-current" d="M7 5L10.5 1.5" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
                     <path class="stroke-current" d="M1.5 10.5L5 7" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
                   </svg>
-                  <svg v-else @click="!deviceHidden(hardwareDevice.name)" class="ml-auto stroke-current text-rGrayDark hover:text-rGreen transition-colors" width="15" height="15" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <svg v-else @click="!deviceAccountsHidden(hardwareDevice.name)" class="ml-auto stroke-current text-rGrayDark hover:text-rGreen transition-colors" width="15" height="15" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path class="stroke-current" d="M7.5 1.5H10.5V4.5" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
                     <path class="stroke-current" d="M4.5 10.5H1.5V7.5" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
                     <path class="stroke-current" d="M10.5 1.5L7 5" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
@@ -110,7 +110,7 @@
                 </div>
               </div>
             </div>
-            <div v-if="deviceHidden(hardwareDevice.name)" class="-mx-5">
+            <div v-if="deviceAccountsHidden(hardwareDevice.name)" class="-mx-5">
               <hardware-account-list-item
                 v-for="address in hardwareDevice.addresses"
                 :key="address.index"
@@ -237,7 +237,7 @@ const WalletSidebarAccounts = defineComponent({
           hiddenHwAccounts.value.push(hardwareDevice.name)
         }
       },
-      deviceHidden (deviceName: string) {
+      deviceAccountsHidden (deviceName: string) {
         const hiddenDevices = Object.values(hiddenHwAccounts.value)
         return !hiddenDevices.includes(deviceName)
       },

--- a/src/views/Wallet/WalletSidebarAccounts.vue
+++ b/src/views/Wallet/WalletSidebarAccounts.vue
@@ -21,27 +21,34 @@
         <div class="pl-3 ">
           {{ $t('wallet.softwareWallets') }}
         </div>
-        <svg class="ml-auto mt-1" width="17" height="17" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M2 7H5V10" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
-          <path d="M10 5H7V2" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
-          <path d="M7 5L10.5 1.5" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
-          <path d="M1.5 10.5L5 7" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
+        <svg v-if="showSoftwareAccounts" @click="toggleSoftwareAccounts" class="ml-auto mt-1 text-rGrayDark hover:text-rGreen transition-colors" width="17" height="17" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path class="stroke-current" d="M2 7H5V10" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
+          <path class="stroke-current" d="M10 5H7V2" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
+          <path class="stroke-current" d="M7 5L10.5 1.5" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
+          <path class="stroke-current" d="M1.5 10.5L5 7" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
+        <svg v-else @click="toggleSoftwareAccounts" class="ml-auto mt-1 stroke-current text-rGrayDark hover:text-rGreen transition-colors" width="15" height="15" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path class="stroke-current" d="M7.5 1.5H10.5V4.5" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
+          <path class="stroke-current" d="M4.5 10.5H1.5V7.5" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
+          <path class="stroke-current" d="M10.5 1.5L7 5" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
+          <path class="stroke-current" d="M1.5 10.5L5 7" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+
       </div>
-
-      <account-list-item
-        v-for="account in localAccounts"
-        :key="account.address.toString()"
-        :address="account.address"
-        :shouldShowEdit="true"
-        @click="debugSwitch(account)"
-        @edit="editName(account)"
-        class="mb-8"
-      >
-      </account-list-item>
-
-      <div @click="addSoftwareAccount" class="my-4 text-center cursor-pointer hover:text-rGreen transition-colors">
-        {{ $t('wallet.addSoftwareAccount') }}
+      <div v-if="showSoftwareAccounts">
+        <account-list-item
+          v-for="account in localAccounts"
+          :key="account.address.toString()"
+          :address="account.address"
+          :shouldShowEdit="true"
+          @click="debugSwitch(account)"
+          @edit="editName(account)"
+          class="mb-8"
+        >
+        </account-list-item>
+        <div @click="addSoftwareAccount" class="my-4 text-center cursor-pointer hover:text-rGreen transition-colors">
+          {{ $t('wallet.addSoftwareAccount') }}
+        </div>
       </div>
       <div class="border-t border-rGray border-opacity-50 mx-4 mt-2 py-4" ></div>
     </div>
@@ -153,6 +160,7 @@ const WalletSidebarAccounts = defineComponent({
 
     const { setState } = useSidebar()
     const showHardwareHelper = ref(false)
+    const showSoftwareAccounts = ref(true)
 
     const displayHardwareAddress: ComputedRef<string> = computed(() => {
       if (!hardwareAddress.value) return ''
@@ -186,6 +194,7 @@ const WalletSidebarAccounts = defineComponent({
       hardwareAddress,
       hardwareDevices,
       showHardwareHelper,
+      showSoftwareAccounts,
       displayHardwareAddress,
       localAccounts,
       handleAccountEditName,
@@ -206,6 +215,9 @@ const WalletSidebarAccounts = defineComponent({
       hardwareSwitch (val: string) {
         const name = router.currentRoute.value.name || 'WalletOverview'
         router.push({ name, params: { activeAddress: val } })
+      },
+      toggleSoftwareAccounts () {
+        showSoftwareAccounts.value = !showSoftwareAccounts.value
       },
       editName (account: AccountT) {
         setState(false)

--- a/src/views/Wallet/WalletSidebarAccounts.vue
+++ b/src/views/Wallet/WalletSidebarAccounts.vue
@@ -94,22 +94,29 @@
                     <path class="stroke-current" d="M4.68616 0.875L8.76949 13.125" stroke="#F2F2FC" stroke-linecap="round"/>
                   </svg>
                 </div>
-                <div class="flex pt-1 pr-1 text-rGrayDark hover:text-rGreen transition-colors cursor-pointer">
-                  <svg width="15" height="15" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <div @click="toggleHardwareAccounts(hardwareDevice)" class="flex pt-1 pr-1 text-rGrayDark hover:text-rGreen transition-colors cursor-pointer">
+                  <svg v-if="deviceHidden(hardwareDevice.name)" width="17" height="17" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path class="stroke-current" d="M2 7H5V10" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
                     <path class="stroke-current" d="M10 5H7V2" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
                     <path class="stroke-current" d="M7 5L10.5 1.5" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
                     <path class="stroke-current" d="M1.5 10.5L5 7" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
                   </svg>
+                  <svg v-else @click="!deviceHidden(hardwareDevice.name)" class="ml-auto stroke-current text-rGrayDark hover:text-rGreen transition-colors" width="15" height="15" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path class="stroke-current" d="M7.5 1.5H10.5V4.5" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path class="stroke-current" d="M4.5 10.5H1.5V7.5" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path class="stroke-current" d="M10.5 1.5L7 5" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path class="stroke-current" d="M1.5 10.5L5 7" stroke="#F2F2FC" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
                 </div>
               </div>
             </div>
-            <div class="-mx-5">
+            <div v-if="deviceHidden(hardwareDevice.name)" class="-mx-5">
               <hardware-account-list-item
                 v-for="address in hardwareDevice.addresses"
                 :key="address.index"
                 :address="address.address"
                 :shouldShowEdit="true"
+                :id="address.address.toString()"
                 @click="hardwareSwitch(address.address.toString())"
                 class="mb-8"
               />
@@ -161,6 +168,8 @@ const WalletSidebarAccounts = defineComponent({
     const { setState } = useSidebar()
     const showHardwareHelper = ref(false)
     const showSoftwareAccounts = ref(true)
+    const showHardwareAccounts = ref(true)
+    const hiddenHwAccounts: any = ref([])
 
     const displayHardwareAddress: ComputedRef<string> = computed(() => {
       if (!hardwareAddress.value) return ''
@@ -195,6 +204,7 @@ const WalletSidebarAccounts = defineComponent({
       hardwareDevices,
       showHardwareHelper,
       showSoftwareAccounts,
+      showHardwareAccounts,
       displayHardwareAddress,
       localAccounts,
       handleAccountEditName,
@@ -218,6 +228,18 @@ const WalletSidebarAccounts = defineComponent({
       },
       toggleSoftwareAccounts () {
         showSoftwareAccounts.value = !showSoftwareAccounts.value
+      },
+      toggleHardwareAccounts (hardwareDevice: any) {
+        const index = hiddenHwAccounts.value.indexOf(hardwareDevice.name)
+        if (index > -1) {
+          hiddenHwAccounts.value.splice(index, 1)
+        } else {
+          hiddenHwAccounts.value.push(hardwareDevice.name)
+        }
+      },
+      deviceHidden (deviceName: string) {
+        const hiddenDevices = Object.values(hiddenHwAccounts.value)
+        return !hiddenDevices.includes(deviceName)
       },
       editName (account: AccountT) {
         setState(false)

--- a/src/views/Wallet/WalletSidebarAccounts.vue
+++ b/src/views/Wallet/WalletSidebarAccounts.vue
@@ -132,7 +132,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed, ComputedRef } from 'vue'
+import { defineComponent, ref, Ref, computed, ComputedRef } from 'vue'
 import { AccountT } from '@radixdlt/application'
 import AccountListItem from '@/components/AccountListItem.vue'
 import HardwareAccountListItem from '@/components/HardwareAccountListItem.vue'
@@ -168,7 +168,7 @@ const WalletSidebarAccounts = defineComponent({
     const showHardwareHelper = ref(false)
     const showSoftwareAccounts = ref(true)
     const showHardwareAccounts = ref(true)
-    const hiddenHwAccounts: any = ref([])
+    const hiddenHwAccounts: Ref<string[]> = ref([])
 
     const displayHardwareAddress: ComputedRef<string> = computed(() => {
       if (!hardwareAddress.value) return ''


### PR DESCRIPTION
This PR allows for the user to toggle "collapse" a cluster of accounts. All software accounts and / or all accounts under and individual hardware wallet can be collapsed and re expanded. 
### 📸📸📸📸📸
![collapse-radix](https://user-images.githubusercontent.com/72633467/165604596-c755d6c8-d920-4d4e-a256-f6310d380c14.gif)

