### PR TITLE
feat: use new SDK to determine transaction message encryption status

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@headlessui/vue": "^1.3.0",
     "@ledgerhq/hw-transport-node-hid": "^6.24.1",
     "@nopr3d/vue-next-rx": "^1.0.6",
-    "@radixdlt/application": "4.0.15",
+    "@radixdlt/application": "4.0.17",
     "@radixdlt/crypto": "^2.1.12",
     "@radixdlt/hardware-ledger": "^2.1.31",
     "@radixdlt/networking": "^2.1.14",

--- a/src/components/TransactionListItem.vue
+++ b/src/components/TransactionListItem.vue
@@ -96,6 +96,7 @@ import ActionListItemStakeTokens from '@/components/ActionListItemStakeTokens.vu
 import ActionListItemUnstakeTokens from '@/components/ActionListItemUnstakeTokens.vue'
 import ActionListItemTransferTokens from '@/components/ActionListItemTransferTokens.vue'
 import ActionListItemOther from '@/components/ActionListItemOther.vue'
+import { decodeMessage, isEncrypted } from '@/helpers/message'
 
 export default defineComponent({
   components: {

--- a/src/components/TransactionListItem.vue
+++ b/src/components/TransactionListItem.vue
@@ -58,9 +58,9 @@
           <span v-else-if="customTxnDisplayType === 'COMPLEX'">{{ $t('history.complexTransaction') }}</span>
         </div>
       </div>
-      <div v-if="messageState" class="text-sm px-3 py-2 bg-rGrayLightest bg-opacity-60 flex items-center">
+      <div v-if="transaction.message" class="text-sm px-3 py-2 bg-rGrayLightest bg-opacity-60 flex items-center">
         <div class="h-5 w-6 flex items-center justify-center -ml-1 mr-1">
-          <svg width="10" height="12" viewBox="0 0 10 12" fill="none" xmlns="http://www.w3.org/2000/svg" class="h-5" v-if="showMessageLock">
+          <svg width="10" height="12" viewBox="0 0 10 12" fill="none" xmlns="http://www.w3.org/2000/svg" class="h-5" v-if="messageIsEncrypted">
             <path d="M2.04883 4.93512V3.79987C2.04883 2.25355 3.30238 1 4.8487 1C6.39502 1 7.64857 2.25355 7.64857 3.79987V4.93512" stroke="#7A99AC" stroke-width="1.5" stroke-miterlimit="10"/>
             <path d="M1 11.4001V4.84473H2.13447H7.58739H8.72185V11.0556H2.60558" stroke="#7A99AC" stroke-width="1.5" stroke-miterlimit="10"/>
           </svg>
@@ -71,10 +71,7 @@
             <line x1="6.2002" y1="9" x2="13.7002" y2="9" stroke="#7A99AC"/>
           </svg>
         </div>
-
-        <span v-if="messageState == 'plaintext'" class="select-text">{{ transaction.message }}</span>
-        <span v-if="messageState == 'decrypted'" class="select-text">{{decryptedMessage}}</span>
-        <button v-if="messageState == 'encrypted'" class="text-rGreen underline hover:text-rGreenDark transition-colors" @click="decrypt">{{ $t('history.clickToDecryptLabel') }}</button>
+        <transaction-message v-if="transaction.message" :message="transaction.message" :decryptedMessage="decryptedMessage" @decrypt="decrypt"/>
       </div>
      </div>
     <div class="bg-rGrayLightest flex items-center justify-center px-3">
@@ -89,21 +86,23 @@
 </template>
 
 <script lang="ts">
-import { computed, ComputedRef, defineComponent, PropType } from 'vue'
+import { computed, ComputedRef, defineComponent, PropType, toRef } from 'vue'
 import { ExecutedTransaction, AccountAddressT, Token, ExecutedAction, ActionType, Message } from '@radixdlt/application'
 import { DateTime } from 'luxon'
 import ActionListItemStakeTokens from '@/components/ActionListItemStakeTokens.vue'
 import ActionListItemUnstakeTokens from '@/components/ActionListItemUnstakeTokens.vue'
 import ActionListItemTransferTokens from '@/components/ActionListItemTransferTokens.vue'
 import ActionListItemOther from '@/components/ActionListItemOther.vue'
-import { decodeMessage, isEncrypted } from '@/helpers/message'
+import TransactionMessage from './TransactionMessage.vue'
+import { isEncrypted } from '@/helpers/message'
 
 export default defineComponent({
   components: {
     ActionListItemStakeTokens,
     ActionListItemTransferTokens,
     ActionListItemUnstakeTokens,
-    ActionListItemOther
+    ActionListItemOther,
+    TransactionMessage
   },
 
   props: {
@@ -171,27 +170,23 @@ export default defineComponent({
       return 'DEFAULT'
     })
 
+    const transaction = toRef(props, 'transaction')
+
+    const sentAt = computed(() => {
+      return DateTime.fromJSDate(transaction.value.sentAt).toLocaleString(DateTime.DATETIME_SHORT)
+    })
+
+    const messageIsEncrypted = computed(() => {
+      if (!transaction.value.message) return false
+      return isEncrypted(transaction.value.message)
+    })
+
     return {
       customTxnDisplayType,
       explorerUrl,
-      relatedActions
-    }
-  },
-
-  computed: {
-    sentAt (): string {
-      return DateTime.fromJSDate(this.transaction.sentAt).toLocaleString(DateTime.DATETIME_SHORT)
-    },
-
-    showMessageLock (): boolean {
-      return this.messageState === 'decrypted' || this.messageState === 'encrypted'
-    },
-
-    messageState (): string | null {
-      if (!this.transaction.message) { return null }
-      if (this.decryptedMessage) { return 'decrypted' }
-      if (Message.isEncrypted(this.transaction.message)) { return 'encrypted' }
-      return 'plaintext'
+      relatedActions,
+      sentAt,
+      messageIsEncrypted
     }
   },
 

--- a/src/components/TransactionMessage.vue
+++ b/src/components/TransactionMessage.vue
@@ -1,0 +1,49 @@
+<template>
+  <div>
+    <button v-if="state === 'encrypted'" class="text-rGreen underline hover:text-rGreenDark transition-colors" @click="$emit('decrypt')">{{ $t('history.clickToDecryptLabel') }}</button>
+    <span v-if="state == 'decrypted'" class="text-rDarkBlue">{{ decryptedMessage }}</span>
+    <span v-if="state == 'plaintext'" class="text-rDarkBlue">{{decodedMessage}}</span>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, toRef, ref, PropType, computed } from 'vue'
+import { decodeMessage, isEncrypted } from '@/helpers/message'
+export default defineComponent({
+  props: {
+    message: {
+      type: String,
+      required: true
+    },
+    decryptedMessage: {
+      type: String as PropType<string>,
+      required: false,
+      default: null
+    }
+  },
+  setup (props) {
+    const message = toRef(props, 'message')
+    const encrypted = ref(false)
+    const decodedMessage = ref('')
+    const decryptedMessage = toRef(props, 'decryptedMessage')
+    if (isEncrypted(message.value)) {
+      encrypted.value = true
+    }
+    const msg = decodeMessage(message.value)
+    if (msg) {
+      decodedMessage.value = msg
+    }
+    const state = computed(() => {
+      if (decryptedMessage.value) return 'decrypted'
+      if (encrypted.value) return 'encrypted'
+      return 'plaintext'
+    })
+    return {
+      encrypted,
+      decodedMessage,
+      state
+    }
+  },
+  emits: ['decrypt']
+})
+</script>

--- a/src/helpers/message.ts
+++ b/src/helpers/message.ts
@@ -1,0 +1,47 @@
+import { Message } from "@radixdlt/crypto";
+
+export const decodeMessage = (message: string): string | false => {
+    const FAILED_MSG = '<Failed to interpret message>'
+  
+    // Check format
+    if (!/^(00|01|30)[0-9a-fA-F]+$/.test(message)) return FAILED_MSG
+  
+    try {
+      if (Message.isHexEncoded(message)) {
+        const decoded = Message.plaintextToString(
+          Buffer.from(message, 'hex'),
+          0
+        )
+  
+        return Message.isPlaintext(decoded)
+          ? Message.plaintextToString(Buffer.from(decoded, 'hex'))
+          : decoded
+      }
+  
+      return Message.isPlaintext(message)
+        ? Message.plaintextToString(Buffer.from(message, 'hex'))
+        : false
+    } catch (error) {
+      return FAILED_MSG
+    }
+  }
+  
+  export const isEncrypted = (message: string): boolean => {
+    if (!/^(00|01|30)[0-9a-fA-F]+$/.test(message)) return false
+  
+    try {
+      if (Message.isHexEncoded(message)) {
+        const decoded = Message.plaintextToString(
+          Buffer.from(message, 'hex'),
+          0
+        )
+  
+        return !Message.isPlaintext(decoded)
+      }
+      return false
+    } catch (error) {
+      return false
+    }
+  }
+
+  

--- a/src/helpers/message.ts
+++ b/src/helpers/message.ts
@@ -1,47 +1,32 @@
-import { Message } from "@radixdlt/crypto";
+import { Message } from '@radixdlt/application'
 
 export const decodeMessage = (message: string): string | false => {
-    const FAILED_MSG = '<Failed to interpret message>'
-  
-    // Check format
-    if (!/^(00|01|30)[0-9a-fA-F]+$/.test(message)) return FAILED_MSG
-  
-    try {
-      if (Message.isHexEncoded(message)) {
-        const decoded = Message.plaintextToString(
-          Buffer.from(message, 'hex'),
-          0
-        )
-  
-        return Message.isPlaintext(decoded)
-          ? Message.plaintextToString(Buffer.from(decoded, 'hex'))
-          : decoded
-      }
-  
-      return Message.isPlaintext(message)
-        ? Message.plaintextToString(Buffer.from(message, 'hex'))
-        : false
-    } catch (error) {
-      return FAILED_MSG
-    }
-  }
-  
-  export const isEncrypted = (message: string): boolean => {
-    if (!/^(00|01|30)[0-9a-fA-F]+$/.test(message)) return false
-  
-    try {
-      if (Message.isHexEncoded(message)) {
-        const decoded = Message.plaintextToString(
-          Buffer.from(message, 'hex'),
-          0
-        )
-  
-        return !Message.isPlaintext(decoded)
-      }
-      return false
-    } catch (error) {
-      return false
-    }
-  }
+  const FAILED_MSG = '<Failed to interpret message>'
 
-  
+  // Check format
+  if (!/^(00|01|30)[0-9a-fA-F]+$/.test(message)) return FAILED_MSG
+
+  try {
+    if (Message.isHexEncoded(message)) {
+      const decoded = Message.plaintextToString(
+        Buffer.from(message, 'hex'),
+        0
+      )
+
+      return Message.isPlaintext(decoded)
+        ? Message.plaintextToString(Buffer.from(decoded, 'hex'))
+        : decoded
+    }
+
+    return Message.isPlaintext(message)
+      ? Message.plaintextToString(Buffer.from(message, 'hex'))
+      : false
+  } catch (error) {
+    return FAILED_MSG
+  }
+}
+
+export const isEncrypted = (message: string): boolean => {
+  if (!/^(00|01|30)[0-9a-fA-F]+$/.test(message)) return false
+  return !Message.isPlaintext(message)
+}

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -217,7 +217,8 @@ const messages = {
       notTopOneHundred: 'Not in top 100 validators',
       unstakeMaxDisclaimer: "You're unstaking all tokens from",
       maxUnstakeButton: 'max',
-      maxUnstakeCapitalized: 'MAX'
+      maxUnstakeCapitalized: 'MAX',
+      maxUnstakeModeEnabledWarning: 'The value you entered is within 0.000001 of the full unstakable amount, therefore, max mode has been automatically enabled on this entry.'
     },
     confirmation: {
       transferFromLabel: 'Your address',

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -218,7 +218,7 @@ const messages = {
       unstakeMaxDisclaimer: "You're unstaking all tokens from",
       maxUnstakeButton: 'max',
       maxUnstakeCapitalized: 'MAX',
-      maxUnstakeModeEnabledWarning: 'The value you entered is within 0.000001 of the full unstakable amount, therefore, max mode has been automatically enabled on this entry.'
+      maxUnstakeModeEnabledNotification: 'The value you entered is within 0.000001 of the full unstakable amount, therefore, max mode has been automatically enabled on this entry.'
     },
     confirmation: {
       transferFromLabel: 'Your address',

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -359,7 +359,6 @@ const WalletStaking = defineComponent({
       const minDifference = maxAmount - currentValue
       if (minDifference <= 0.000001) {
         setMaxUnstakeNotificationOn()
-        console.log('showMaxUnstakeNotification ', showMaxUnstakeNotification.value)
         setMaxUnstakeOn()
       }
     }

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -395,10 +395,6 @@ const WalletStaking = defineComponent({
     const handleMaxSubmitUnstake = () => {
       const safeAddress = safelyUnwrapValidator(values.validator)
       if (!safeAddress) return
-      // What is safeOneHundredPercent?
-      // values.validator is the validator address
-      // values.amount is the amount the user types
-      // What does safelyUnrapValidator do? I did a console.log but I wasnt sure what i was looking at
       const safeOneHundredPercent = safelyUnwrapAmount(Number('0.0000000000000001'))
       if (!safeOneHundredPercent) return
 

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -96,6 +96,13 @@
                   </button>
                 </div>
                 <FormErrorMessage name="amount" class="text-sm text-red-400" errorClass="w-120" />
+                <!-- I want to a boolean variable that changes to true one the user types a number within range, this boolean then displays an alert message similar to the error message -->
+                <div v-if="maxUnstakeMode" class="flex items-center gap-2 max-w-md">
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M14 7C14 10.866 10.866 14 7 14C3.13401 14 0 10.866 0 7C0 3.13401 3.13401 0 7 0C10.866 0 14 3.13401 14 7ZM7.875 3.5C7.875 3.98325 7.48325 4.375 7 4.375C6.51675 4.375 6.125 3.98325 6.125 3.5C6.125 3.01675 6.51675 2.625 7 2.625C7.48325 2.625 7.875 3.01675 7.875 3.5ZM6.125 6.125C5.64175 6.125 5.25 6.51675 5.25 7C5.25 7.48325 5.64175 7.875 6.125 7.875V10.5C6.125 10.9832 6.51675 11.375 7 11.375H7.875C8.35825 11.375 8.75 10.9832 8.75 10.5C8.75 10.0168 8.35825 9.625 7.875 9.625V7C7.875 6.51675 7.48325 6.125 7 6.125H6.125Z" fill="#052CC0"/>
+                  </svg>
+                  <span class=" text-xs text-rBlue flex-1 ">{{$t('staking.maxUnstakeModeEnabledWarning')}}</span>
+                </div>
               </div>
             </div>
           </div>

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -349,7 +349,7 @@ const WalletStaking = defineComponent({
         const activeValidatorStakeAmount = getActiveStakeAmountForValidator(validatorAddress.value)
         const maxAmount: number = +asBigNumber(activeValidatorStakeAmount)
         const minDifference: number = maxAmount - stakingInputAmount
-        if (minDifference < 0.000001) {
+        if (minDifference <= 0.000001) {
           setMaxUnstakeOn()
         }
       }

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -96,8 +96,7 @@
                   </button>
                 </div>
                 <FormErrorMessage name="amount" class="text-sm text-red-400" errorClass="w-120" />
-                <!-- I want to a boolean variable that changes to true one the user types a number within range, this boolean then displays an alert message similar to the error message -->
-                <div v-if="maxUnstakeMode" class="flex items-center gap-2 max-w-md">
+                <div v-if="showMaxUnstakeNotification" class="flex items-center gap-2 max-w-md">
                   <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path fill-rule="evenodd" clip-rule="evenodd" d="M14 7C14 10.866 10.866 14 7 14C3.13401 14 0 10.866 0 7C0 3.13401 3.13401 0 7 0C10.866 0 14 3.13401 14 7ZM7.875 3.5C7.875 3.98325 7.48325 4.375 7 4.375C6.51675 4.375 6.125 3.98325 6.125 3.5C6.125 3.01675 6.51675 2.625 7 2.625C7.48325 2.625 7.875 3.01675 7.875 3.5ZM6.125 6.125C5.64175 6.125 5.25 6.51675 5.25 7C5.25 7.48325 5.64175 7.875 6.125 7.875V10.5C6.125 10.9832 6.51675 11.375 7 11.375H7.875C8.35825 11.375 8.75 10.9832 8.75 10.5C8.75 10.0168 8.35825 9.625 7.875 9.625V7C7.875 6.51675 7.48325 6.125 7 6.125H6.125Z" fill="#052CC0"/>
                   </svg>
@@ -223,6 +222,7 @@ const WalletStaking = defineComponent({
     const maxUnstakeMode: Ref<boolean> = ref(false)
     const tokenBalances: Ref<AccountBalancesEndpoint.DecodedResponse | null> = ref(null)
     const nativeTokenBalance: Ref<Decoded.TokenAmount | null> = ref(null)
+    const showMaxUnstakeNotification: Ref<boolean> = ref(false)
 
     /* ------
      *  Side Effects
@@ -358,6 +358,8 @@ const WalletStaking = defineComponent({
       const currentValue = +asBigNumber(safeAmount) as number
       const minDifference = maxAmount - currentValue
       if (minDifference <= 0.000001) {
+        setMaxUnstakeNotificationOn()
+        console.log('showMaxUnstakeNotification ', showMaxUnstakeNotification.value)
         setMaxUnstakeOn()
       }
     }
@@ -424,7 +426,18 @@ const WalletStaking = defineComponent({
     }
 
     const setMaxUnstakeOff = () => {
+      if (showMaxUnstakeNotification.value) {
+        setMaxUnstakeNotifcationOff()
+      }
       maxUnstakeMode.value = false
+    }
+
+    const setMaxUnstakeNotificationOn = () => {
+      showMaxUnstakeNotification.value = true
+    }
+
+    const setMaxUnstakeNotifcationOff = () => {
+      showMaxUnstakeNotification.value = false
     }
 
     const handleSubmitStakeForm = () => {
@@ -464,6 +477,7 @@ const WalletStaking = defineComponent({
       tokenBalances,
       values,
       xrdBalance,
+      showMaxUnstakeNotification,
 
       // methods
       handleSubmitStakeForm,

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -100,7 +100,7 @@
                   <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path fill-rule="evenodd" clip-rule="evenodd" d="M14 7C14 10.866 10.866 14 7 14C3.13401 14 0 10.866 0 7C0 3.13401 3.13401 0 7 0C10.866 0 14 3.13401 14 7ZM7.875 3.5C7.875 3.98325 7.48325 4.375 7 4.375C6.51675 4.375 6.125 3.98325 6.125 3.5C6.125 3.01675 6.51675 2.625 7 2.625C7.48325 2.625 7.875 3.01675 7.875 3.5ZM6.125 6.125C5.64175 6.125 5.25 6.51675 5.25 7C5.25 7.48325 5.64175 7.875 6.125 7.875V10.5C6.125 10.9832 6.51675 11.375 7 11.375H7.875C8.35825 11.375 8.75 10.9832 8.75 10.5C8.75 10.0168 8.35825 9.625 7.875 9.625V7C7.875 6.51675 7.48325 6.125 7 6.125H6.125Z" fill="#052CC0"/>
                   </svg>
-                  <span class=" text-xs text-rBlue flex-1 ">{{$t('staking.maxUnstakeModeEnabledWarning')}}</span>
+                  <span class=" text-xs text-rBlue flex-1 ">{{$t('staking.maxUnstakeModeEnabledNotification')}}</span>
                 </div>
               </div>
             </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,10 +1531,10 @@
     prelude-ts "^1.0.2"
     rxjs "7.0.0"
 
-"@radixdlt/application@4.0.15":
-  version "4.0.15"
-  resolved "https://registry.yarnpkg.com/@radixdlt/application/-/application-4.0.15.tgz#91e41c282495d516f7d52c3e89184b9194875aa9"
-  integrity sha512-NL3pCE2A4fqJ4S86D2iuBaThwJF+8wr4KEdyToFVxIls4R7i3qE92SwWk2Wh4/h3qcVoMMHmjrgsdEAXt9+lDQ==
+"@radixdlt/application@4.0.17":
+  version "4.0.17"
+  resolved "https://registry.yarnpkg.com/@radixdlt/application/-/application-4.0.17.tgz#c9f1c5b0dba3c0d8ecbbc37124ba9f7ad3ee6354"
+  integrity sha512-Akpi23+4d7cIu4I/qUUzgrgIOFgz1fPIZ/iCJ8Z483EIOvOIDWJS9FdK1AnpPZ022boWsGvMY6U5h8FdDQO7UA==
   dependencies:
     "@open-rpc/mock-server" "1.7.2"
     "@open-rpc/schema-utils-js" "1.14.3"


### PR DESCRIPTION
This pull request switches from the SDK provided in 4.0.15 to 4.0.17.  The new SDK provides the raw hex-encoded message from the API.  The functionality was copied from the explorer into the wallet. Now, the `TransactionListItem` component can use the raw message and determine if it is plain text or encrypted.  If it is plain text the plain text is displayed initially.  If the message is encrypted a button is displayed that the user can click to reveal the decrypted message.

[See Linear Issue #RDX-388 Here](https://linear.app/township/issue/RDX-388/encrypted-message-tomfoolery)

I copied the functionality from the explorer in [this PR](https://github.com/radixdlt/explorer/pull/97)

## Demo Video

https://user-images.githubusercontent.com/83678228/170314521-d22fd06b-8dce-439f-aa38-ae30ac658aff.mp4

## Screenshots
<img width="1243" alt="Screen Shot 2022-05-25 at 9 33 05 AM" src="https://user-images.githubusercontent.com/83678228/170314036-1b68595b-9352-4313-8ab1-11287671bfc0.png">

<img width="1243" alt="Screen Shot 2022-05-25 at 9 33 20 AM" src="https://user-images.githubusercontent.com/83678228/170314121-7a524541-1dd8-48c5-98a9-ecf40f931012.png">

