### PR TITLE
fix: stake list items no longer flickering on refresh 

### DIFF
--- a/src/composables/useStaking.ts
+++ b/src/composables/useStaking.ts
@@ -21,8 +21,9 @@ const maybeFetchValidators = async (radix: ReturnType<typeof Radix.create>, netw
 }
 
 const fetchStakesForAddress = async (radix: ReturnType<typeof Radix.create>, address: AccountAddressT) => {
-  loadingStakes.value = true
-  loadingUnstakes.value = true
+  console.log('base')
+  // loadingStakes.value = true
+  // loadingUnstakes.value = true
   activeStakes.value = await firstValueFrom(radix.ledger.stakesForAddress(address))
   activeUnstakes.value = await firstValueFrom(radix.ledger.unstakesForAddress(address))
   loadingStakes.value = false

--- a/src/composables/useStaking.ts
+++ b/src/composables/useStaking.ts
@@ -21,9 +21,6 @@ const maybeFetchValidators = async (radix: ReturnType<typeof Radix.create>, netw
 }
 
 const fetchStakesForAddress = async (radix: ReturnType<typeof Radix.create>, address: AccountAddressT) => {
-  console.log('base')
-  // loadingStakes.value = true
-  // loadingUnstakes.value = true
   activeStakes.value = await firstValueFrom(radix.ledger.stakesForAddress(address))
   activeUnstakes.value = await firstValueFrom(radix.ledger.unstakesForAddress(address))
   loadingStakes.value = false


### PR DESCRIPTION
The issue - In order to keep staking/unstaking list items content up to date the data was refreshing every ~15 seconds, causing the `loadingStakes.value`  & `loadingUnstakes.value` Refs to be set to true, in turn having the list items unmount and a loading wheel take its place. this gave off the illusion of a flickering side panel. 

The solution - Continue to refresh the staking data every 15 seconds, but in the function `fetchStakesForAddress` no longer set the `loadingStakes.value`  & `loadingUnstakes.value` to false for each refresh, since those two Refs default to true, the loading wheel will render on initial mount but not on each individual refresh. 

### 🎥🎥🎥🎥
[Loom video here. ](https://www.loom.com/share/c02d25d6f0c7478dac51bf35f7222276)