### PR TITLE
chore(ci): Fix Mac OS Notarization by providing the apple team id

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -25,6 +25,7 @@ jobs:
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           # GitHub token, automatically provided to the action
           # (No need to define this secret in the repo settings)

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -30,6 +30,7 @@ jobs:
           VUE_APP_EXPLORER: https://explorer.radixdlt.com
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           # GitHub token, automatically provided to the action
           # (No need to define this secret in the repo settings)


### PR DESCRIPTION
The notarization of Mac OS builds (currently only the latest builds, but I'm assuming the same problem will arise from a proper release) fail because the notarization system now requires the team id associated with the app and certificates.

You can see an example of this error [here](https://github.com/radixdlt/olympia-wallet/runs/6489331794?check_suite_focus=true).   You can see this [gist](https://gist.github.com/fbaiodias/ec08ee0141e06a98470230e564220cfa) for a related issue and [the electron-build-notarize](https://github.com/karaggeorge/electron-builder-notarize) repo for how the environment values are specified.  @russellharvey We'll need to add this variable as a repo secret value.  I'll follow up directly to make sure the value gets set.