### PR TITLE
Chore: Minor UI Tweaks

### DIFF
--- a/src/components/AccountListItem.vue
+++ b/src/components/AccountListItem.vue
@@ -2,7 +2,7 @@
   <div class="px-5 bg-sidebar border-transparent border-l-4 group" :class="{'border-rGreen': isActiveAccount}">
     <div class="flex flex-row mb-4 justify-between" v-if="addressVal">
       <div class="flex flex-row">
-        <div class="leading-snug text-rGrayDark hover:text-rGreen transition-colors cursor-pointer w-36 truncate">{{ nickName }}</div>
+        <div class="leading-snug text-rGrayDark hover:text-rGreen transition-colors cursor-pointer w-40 truncate">{{ nickName }}</div>
       </div>
       <div v-if="shouldShowEdit" class="z-20 hidden group-hover:block text-rGrayDark hover:text-rGreen transition-colors cursor-pointer flex items-center justify-center  pt-2 z-20" @click.stop="editName">
         <svg width="12" height="12" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/components/AccountListPreview.vue
+++ b/src/components/AccountListPreview.vue
@@ -2,7 +2,7 @@
   <div class=" bg-sidebar border-transparent border-l-4 text" :class="{'': isActiveAccount}">
     <div class="flex flex-row mb-4 justify-between" v-if="addressVal">
       <div class="flex flex-row">
-        <div class="leading-snug text-rGreen text-lg hover:text-rGreen transition-colors cursor-pointer w-36 flex">
+        <div class="leading-snug text-rGreen text-lg hover:text-rGreen transition-colors cursor-pointer w-40 flex">
           <div class="truncate">{{ nickName }}</div>
           <div class="my-auto pl-2">
             <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/components/HardwareAccountListItem.vue
+++ b/src/components/HardwareAccountListItem.vue
@@ -2,7 +2,7 @@
   <div class="px-5 bg-sidebar border-transparent border-l-4 group" :class="{'border-rGreen': isActiveAccount}">
     <div class="flex flex-row mb-4 justify-between" v-if="addressVal">
       <div class="flex flex-row">
-        <div class="leading-snug text-rGrayDark hover:text-rGreen transition-colors cursor-pointer w-36 truncate">{{ nickName }}</div>
+        <div class="leading-snug text-rGrayDark hover:text-rGreen transition-colors cursor-pointer w-40 truncate">{{ nickName }}</div>
       </div>
       <div v-if="shouldShowEdit" @click.stop="editName" class="z-20 hidden group-hover:block text-rGrayDark hover:text-rGreen transition-colors cursor-pointer flex items-center justify-center  pt-2 z-20">
         <svg width="12" height="12" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/views/Wallet/WalletSidebarAccounts.vue
+++ b/src/views/Wallet/WalletSidebarAccounts.vue
@@ -121,7 +121,7 @@
               />
             </div>
           </div>
-        <div class="border-t border-rGray border-opacity-50 mx-4 mt-6 pb-2" ></div>
+        <div v-if="hardwareDevices.length" class="border-t border-rGray border-opacity-50 mx-4 mt-6 pb-2" ></div>
         <div @click="createNewHardwareAccount" class="my-4 pb-6 mx-auto text-center cursor-pointer hover:text-rGreen transition-colors">
           {{ $t('wallet.navAddHWAccount') }}
         </div>


### PR DESCRIPTION
This PR just makes a couple small tweaks that came up during QA.

- Removes a double divider line when there are no hardware accounts.
- Slightly widens the account name labels to provide for longer titles.

Before:
<img width="1312" alt="Screen Shot 2022-06-01 at 9 33 46 AM" src="https://user-images.githubusercontent.com/102228/171422558-e1e6dd11-3c0c-47fb-a0f3-bbf164e27d7e.png">

After:
<img width="1312" alt="Screen Shot 2022-06-01 at 10 00 08 AM" src="https://user-images.githubusercontent.com/102228/171422765-3720046b-7ef3-4a6d-8179-28dfdb40aa4d.png">



