### PR TITLE
fix: Network Change Reset

### DIFF
--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -595,6 +595,7 @@ export default function useWallet (router: Router): useWalletInterface {
     walletLoaded,
     async updateConnection (url: string): Promise<void> {
       await persistNodeUrl(url)
+      await router.push('/')
       refreshApp()
     },
 


### PR DESCRIPTION
When a user chooses to connect to a different node in the settings, the
app should restart and they should be required to log back in.

Currently the reload was occurring but they were not being redirected to
the home page.  This was a regression from the refactoring of the url
params.

Loom video:
https://www.loom.com/share/4971a0c647b447f29f5ad7c5460a1ed1