### PR TITLE
feat: add check for amount greater than max

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -223,7 +223,8 @@ const messages = {
       unstakeMaxDisclaimer: "You're unstaking all tokens from",
       maxUnstakeButton: 'max',
       maxUnstakeCapitalized: 'MAX',
-      maxUnstakeModeEnabledNotification: 'The value you entered is within 0.000001 of the full unstakable amount, therefore, max mode has been automatically enabled on this entry.'
+      maxUnstakeModeEnabledNotification: 'The value you entered is within 0.000001 of the full unstakable amount, therefore, max mode has been automatically enabled on this entry.',
+      maxUnstakeModeOverageNotification: 'The value you entered is greater than the full unstakable amount, therefore, max mode has been automatically enabled on this entry.'
     },
     confirmation: {
       transferFromLabel: 'Your address',

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -357,9 +357,12 @@ const WalletStaking = defineComponent({
       const maxAmount = +asBigNumber(activeValidatorStakeAmount) as number
       const currentValue = +asBigNumber(safeAmount) as number
       const minDifference = maxAmount - currentValue
-      if (minDifference <= 0.000001) {
+      if (minDifference <= 0.000001 && minDifference > 0) {
+        console.log('amount meets auto max unstaking criteria')
         setMaxUnstakeNotificationOn()
         setMaxUnstakeOn()
+      } else if (minDifference < 0) {
+        console.log('amount greater than auto max unstaking criteria')
       }
     }
 

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -100,7 +100,8 @@
                   <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path fill-rule="evenodd" clip-rule="evenodd" d="M14 7C14 10.866 10.866 14 7 14C3.13401 14 0 10.866 0 7C0 3.13401 3.13401 0 7 0C10.866 0 14 3.13401 14 7ZM7.875 3.5C7.875 3.98325 7.48325 4.375 7 4.375C6.51675 4.375 6.125 3.98325 6.125 3.5C6.125 3.01675 6.51675 2.625 7 2.625C7.48325 2.625 7.875 3.01675 7.875 3.5ZM6.125 6.125C5.64175 6.125 5.25 6.51675 5.25 7C5.25 7.48325 5.64175 7.875 6.125 7.875V10.5C6.125 10.9832 6.51675 11.375 7 11.375H7.875C8.35825 11.375 8.75 10.9832 8.75 10.5C8.75 10.0168 8.35825 9.625 7.875 9.625V7C7.875 6.51675 7.48325 6.125 7 6.125H6.125Z" fill="#052CC0"/>
                   </svg>
-                  <span class=" text-xs text-rBlue flex-1 ">{{$t('staking.maxUnstakeModeEnabledNotification')}}</span>
+                  <span v-if="showMaxUnstakeOverageNotification" class=" text-xs text-rBlue flex-1 ">{{$t('staking.maxUnstakeModeEnabledNotification')}}</span>
+                  <span v-else class=" text-xs text-rBlue flex-1 ">{{$t('staking.maxUnstakeModeEnabledNotification')}}</span>
                 </div>
               </div>
             </div>
@@ -366,6 +367,7 @@ const WalletStaking = defineComponent({
         console.log('amount greater than auto max unstaking criteria')
         setMaxUnstakeNotificationOn()
         setMaxUnstakeOn()
+        setMaxUnstakeOverageNotifcationOn()
       }
     }
 
@@ -446,11 +448,11 @@ const WalletStaking = defineComponent({
     }
 
     const setMaxUnstakeOverageNotifcationOn = () => {
-      
+      showMaxUnstakeOverageNotification.value = true
     }
 
     const setMaxUnstakeOverageNotifcationOff = () => {
-      
+      showMaxUnstakeOverageNotification.value = false
     }
 
     const handleSubmitStakeForm = () => {

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -359,14 +359,16 @@ const WalletStaking = defineComponent({
       const maxAmount = +asBigNumber(activeValidatorStakeAmount) as number
       const currentValue = +asBigNumber(safeAmount) as number
       const minDifference = maxAmount - currentValue
-      if (minDifference <= 0.000001 && minDifference > 0) {
+
+      if (minDifference <= 0.000001) {
         setMaxUnstakeNotificationOn()
         setMaxUnstakeOn()
-        setMaxUnstakeOverageNotifcationOff()
-      } else if (minDifference < 0) {
-        setMaxUnstakeNotificationOn()
-        setMaxUnstakeOn()
-        setMaxUnstakeOverageNotifcationOn()
+
+        if (minDifference < 0) {
+          setMaxUnstakeOverageNotifcationOn()
+        } else {
+          setMaxUnstakeOverageNotifcationOff()
+        }
       }
     }
 

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -100,7 +100,9 @@
                   <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path fill-rule="evenodd" clip-rule="evenodd" d="M14 7C14 10.866 10.866 14 7 14C3.13401 14 0 10.866 0 7C0 3.13401 3.13401 0 7 0C10.866 0 14 3.13401 14 7ZM7.875 3.5C7.875 3.98325 7.48325 4.375 7 4.375C6.51675 4.375 6.125 3.98325 6.125 3.5C6.125 3.01675 6.51675 2.625 7 2.625C7.48325 2.625 7.875 3.01675 7.875 3.5ZM6.125 6.125C5.64175 6.125 5.25 6.51675 5.25 7C5.25 7.48325 5.64175 7.875 6.125 7.875V10.5C6.125 10.9832 6.51675 11.375 7 11.375H7.875C8.35825 11.375 8.75 10.9832 8.75 10.5C8.75 10.0168 8.35825 9.625 7.875 9.625V7C7.875 6.51675 7.48325 6.125 7 6.125H6.125Z" fill="#052CC0"/>
                   </svg>
-                  <span v-if="showMaxUnstakeOverageNotification" class=" text-xs text-rBlue flex-1 ">{{$t('staking.maxUnstakeModeOverageNotification')}}</span>
+                  <span v-if="showMaxUnstakeOverageNotification" class=" text-xs text-rBlue flex-1 ">
+                    {{$t('staking.maxUnstakeModeOverageNotification')}}
+                  </span>
                   <span v-else class=" text-xs text-rBlue flex-1 ">{{$t('staking.maxUnstakeModeEnabledNotification')}}</span>
                 </div>
               </div>

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -223,6 +223,7 @@ const WalletStaking = defineComponent({
     const tokenBalances: Ref<AccountBalancesEndpoint.DecodedResponse | null> = ref(null)
     const nativeTokenBalance: Ref<Decoded.TokenAmount | null> = ref(null)
     const showMaxUnstakeNotification: Ref<boolean> = ref(false)
+    const showMaxUnstakeOverageNotification: Ref<boolean> = ref(false)
 
     /* ------
      *  Side Effects
@@ -363,6 +364,8 @@ const WalletStaking = defineComponent({
         setMaxUnstakeOn()
       } else if (minDifference < 0) {
         console.log('amount greater than auto max unstaking criteria')
+        setMaxUnstakeNotificationOn()
+        setMaxUnstakeOn()
       }
     }
 
@@ -442,6 +445,14 @@ const WalletStaking = defineComponent({
       showMaxUnstakeNotification.value = false
     }
 
+    const setMaxUnstakeOverageNotifcationOn = () => {
+      
+    }
+
+    const setMaxUnstakeOverageNotifcationOff = () => {
+      
+    }
+
     const handleSubmitStakeForm = () => {
       if (maxUnstakeMode.value && activeForm.value === 'UNSTAKING') {
         handleMaxSubmitUnstake()
@@ -480,6 +491,7 @@ const WalletStaking = defineComponent({
       values,
       xrdBalance,
       showMaxUnstakeNotification,
+      showMaxUnstakeOverageNotification,
 
       // methods
       handleSubmitStakeForm,

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -360,12 +360,10 @@ const WalletStaking = defineComponent({
       const currentValue = +asBigNumber(safeAmount) as number
       const minDifference = maxAmount - currentValue
       if (minDifference <= 0.000001 && minDifference > 0) {
-        console.log('amount meets auto max unstaking criteria')
         setMaxUnstakeNotificationOn()
         setMaxUnstakeOn()
         setMaxUnstakeOverageNotifcationOff()
       } else if (minDifference < 0) {
-        console.log('amount greater than auto max unstaking criteria')
         setMaxUnstakeNotificationOn()
         setMaxUnstakeOn()
         setMaxUnstakeOverageNotifcationOn()

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -100,7 +100,7 @@
                   <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path fill-rule="evenodd" clip-rule="evenodd" d="M14 7C14 10.866 10.866 14 7 14C3.13401 14 0 10.866 0 7C0 3.13401 3.13401 0 7 0C10.866 0 14 3.13401 14 7ZM7.875 3.5C7.875 3.98325 7.48325 4.375 7 4.375C6.51675 4.375 6.125 3.98325 6.125 3.5C6.125 3.01675 6.51675 2.625 7 2.625C7.48325 2.625 7.875 3.01675 7.875 3.5ZM6.125 6.125C5.64175 6.125 5.25 6.51675 5.25 7C5.25 7.48325 5.64175 7.875 6.125 7.875V10.5C6.125 10.9832 6.51675 11.375 7 11.375H7.875C8.35825 11.375 8.75 10.9832 8.75 10.5C8.75 10.0168 8.35825 9.625 7.875 9.625V7C7.875 6.51675 7.48325 6.125 7 6.125H6.125Z" fill="#052CC0"/>
                   </svg>
-                  <span v-if="showMaxUnstakeOverageNotification" class=" text-xs text-rBlue flex-1 ">{{$t('staking.maxUnstakeModeEnabledNotification')}}</span>
+                  <span v-if="showMaxUnstakeOverageNotification" class=" text-xs text-rBlue flex-1 ">{{$t('staking.maxUnstakeModeOverageNotification')}}</span>
                   <span v-else class=" text-xs text-rBlue flex-1 ">{{$t('staking.maxUnstakeModeEnabledNotification')}}</span>
                 </div>
               </div>
@@ -363,6 +363,7 @@ const WalletStaking = defineComponent({
         console.log('amount meets auto max unstaking criteria')
         setMaxUnstakeNotificationOn()
         setMaxUnstakeOn()
+        setMaxUnstakeOverageNotifcationOff()
       } else if (minDifference < 0) {
         console.log('amount greater than auto max unstaking criteria')
         setMaxUnstakeNotificationOn()


### PR DESCRIPTION
This PR checks if the `unstake` amount the user typed is greater than the `max-unstake` amount available.  If so, a notification is displayed informing the user that the amount they typed was rounded down to the `max-unstake` amount available, since you cant unstake more than you have.  Before it only checked if the `minDifference` amount was <=`0.000001` which did not account for any negative values.  If the `minDifference` is negative that means the user tried to `unstake` more than they have available.  If `minDifference` is positive, then the user entered a number lower than the `max-unstake` amount and a notification should only be displayed if this value is <= `0.000001`.

[See Linear Issue RDX-397 Here](https://linear.app/township/issue/RDX-397/user-not-accurately-notified-of-unstake-rounding)

### Before

https://user-images.githubusercontent.com/83678228/171427547-f72d69f9-7ae9-434f-a55d-71a3fa8849a1.mp4

### After

https://user-images.githubusercontent.com/83678228/171439740-1d1c2295-c2d1-4e4c-81aa-413e36b5b4d6.mp4

In `WalletStaking.vue`

Inside the `compareToMaxUnstakeAmount` function I added another constraint to the conditional  to determine which notification will be displayed to the user if any.

```
if (minDifference <= 0.000001) {
  setMaxUnstakeNotificationOn()
  setMaxUnstakeOn()

  if (minDifference < 0) {
    setMaxUnstakeOverageNotifcationOn()
  } else {
    setMaxUnstakeOverageNotifcationOff()
  }
}
```

I added another ref `showMaxUnstakeOverageNotification` to control which notification message is conditionally rendered inside of the notification div

```
<span v-if="showMaxUnstakeOverageNotification" class=" text-xs text-rBlue flex-1 ">
  {{$t('staking.maxUnstakeModeOverageNotification')}}
</span>
<span v-else class=" text-xs text-rBlue flex-1 ">{{$t('staking.maxUnstakeModeEnabledNotification')}}</span>
```

Inside `index.ts`

I added another property `maxUnstakeModeOverageNotification` inside of the staking object and set it equal to the notification message that will be displayed to the user for I8n compatibility.

```
maxUnstakeModeOverageNotification: 'The value you entered is greater than the full unstakable amount, therefore, max mode has been automatically enabled on this entry.'
```

