### PR TITLE
feat: notify user when max mode enabled

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -217,7 +217,8 @@ const messages = {
       notTopOneHundred: 'Not in top 100 validators',
       unstakeMaxDisclaimer: "You're unstaking all tokens from",
       maxUnstakeButton: 'max',
-      maxUnstakeCapitalized: 'MAX'
+      maxUnstakeCapitalized: 'MAX',
+      maxUnstakeModeEnabledWarning: 'The value you entered is within 0.000001 of the full unstakable amount, therefore, max mode has been automatically enabled on this entry.'
     },
     confirmation: {
       transferFromLabel: 'Your address',

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -218,7 +218,7 @@ const messages = {
       unstakeMaxDisclaimer: "You're unstaking all tokens from",
       maxUnstakeButton: 'max',
       maxUnstakeCapitalized: 'MAX',
-      maxUnstakeModeEnabledWarning: 'The value you entered is within 0.000001 of the full unstakable amount, therefore, max mode has been automatically enabled on this entry.'
+      maxUnstakeModeEnabledNotification: 'The value you entered is within 0.000001 of the full unstakable amount, therefore, max mode has been automatically enabled on this entry.'
     },
     confirmation: {
       transferFromLabel: 'Your address',

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -359,7 +359,6 @@ const WalletStaking = defineComponent({
       const minDifference = maxAmount - currentValue
       if (minDifference <= 0.000001) {
         setMaxUnstakeNotificationOn()
-        console.log('showMaxUnstakeNotification ', showMaxUnstakeNotification.value)
         setMaxUnstakeOn()
       }
     }

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -395,10 +395,6 @@ const WalletStaking = defineComponent({
     const handleMaxSubmitUnstake = () => {
       const safeAddress = safelyUnwrapValidator(values.validator)
       if (!safeAddress) return
-      // What is safeOneHundredPercent?
-      // values.validator is the validator address
-      // values.amount is the amount the user types
-      // What does safelyUnrapValidator do? I did a console.log but I wasnt sure what i was looking at
       const safeOneHundredPercent = safelyUnwrapAmount(Number('0.0000000000000001'))
       if (!safeOneHundredPercent) return
 

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -84,7 +84,8 @@
                     :class="{'w-full': activeForm !== 'UNSTAKING'}"
                     :placeholder="amountPlaceholder"
                     rules="required|validAmount"
-                    @input="compareToMaxUnstakeAmount"
+                    v-model="stakingInputAmount"
+                    v-on:input="e => compareToMaxUnstakeAmount(stakingInputAmount)"
                     :validateOnInput="true"
                   />
                   <button
@@ -159,6 +160,7 @@ interface StakeForm {
   amount: number;
 }
 const refreshSub: Ref<Subscription | null> = ref(null)
+const validatorAddress: Ref<ValidatorAddressT | null> = ref(null)
 
 const uniqBy = (arr: any[], predicate: (item: any) => string) => {
   if (!Array.isArray(arr)) { return [] }
@@ -333,6 +335,7 @@ const WalletStaking = defineComponent({
     }
 
     const handleReduceFromValidator = (validator: ValidatorAddressT) => {
+      validatorAddress.value = validator
       setActiveForm('UNSTAKING')
       setActiveTransactionForm('unstake')
       resetForm()
@@ -341,17 +344,14 @@ const WalletStaking = defineComponent({
       validateField('validator')
     }
 
-    const compareToMaxUnstakeAmount = () => {
-      const safeAddress = safelyUnwrapValidator(values.validator)
-      const safeAmount = safelyUnwrapAmount(Number(values.amount))
-      if (!safeAddress || !safeAmount) return
-
-      const activeValidatorStakeAmount = getActiveStakeAmountForValidator(safeAddress)
-      const maxAmount = +asBigNumber(activeValidatorStakeAmount) as number
-      const currentValue = +asBigNumber(safeAmount) as number
-      const minDifference = maxAmount - currentValue
-      if (minDifference <= 0.000001) {
-        setMaxUnstakeOn()
+    const compareToMaxUnstakeAmount = (stakingInputAmount: number) => {
+      if (validatorAddress.value) {
+        const activeValidatorStakeAmount = getActiveStakeAmountForValidator(validatorAddress.value)
+        const maxAmount: number = +asBigNumber(activeValidatorStakeAmount)
+        const minDifference: number = maxAmount - stakingInputAmount
+        if (minDifference < 0.000001) {
+          setMaxUnstakeOn()
+        }
       }
     }
 

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -96,6 +96,13 @@
                   </button>
                 </div>
                 <FormErrorMessage name="amount" class="text-sm text-red-400" errorClass="w-120" />
+                <!-- I want to a boolean variable that changes to true one the user types a number within range, this boolean then displays an alert message similar to the error message -->
+                <div v-if="maxUnstakeMode" class="flex items-center gap-2 max-w-md">
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M14 7C14 10.866 10.866 14 7 14C3.13401 14 0 10.866 0 7C0 3.13401 3.13401 0 7 0C10.866 0 14 3.13401 14 7ZM7.875 3.5C7.875 3.98325 7.48325 4.375 7 4.375C6.51675 4.375 6.125 3.98325 6.125 3.5C6.125 3.01675 6.51675 2.625 7 2.625C7.48325 2.625 7.875 3.01675 7.875 3.5ZM6.125 6.125C5.64175 6.125 5.25 6.51675 5.25 7C5.25 7.48325 5.64175 7.875 6.125 7.875V10.5C6.125 10.9832 6.51675 11.375 7 11.375H7.875C8.35825 11.375 8.75 10.9832 8.75 10.5C8.75 10.0168 8.35825 9.625 7.875 9.625V7C7.875 6.51675 7.48325 6.125 7 6.125H6.125Z" fill="#052CC0"/>
+                  </svg>
+                  <span class=" text-xs text-rBlue flex-1 ">{{$t('staking.maxUnstakeModeEnabledWarning')}}</span>
+                </div>
               </div>
             </div>
           </div>

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -349,7 +349,7 @@ const WalletStaking = defineComponent({
         const activeValidatorStakeAmount = getActiveStakeAmountForValidator(validatorAddress.value)
         const maxAmount: number = +asBigNumber(activeValidatorStakeAmount)
         const minDifference: number = maxAmount - stakingInputAmount
-        if (minDifference < 0.000001) {
+        if (minDifference <= 0.000001) {
           setMaxUnstakeOn()
         }
       }

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -96,8 +96,7 @@
                   </button>
                 </div>
                 <FormErrorMessage name="amount" class="text-sm text-red-400" errorClass="w-120" />
-                <!-- I want to a boolean variable that changes to true one the user types a number within range, this boolean then displays an alert message similar to the error message -->
-                <div v-if="maxUnstakeMode" class="flex items-center gap-2 max-w-md">
+                <div v-if="showMaxUnstakeNotification" class="flex items-center gap-2 max-w-md">
                   <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path fill-rule="evenodd" clip-rule="evenodd" d="M14 7C14 10.866 10.866 14 7 14C3.13401 14 0 10.866 0 7C0 3.13401 3.13401 0 7 0C10.866 0 14 3.13401 14 7ZM7.875 3.5C7.875 3.98325 7.48325 4.375 7 4.375C6.51675 4.375 6.125 3.98325 6.125 3.5C6.125 3.01675 6.51675 2.625 7 2.625C7.48325 2.625 7.875 3.01675 7.875 3.5ZM6.125 6.125C5.64175 6.125 5.25 6.51675 5.25 7C5.25 7.48325 5.64175 7.875 6.125 7.875V10.5C6.125 10.9832 6.51675 11.375 7 11.375H7.875C8.35825 11.375 8.75 10.9832 8.75 10.5C8.75 10.0168 8.35825 9.625 7.875 9.625V7C7.875 6.51675 7.48325 6.125 7 6.125H6.125Z" fill="#052CC0"/>
                   </svg>
@@ -223,6 +222,7 @@ const WalletStaking = defineComponent({
     const maxUnstakeMode: Ref<boolean> = ref(false)
     const tokenBalances: Ref<AccountBalancesEndpoint.DecodedResponse | null> = ref(null)
     const nativeTokenBalance: Ref<Decoded.TokenAmount | null> = ref(null)
+    const showMaxUnstakeNotification: Ref<boolean> = ref(false)
 
     /* ------
      *  Side Effects
@@ -358,6 +358,8 @@ const WalletStaking = defineComponent({
       const currentValue = +asBigNumber(safeAmount) as number
       const minDifference = maxAmount - currentValue
       if (minDifference <= 0.000001) {
+        setMaxUnstakeNotificationOn()
+        console.log('showMaxUnstakeNotification ', showMaxUnstakeNotification.value)
         setMaxUnstakeOn()
       }
     }
@@ -424,7 +426,18 @@ const WalletStaking = defineComponent({
     }
 
     const setMaxUnstakeOff = () => {
+      if (showMaxUnstakeNotification.value) {
+        setMaxUnstakeNotifcationOff()
+      }
       maxUnstakeMode.value = false
+    }
+
+    const setMaxUnstakeNotificationOn = () => {
+      showMaxUnstakeNotification.value = true
+    }
+
+    const setMaxUnstakeNotifcationOff = () => {
+      showMaxUnstakeNotification.value = false
     }
 
     const handleSubmitStakeForm = () => {
@@ -464,6 +477,7 @@ const WalletStaking = defineComponent({
       tokenBalances,
       values,
       xrdBalance,
+      showMaxUnstakeNotification,
 
       // methods
       handleSubmitStakeForm,

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -100,7 +100,7 @@
                   <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path fill-rule="evenodd" clip-rule="evenodd" d="M14 7C14 10.866 10.866 14 7 14C3.13401 14 0 10.866 0 7C0 3.13401 3.13401 0 7 0C10.866 0 14 3.13401 14 7ZM7.875 3.5C7.875 3.98325 7.48325 4.375 7 4.375C6.51675 4.375 6.125 3.98325 6.125 3.5C6.125 3.01675 6.51675 2.625 7 2.625C7.48325 2.625 7.875 3.01675 7.875 3.5ZM6.125 6.125C5.64175 6.125 5.25 6.51675 5.25 7C5.25 7.48325 5.64175 7.875 6.125 7.875V10.5C6.125 10.9832 6.51675 11.375 7 11.375H7.875C8.35825 11.375 8.75 10.9832 8.75 10.5C8.75 10.0168 8.35825 9.625 7.875 9.625V7C7.875 6.51675 7.48325 6.125 7 6.125H6.125Z" fill="#052CC0"/>
                   </svg>
-                  <span class=" text-xs text-rBlue flex-1 ">{{$t('staking.maxUnstakeModeEnabledWarning')}}</span>
+                  <span class=" text-xs text-rBlue flex-1 ">{{$t('staking.maxUnstakeModeEnabledNotification')}}</span>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Description

This PR adds a notification to the user when `max unstake mode` has automatically been enabled if the amount they input is  within `0.000001` of the max staking amount.  This notification is not displayed if the user pressed the `max` button as that is intentional.

[See Linear Issue RDX-391 Here](https://linear.app/township/issue/RDX-391/notify-when-max-mode-enabled)
[See Figma File Here](https://www.figma.com/file/lNzG5jBt1P9yatkGbWjrlk/Radix-Wireframe-V1?node-id=4270%3A68504)

## Before
<img width="610" alt="Screen Shot 2022-05-19 at 4 04 04 PM" src="https://user-images.githubusercontent.com/83678228/169527707-50e454b3-3328-4286-9013-e30d021768cc.png">

## After
<img width="610" alt="Screen Shot 2022-05-19 at 4 04 25 PM" src="https://user-images.githubusercontent.com/83678228/169527734-38895557-3e06-403d-87c0-79d8f040e4fc.png">


https://user-images.githubusercontent.com/83678228/169533405-91df34aa-1b02-4685-af2a-b702d7714319.mov


## Code Snippets

In `WalletStaking.vue`

- I added a div that is conditionally rendered if `showMaxUnstakeNotification` is `true`.  The div contains the svg from the Figma file as well as a span displaying the notification message.   
```
<div v-if="showMaxUnstakeNotification" class="flex items-center gap-2 max-w-md">
  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path fill-rule="evenodd" clip-rule="evenodd" d="M14 7C14 10.866 10.866 14 7 14C3.13401 14 0 10.866 0 7C0 3.13401 3.13401 0 7 0C10.866 0 14 3.13401 14 7ZM7.875 3.5C7.875 3.98325 7.48325 4.375 7 4.375C6.51675 4.375 6.125 3.98325 6.125 3.5C6.125 3.01675 6.51675 2.625 7 2.625C7.48325 2.625 7.875 3.01675 7.875 3.5ZM6.125 6.125C5.64175 6.125 5.25 6.51675 5.25 7C5.25 7.48325 5.64175 7.875 6.125 7.875V10.5C6.125 10.9832 6.51675 11.375 7 11.375H7.875C8.35825 11.375 8.75 10.9832 8.75 10.5C8.75 10.0168 8.35825 9.625 7.875 9.625V7C7.875 6.51675 7.48325 6.125 7 6.125H6.125Z" fill="#052CC0"/>
  </svg>
  <span class=" text-xs text-rBlue flex-1 ">{{$t('staking.maxUnstakeModeEnabledWarning')}}</span>
</div>
```


`showMaxUnstakeNotification` is a Ref I added to hold the status of the display message visibility.
```
const showMaxUnstakeNotification: Ref<boolean> = ref(false)
```


 I also added 2 setter functions to toggle `showMaxUnstakeNotification`.  When the value of `maxUnstakeMode` changes, the respective functions are invoked.
```
   const setMaxUnstakeNotificationOn = () => {
      showMaxUnstakeNotification.value = true
    }

    const setMaxUnstakeNotifcationOff = () => {
      showMaxUnstakeNotification.value = false
    }
```

Inside `compareToMaxUnstakeAmount` if the difference between the amount the user input is less than or equal to `0.000001` the value of `setMaxUnstakeNotificationOn` is set to true, so the notification is displayed to the user.  This function call was added here so that the notification is only displayed as a result of the user manually inputting the amount, and not show if the pressed the `max` button.
```
      if (minDifference <= 0.000001) {
        setMaxUnstakeNotificationOn()
        setMaxUnstakeOn()
      }
```


In `index.ts`

I added a `maxUnstakeModeEnabledNotification` property to the staking object, so the message wouldnt be hard coded and compatible `i18n`
```
maxUnstakeModeEnabledNotification: 'The value you entered is within 0.000001 of the full unstakable amount, therefore, max mode has been automatically enabled on this entry.'
```


