### PR TITLE
fix: multiple error pop ups when the ledger

### DIFF
--- a/src/composables/useHistory.ts
+++ b/src/composables/useHistory.ts
@@ -5,7 +5,6 @@ import { firstValueFrom, interval, Subscription } from 'rxjs'
 const PAGE_SIZE = 30
 
 const decryptedMessages: Ref<{id: string, message: string}[]> = ref([])
-const displayLedgerErrorModal: Ref<boolean> = ref(false)
 const cursorStack: Ref<string[]> = ref([])
 const canGoBack: ComputedRef<boolean> = computed(() => cursorStack.value.length > 0)
 const canGoNext: Ref<boolean> = ref(false)
@@ -59,14 +58,7 @@ export default function useHistory (radix: ReturnType<typeof Radix.create>, addr
       .then((val) => {
         decryptedMessages.value.push({ id: tx.txID.toString(), message: val })
       })
-      .catch(() => {
-        displayHardwareError()
-      })
       .finally(() => { isDecrypting.value = false })
-  }
-
-  const displayHardwareError = () => {
-    displayLedgerErrorModal.value = true
   }
 
   const previousPage = () => {
@@ -91,7 +83,6 @@ export default function useHistory (radix: ReturnType<typeof Radix.create>, addr
     canGoBack,
     canGoNext,
     decryptedMessages,
-    displayLedgerErrorModal,
     loadingHistory,
     transactions,
     decryptMessage,

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -346,6 +346,7 @@ const createNewHardwareAccount = async () => {
 const connectHardwareWallet = async (hwaddr: HardwareAddress) => {
   try {
     // const wallet = await firstValueFrom(radix.__wallet)
+    hardwareError.value = null
     const hwAccount: AccountT = await firstValueFrom(radix.deriveHWAccount({
       keyDerivation: HDPathRadix.create({
         address: { index: hwaddr.index, isHardened: true }
@@ -356,7 +357,6 @@ const connectHardwareWallet = async (hwaddr: HardwareAddress) => {
       alsoSwitchTo: true,
       verificationPrompt: false
     }))
-    hardwareError.value = null
     hardwareInteractionState.value = 'DERIVING'
     if (!hardwareAddress.value && activeNetwork.value) {
       // saveAccountName(hwAccount.address.toString(), 'Hardware Account')

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -279,8 +279,6 @@ const closeLedgerErrorModal = () => { hardwareError.value = null }
 
 const createNewHardwareAccount = async () => {
   if (!activeNetwork.value) return
-  hardwareError.value = null
-  hardwareInteractionState.value = 'DERIVING'
   try {
     const wallet = await firstValueFrom(radix.__wallet)
     const connectedDeviceAccount = await firstValueFrom(wallet.deriveHWAccount({
@@ -293,6 +291,8 @@ const createNewHardwareAccount = async () => {
       alsoSwitchTo: false,
       verificationPrompt: false
     }))
+    hardwareError.value = null
+    hardwareInteractionState.value = 'DERIVING'
     const hardwareDevice = hardwareDevices.value.find((hw) => hw.addresses.find((addr) => addr.address.equals(connectedDeviceAccount.address)))
     let newHardwareDevices
     if (hardwareDevice) {

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -338,7 +338,7 @@ const createNewHardwareAccount = async () => {
     }
     hardwareInteractionState.value = ''
   } catch (err) {
-    console.log('This is where the incorrect modal is being triggered i believe')
+    hardwareInteractionState.value = ''
     hardwareError.value = err as Error
   }
 }

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -335,6 +335,7 @@ const createNewHardwareAccount = async () => {
     }
     hardwareInteractionState.value = ''
   } catch (err) {
+    console.log('This is where the incorrect modal is being triggered i believe')
     hardwareError.value = err as Error
   }
 }

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -167,6 +167,7 @@ interface useWalletInterface {
   waitUntilAllLoaded: () => Promise<any>;
   walletLoaded: () => void;
   createNewHardwareAccount: () => void;
+  closeLedgerErrorModal: () => void;
 }
 
 const walletLoaded = async () => {
@@ -274,6 +275,8 @@ const accountNameFor = (accountAddress: AccountAddressT): string => {
 
 const setShowNewDevicePopup = (val: boolean) => { showNewDevicePopup.value = val }
 
+const closeLedgerErrorModal = () => { hardwareError.value = null }
+
 const createNewHardwareAccount = async () => {
   if (!activeNetwork.value) return
   hardwareError.value = null
@@ -341,9 +344,6 @@ const createNewHardwareAccount = async () => {
 }
 
 const connectHardwareWallet = async (hwaddr: HardwareAddress) => {
-  hardwareError.value = null
-  hardwareInteractionState.value = 'DERIVING'
-
   try {
     // const wallet = await firstValueFrom(radix.__wallet)
     const hwAccount: AccountT = await firstValueFrom(radix.deriveHWAccount({
@@ -356,6 +356,8 @@ const connectHardwareWallet = async (hwaddr: HardwareAddress) => {
       alsoSwitchTo: true,
       verificationPrompt: false
     }))
+    hardwareError.value = null
+    hardwareInteractionState.value = 'DERIVING'
     if (!hardwareAddress.value && activeNetwork.value) {
       // saveAccountName(hwAccount.address.toString(), 'Hardware Account')
       hardwareAddress.value = hwAccount.address.toString()
@@ -365,7 +367,7 @@ const connectHardwareWallet = async (hwaddr: HardwareAddress) => {
     hardwareAccount.value = hwAccount
     hardwareInteractionState.value = ''
   } catch (err) {
-    hardwareInteractionState.value = 'error'
+    hardwareInteractionState.value = ''
     hardwareError.value = err as Error
   }
 }
@@ -620,6 +622,7 @@ export default function useWallet (router: Router): useWalletInterface {
     }),
 
     activateAccount,
-    createNewHardwareAccount
+    createNewHardwareAccount,
+    closeLedgerErrorModal
   }
 }

--- a/src/views/Wallet/WalletDisconnectDeviceModal.vue
+++ b/src/views/Wallet/WalletDisconnectDeviceModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fixed w-screen h-screen z-20 flex items-center justify-center bg-translucent-black">
+  <div class="fixed w-screen h-screen z-40 flex items-center justify-center bg-translucent-black">
     <div class="h-modalSmall bg-white rounded-md w-full max-w-lg absolute top-1/2 left-1/2 transform -translate-x-1/3 -translate-y-1/2">
       <div class="border bg-rGrayLight">
         <div class="flex items-center justify-center pt-8">
@@ -39,8 +39,6 @@ const WalletDisconnectDeviceModal = defineComponent({
     const {
       setDisconnectDeviceModal,
       forgetDevice,
-      connectHardwareWallet,
-      hardwareError,
       hideLedgerInteraction
     } = useWallet(router)
 
@@ -52,8 +50,6 @@ const WalletDisconnectDeviceModal = defineComponent({
       handleClose: () => {
         setDisconnectDeviceModal(-1)
       },
-      connectHardwareWallet,
-      hardwareError,
       hideLedgerInteraction
     }
   }

--- a/src/views/Wallet/WalletHistory.vue
+++ b/src/views/Wallet/WalletHistory.vue
@@ -185,7 +185,7 @@ const WalletHistory = defineComponent({
       fetchTransactions()
     }, { immediate: true })
 
-    watch((hardwareInteractionState), () => {
+    watch((displayLedgerErrorModal), () => {
       console.log(hardwareError)
       hardwareInteractionState.value = ''
     })

--- a/src/views/Wallet/WalletHistory.vue
+++ b/src/views/Wallet/WalletHistory.vue
@@ -119,6 +119,8 @@ const WalletHistory = defineComponent({
       explorerUrlBase,
       hardwareAccount,
       nativeToken,
+      hardwareError,
+      hardwareInteractionState,
       radix,
       verifyHardwareWalletAddress
     } = useWallet(router)
@@ -183,6 +185,11 @@ const WalletHistory = defineComponent({
       fetchTransactions()
     }, { immediate: true })
 
+    watch((displayLedgerErrorModal), () => {
+      console.log(hardwareError)
+      hardwareInteractionState.value = ''
+    })
+
     // Fetch initial history on route load
     onMounted(() => {
       resetHistory()
@@ -205,6 +212,7 @@ const WalletHistory = defineComponent({
       loadingHistory,
       nativeToken,
       nextPage,
+      hardwareError,
       previousPage,
       resetHistory,
       shouldShowDecryptModal,

--- a/src/views/Wallet/WalletHistory.vue
+++ b/src/views/Wallet/WalletHistory.vue
@@ -185,7 +185,7 @@ const WalletHistory = defineComponent({
       fetchTransactions()
     }, { immediate: true })
 
-    watch((displayLedgerErrorModal), () => {
+    watch((hardwareInteractionState), () => {
       console.log(hardwareError)
       hardwareInteractionState.value = ''
     })

--- a/src/views/Wallet/WalletHistory.vue
+++ b/src/views/Wallet/WalletHistory.vue
@@ -16,10 +16,6 @@
         </div>
       </div>
     </div>
-    <wallet-ledger-disconnected-modal
-      :shouldShow="displayLedgerErrorModal"
-      :handleClose="closeLedgerErrorModal"
-    />
     <div class="text-rBlack py-6 min-h-full text-sm">
       <div v-if="loadingHistory || !nativeToken" class="p-4 flex items-center justify-center">
         <loading-icon class="text-rGrayDark" />
@@ -96,7 +92,6 @@ import { computed, ComputedRef, defineComponent, onMounted, watch } from 'vue'
 import TransactionListItem from '@/components/TransactionListItem.vue'
 import LoadingIcon from '@/components/LoadingIcon.vue'
 import ClickToCopy from '@/components/ClickToCopy.vue'
-import WalletLedgerDisconnectedModal from '@/views/Wallet/WalletLedgerDisconnectedModal.vue'
 import { useWallet, useHistory } from '@/composables'
 import { useRouter, onBeforeRouteLeave } from 'vue-router'
 import WalletLedgerVerifyDecryptModal from './WalletLedgerVerifyDecryptModal.vue'
@@ -107,7 +102,6 @@ const WalletHistory = defineComponent({
     LoadingIcon,
     ClickToCopy,
     TransactionListItem,
-    WalletLedgerDisconnectedModal,
     WalletLedgerVerifyDecryptModal
   },
 
@@ -120,7 +114,6 @@ const WalletHistory = defineComponent({
       hardwareAccount,
       nativeToken,
       hardwareError,
-      hardwareInteractionState,
       radix,
       verifyHardwareWalletAddress
     } = useWallet(router)
@@ -133,7 +126,6 @@ const WalletHistory = defineComponent({
       canGoBack,
       canGoNext,
       decryptedMessages,
-      displayLedgerErrorModal,
       fetchTransactions,
       loadingHistory,
       transactions,
@@ -160,11 +152,6 @@ const WalletHistory = defineComponent({
       isDecrypting.value && !!activeAddress.value && !!hardwareAccount.value && activeAddress.value === hardwareAccount.value.address
     )
 
-    const closeLedgerErrorModal = () => {
-      // switchAccount(localAccounts.value[0])
-      displayLedgerErrorModal.value = false
-    }
-
     const activateThenDecrypt = async (data: ExecutedTransaction) => {
       activateAccount((client) => {
         decryptMessage(client, data)
@@ -185,11 +172,6 @@ const WalletHistory = defineComponent({
       fetchTransactions()
     }, { immediate: true })
 
-    watch((displayLedgerErrorModal), () => {
-      console.log(hardwareError)
-      hardwareInteractionState.value = ''
-    })
-
     // Fetch initial history on route load
     onMounted(() => {
       resetHistory()
@@ -205,10 +187,8 @@ const WalletHistory = defineComponent({
       canGoBack,
       canGoNext,
       decryptMessage,
-      displayLedgerErrorModal,
       explorerUrlBase,
       decryptedMessages,
-      closeLedgerErrorModal,
       loadingHistory,
       nativeToken,
       nextPage,

--- a/src/views/Wallet/WalletLedgerDisconnectedModal.vue
+++ b/src/views/Wallet/WalletLedgerDisconnectedModal.vue
@@ -1,6 +1,6 @@
 <template>
   <AppModal
-    :visible="shouldShow"
+    :visible="true"
     :title="$t('wallet.ledgerModal.title')"
   >
     <template v-slot:icon>
@@ -29,10 +29,6 @@ const WalletLedgerDisconnectedModal = defineComponent({
     AppButtonCancel
   },
   props: {
-    shouldShow: {
-      type: Boolean,
-      required: true
-    },
     handleClose: {
       type: Function,
       required: true

--- a/src/views/Wallet/WalletLedgerInteractionModal.vue
+++ b/src/views/Wallet/WalletLedgerInteractionModal.vue
@@ -1,19 +1,7 @@
 <template>
   <div class="fixed w-screen h-screen z-20 flex items-center justify-center bg-translucent-black">
     <div class="h-modalSmall bg-white rounded-md py-7 px-7 w-full max-w-lg absolute top-1/2 left-1/2 transform -translate-x-1/3 -translate-y-1/2">
-      <div v-if="hardwareError">
-        <div class="text-center">
-          <div class="text-center mt-8 text-rRed text-lg">
-            Unable to Connect to Ledger
-          </div>
-          <div class="text-center mt-4 text-rBlack text-sm px-8">
-            We were unable to derive your wallet. Please ensure your Ledger is connected and the Radix application is open.
-          </div>
-
-          <button @click="close()" class="block m-auto pt-4"> Close this </button>
-        </div>
-      </div>
-      <div v-else>
+      <div>
         <div class="mt-16">
           <svg width="40" height="40" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" class="container animate-spin">
             <path fill-rule="evenodd" clip-rule="evenodd" d="M77.8789 52.8857C72.5168 68.6526 57.5862 80.0002 40.0001 80.0002C29.2115 80.0002 19.417 75.7265 12.2241 68.7838L14.9924 65.9158C21.4721 72.1701 30.2851 76.0141 40.0001 76.0141C55.8278 76.0141 69.2758 65.8025 74.1051 51.6023L77.8789 52.8857Z" fill="#052CC0"/>
@@ -44,7 +32,6 @@ const WalletLedgerInteractionModal = defineComponent({
     const {
       activeAddress,
       hardwareAccount,
-      hardwareError,
       hideLedgerInteraction,
       radix
     } = useWallet(router)
@@ -52,7 +39,6 @@ const WalletLedgerInteractionModal = defineComponent({
     const { cancelTransaction } = useTransactions(radix, router, activeAddress.value, hardwareAccount.value)
 
     return {
-      hardwareError,
       hideLedgerInteraction,
       close () {
         hideLedgerInteraction()

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -46,7 +46,7 @@ import WalletDisconnectDeviceModal from '@/views/Wallet/WalletDisconnectDeviceMo
 import WalletUpdateModal from '@/views/Wallet/WalletUpdateModal.vue'
 import WalletNewDevicePopup from '@/views/Wallet/WalletNewDevicePopup.vue'
 import WalletLedgerDisconnectedModal from '@/views/Wallet/WalletLedgerDisconnectedModal.vue'
-import { useRouter, onBeforeRouteUpdate, onBeforeRouteLeave, useRoute } from 'vue-router'
+import { useRouter, onBeforeRouteUpdate, useRoute } from 'vue-router'
 import { useTransactions, useWallet } from '@/composables'
 
 const WalletIndex = defineComponent({
@@ -132,7 +132,7 @@ const WalletIndex = defineComponent({
       isTestNet,
       walletLoaded,
       updateInProcess,
-      closeLedgerErrorModal,
+      closeLedgerErrorModal
     }
   }
 })

--- a/src/views/Wallet/index.vue
+++ b/src/views/Wallet/index.vue
@@ -20,7 +20,11 @@
 
     <wallet-confirm-transaction-modal v-if="shouldShowConfirmation" />
     <wallet-ledger-verify-address-modal v-if="showLedgerVerify" />
-    <wallet-ledger-interaction-modal v-if="hardwareInteractionState && hardwareInteractionState.length > 0" />
+    <wallet-ledger-interaction-modal v-if="hardwareInteractionState && hardwareInteractionState.length > 0 && hardwareInteractionState != 'error'" />
+    <wallet-ledger-disconnected-modal
+      :handleClose="closeLedgerErrorModal"
+      :hardwareError="hardwareError"
+      v-if="hardwareError"/>
     <wallet-ledger-delete-modal v-if="showDeleteHWWalletPrompt" />
     <wallet-hide-account-modal v-if="showHideAccountModal"/>
     <wallet-disconnect-device-modal v-if="showDisconnectDeviceModal"/>
@@ -41,6 +45,7 @@ import WalletHideAccountModal from '@/views/Wallet/WalletHideAccountModal.vue'
 import WalletDisconnectDeviceModal from '@/views/Wallet/WalletDisconnectDeviceModal.vue'
 import WalletUpdateModal from '@/views/Wallet/WalletUpdateModal.vue'
 import WalletNewDevicePopup from '@/views/Wallet/WalletNewDevicePopup.vue'
+import WalletLedgerDisconnectedModal from '@/views/Wallet/WalletLedgerDisconnectedModal.vue'
 import { useRouter, onBeforeRouteUpdate, onBeforeRouteLeave, useRoute } from 'vue-router'
 import { useTransactions, useWallet } from '@/composables'
 
@@ -55,7 +60,8 @@ const WalletIndex = defineComponent({
     WalletDisconnectDeviceModal,
     WalletNewDevicePopup,
     WalletLoading,
-    WalletUpdateModal
+    WalletUpdateModal,
+    WalletLedgerDisconnectedModal
   },
 
   setup () {
@@ -77,7 +83,9 @@ const WalletIndex = defineComponent({
       setActiveAddress,
       walletLoaded,
       waitUntilAllLoaded,
-      updateInProcess
+      updateInProcess,
+      hardwareError,
+      closeLedgerErrorModal
     } = useWallet(router)
 
     watch(
@@ -113,6 +121,7 @@ const WalletIndex = defineComponent({
     return {
       hardwareInteractionState,
       hasWallet,
+      hardwareError,
       activeNetwork,
       shouldShowConfirmation,
       showDeleteHWWalletPrompt,
@@ -122,7 +131,8 @@ const WalletIndex = defineComponent({
       showLedgerVerify,
       isTestNet,
       walletLoaded,
-      updateInProcess
+      updateInProcess,
+      closeLedgerErrorModal,
     }
   }
 })


### PR DESCRIPTION
Removed any rendering of the original boilerplate ledger error modal and am now rendering a prettier modal when a ledger-specific action results in an error. 

![error](https://user-images.githubusercontent.com/72633467/171307067-bcbadcd1-a448-42fc-846f-0d8cefcd4247.gif)

 