### PR TITLE
feat: automatically turn on max unstake mode based on user input

### DIFF
--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -395,10 +395,6 @@ const WalletStaking = defineComponent({
     const handleMaxSubmitUnstake = () => {
       const safeAddress = safelyUnwrapValidator(values.validator)
       if (!safeAddress) return
-      // What is safeOneHundredPercent?
-      // values.validator is the validator address
-      // values.amount is the amount the user types
-      // What does safelyUnrapValidator do? I did a console.log but I wasnt sure what i was looking at
       const safeOneHundredPercent = safelyUnwrapAmount(Number('0.0000000000000001'))
       if (!safeOneHundredPercent) return
 

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -349,7 +349,7 @@ const WalletStaking = defineComponent({
         const activeValidatorStakeAmount = getActiveStakeAmountForValidator(validatorAddress.value)
         const maxAmount: number = +asBigNumber(activeValidatorStakeAmount)
         const minDifference: number = maxAmount - stakingInputAmount
-        if (minDifference < 0.000001) {
+        if (minDifference <= 0.000001) {
           setMaxUnstakeOn()
         }
       }


### PR DESCRIPTION

### Feat: Add dust prevention unstaking

[See Linear Issue RDX-358](https://linear.app/township/issue/RDX-358/dust-prevention-unstaking)

This PR prevents the user from leaving “dust” in their wallet if they manually input the unstake amount instead of clicking the max button.  When a user presses the ```reduce stake``` button, the validatorAddress ref is assigned the value of the validator.  A function was added that checks if the difference between the users input and the max unstake amount is within ```0.000001``` only if there is an address in the validator address field above it.  If it is, this triggers the same behavior as if the user had pressed the max button, utilizing the full unstakable amount.  

[Watch Loom Demo Walkthrough](https://loom.com/share/f15fb724a2b84ef08dd287022dfc7b35)


In WalletStaking.vue

- In the template a ```v-model``` attribute was added to the form field component to get the users input. Also, a ```v-on``` attribute was added to invoke the ```compareToMaxUnstakeAmount``` function with the input the user typed as a parameter.
```
    <FormField
      name="amount"
      type="number"
      step="any"
      class="w-9/12 text-sm justify-items-start"
      :class="{'w-full': activeForm !== 'UNSTAKING'}"
      :placeholder="amountPlaceholder"
      rules="required|validAmount"
      v-model="stakingInputAmount"
      v-on:input="e => compareToMaxUnstakeAmount(stakingInputAmount)"
      :validateOnInput="true"
    />
```


- Ref add to store the value of the validator address

```
const validatorAddress: Ref<ValidatorAddressT | null> = ref(null)

```


- Assigned the value of the ```validatorAddress``` ref to the validator passed in to the ```handleReduceFromValidator``` function which is the method attached to the on click event handler of the ```reduce state``` button
```
    const handleReduceFromValidator = (validator: ValidatorAddressT) => {
      validatorAddress.value = validator
      setActiveForm('UNSTAKING')
      setActiveTransactionForm('unstake')
      resetForm()
      setMaxUnstakeOff()
      values.validator = validator.toString()
      validateField('validator')
    }

```


- Custom function to compare user input unstake amount to the max unstake amount, ```setMaxUnstakeOn``` is invoked  if the ```minDifference``` is less than or equal to ```0.000001```.  ```setMaxUnstakeOn``` is the on click event handler for the ```max``` button.

```
    const compareToMaxUnstakeAmount = (stakingInputAmount: number) => {
      if (validatorAddress.value) {
        const activeValidatorStakeAmount = getActiveStakeAmountForValidator(validatorAddress.value)
        const maxAmount: number = +asBigNumber(activeValidatorStakeAmount)
        const minDifference: number = maxAmount - stakingInputAmount
        if (minDifference < = 0.000001) {
          setMaxUnstakeOn()
        }
      }
    }

```


## Challenges
- Finding where the amount that the user input is originally extracted from and how to access that value, without having to add v-model to the FormField component.
