### PR TITLE
chore: notarize needs the team id

### DIFF
--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -12,6 +12,7 @@ exports.default = async function notarizing (context) {
     appBundleId: 'com.radixdlt.olympia-wallet',
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLE_ID,
-    appleIdPassword: process.env.APPLE_ID_PASSWORD
+    appleIdPassword: process.env.APPLE_ID_PASSWORD,
+    teamId: process.env.APPLE_TEAM_ID
   })
 }


### PR DESCRIPTION
<img width="871" alt="Screen Shot 2022-05-25 at 5 56 38 PM" src="https://user-images.githubusercontent.com/2738409/170374194-db10b97a-e147-447e-ae8b-32ec02c04977.png">
<img width="638" alt="Screen Shot 2022-05-25 at 5 57 16 PM" src="https://user-images.githubusercontent.com/2738409/170374287-7876ffef-f6e1-4b5a-8216-2e9a05e5cac1.png">

Validated locally that this change correctly allows the app to notarize again.  
