### PR TITLE
fix: don't set XRD by default multiple times

### DIFF
--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -172,6 +172,7 @@ const WalletTransaction = defineComponent({
     const tokenOptions: Ref<TokenOption[]> = ref([])
     const hiddenTokens: Ref<string[]> = ref([])
     const tokenBalances: Ref<AccountBalancesEndpoint.DecodedResponse | null> = ref(null)
+    const nativeTokenLoaded: Ref<boolean> = ref(false)
 
     /* ------
      *  Lifecycle Events
@@ -223,8 +224,9 @@ const WalletTransaction = defineComponent({
 
     // reset currency when required state has loaded. Especially necessary when switching account
     watch([nativeToken, tokenBalances], ([nt, tb]) => {
-      if (tb && nt) {
+      if (tb && nt && !nativeTokenLoaded.value) {
         setXRDByDefault(nt)
+        nativeTokenLoaded.value = true
       }
     })
 


### PR DESCRIPTION
This PR addresses an issue in the wallet transaction view. We were originally resetting the selected currency input to XRD every time `nativeToken` or `tokenBalances` were loaded. This ensures the value is not reset after the initial load.