### PR TITLE
fix: stops user from pressing max without entering a validator address

### DIFF
--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -476,7 +476,6 @@ const WalletStaking = defineComponent({
     })
 
     const emptyFormValidatorName: ComputedRef<boolean> = computed(() => {
-      console.log(!!formValidatorName.value)
       return !formValidatorName.value
     })
 

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -90,8 +90,7 @@
                   <button
                     @click.prevent="setMaxUnstakeOn"
                     v-if="activeForm == 'UNSTAKING'"
-                    class="rounded border border-rGreen text-rGreen w-2/12 h-full ml-6"
-                    :class="formValidatorName === '' && 'bg-rGray text-rGrayDark cursor-not-allowed border border-rGray'"
+                    :class="{'rounded border border-rGreen text-rGreen w-2/12 h-full ml-6': true, 'bg-rGray text-rGrayDark cursor-not-allowed border border-rGray': formValidatorName === ''}"
                     :disabled="formValidatorName === ''"
                   >
                     {{ $t('staking.maxUnstakeButton') }}

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -51,6 +51,7 @@
               :placeholder="$t('staking.validatorPlaceholder')"
               rules="required|validValidator"
               :validateOnInput="true"
+              ref="address"
             />
             <FormErrorMessage name="validator" class="text-sm text-red-400" />
           </div>
@@ -91,6 +92,7 @@
                     @click.prevent="setMaxUnstakeOn"
                     v-if="activeForm == 'UNSTAKING'"
                     class="rounded border border-rGreen text-rGreen w-2/12 h-full ml-6"
+                    :disabled="address"
                   >
                     {{ $t('staking.maxUnstakeButton') }}
                   </button>
@@ -413,6 +415,7 @@ const WalletStaking = defineComponent({
 
     const handleMaxSubmitUnstake = () => {
       const safeAddress = safelyUnwrapValidator(values.validator)
+      console.log(safeAddress)
       if (!safeAddress) return
       const safeOneHundredPercent = safelyUnwrapAmount(Number('0.0000000000000001'))
       if (!safeOneHundredPercent) return

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -44,7 +44,6 @@
           </div>
           <div class="pt-3 pb-6 px-4 text-sm border-b border-rGray">
             <div class="text-rGrayDark mb-2">{{ $t('staking.validatorLabel')}}</div>
-            <!-- how can I access the value of this form field? -->
             <FormField
               name="validator"
               type="text"
@@ -88,13 +87,12 @@
                     @input="compareToMaxUnstakeAmount"
                     :validateOnInput="true"
                   />
-                  <!-- i was to set :disabled= whatever the value of the address form field is -->
                   <button
                     @click.prevent="setMaxUnstakeOn"
                     v-if="activeForm == 'UNSTAKING'"
                     class="rounded border border-rGreen text-rGreen w-2/12 h-full ml-6"
-                    :class="formValidatorName == '' && 'bg-rGray text-rGrayDark cursor-not-allowed border border-rGray'"
-                    :disabled="formValidatorName == ''"
+                    :class="formValidatorName === '' && 'bg-rGray text-rGrayDark cursor-not-allowed border border-rGray'"
+                    :disabled="formValidatorName === ''"
                   >
                     {{ $t('staking.maxUnstakeButton') }}
                   </button>

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -44,6 +44,7 @@
           </div>
           <div class="pt-3 pb-6 px-4 text-sm border-b border-rGray">
             <div class="text-rGrayDark mb-2">{{ $t('staking.validatorLabel')}}</div>
+            <!-- how can I access the value of this form field? -->
             <FormField
               name="validator"
               type="text"
@@ -88,11 +89,12 @@
                     @input="compareToMaxUnstakeAmount"
                     :validateOnInput="true"
                   />
+                  <!-- i was to set :disabled= whatever the value of the address form field is -->
                   <button
                     @click.prevent="setMaxUnstakeOn"
                     v-if="activeForm == 'UNSTAKING'"
                     class="rounded border border-rGreen text-rGreen w-2/12 h-full ml-6"
-                    :disabled="address"
+                    :disabled="address.value"
                   >
                     {{ $t('staking.maxUnstakeButton') }}
                   </button>

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -52,7 +52,6 @@
               :placeholder="$t('staking.validatorPlaceholder')"
               rules="required|validValidator"
               :validateOnInput="true"
-              ref="address"
             />
             <FormErrorMessage name="validator" class="text-sm text-red-400" />
           </div>
@@ -94,7 +93,7 @@
                     @click.prevent="setMaxUnstakeOn"
                     v-if="activeForm == 'UNSTAKING'"
                     class="rounded border border-rGreen text-rGreen w-2/12 h-full ml-6"
-                    :disabled="address.value"
+                    :disabled="formValidatorName == ''"
                   >
                     {{ $t('staking.maxUnstakeButton') }}
                   </button>
@@ -166,6 +165,7 @@ import { useRouter, onBeforeRouteLeave } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { interval, Subscription, firstValueFrom } from 'rxjs'
 import { Decoded, AccountBalancesEndpoint } from '@radixdlt/application/dist/api/open-api/_types'
+import { truncateRRIStringForDisplay } from '@/helpers/formatter'
 
 interface StakeForm {
   validator: string;
@@ -417,7 +417,6 @@ const WalletStaking = defineComponent({
 
     const handleMaxSubmitUnstake = () => {
       const safeAddress = safelyUnwrapValidator(values.validator)
-      console.log(safeAddress)
       if (!safeAddress) return
       const safeOneHundredPercent = safelyUnwrapAmount(Number('0.0000000000000001'))
       if (!safeOneHundredPercent) return

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -93,6 +93,7 @@
                     @click.prevent="setMaxUnstakeOn"
                     v-if="activeForm == 'UNSTAKING'"
                     class="rounded border border-rGreen text-rGreen w-2/12 h-full ml-6"
+                    :class="formValidatorName == '' && 'bg-rGray text-rGrayDark cursor-not-allowed border border-rGray'"
                     :disabled="formValidatorName == ''"
                   >
                     {{ $t('staking.maxUnstakeButton') }}

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -90,8 +90,8 @@
                   <button
                     @click.prevent="setMaxUnstakeOn"
                     v-if="activeForm == 'UNSTAKING'"
-                    :class="{'rounded border border-rGreen text-rGreen w-2/12 h-full ml-6': true, 'bg-rGray text-rGrayDark cursor-not-allowed border border-rGray': formValidatorName === ''}"
-                    :disabled="formValidatorName === ''"
+                    :class="{'rounded border border-rGreen text-rGreen w-2/12 h-full ml-6': true, 'bg-rGray text-rGrayDark cursor-not-allowed border border-rGray': !emptyFormValidatorName}"
+                    :disabled="emptyFormValidatorName"
                   >
                     {{ $t('staking.maxUnstakeButton') }}
                   </button>
@@ -475,6 +475,11 @@ const WalletStaking = defineComponent({
       return v ? v.name : ''
     })
 
+    const emptyFormValidatorName: ComputedRef<boolean> = computed(() => {
+      console.log(!!formValidatorName.value)
+      return !!formValidatorName.value
+    })
+
     return {
       activeForm,
       activeAddress,
@@ -482,6 +487,7 @@ const WalletStaking = defineComponent({
       errors,
       explorerUrl,
       explorerUrlBase,
+      emptyFormValidatorName,
       formValidatorName,
       hasTokenBalances,
       loadedAllData,

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -164,7 +164,6 @@ import { useRouter, onBeforeRouteLeave } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { interval, Subscription, firstValueFrom } from 'rxjs'
 import { Decoded, AccountBalancesEndpoint } from '@radixdlt/application/dist/api/open-api/_types'
-import { truncateRRIStringForDisplay } from '@/helpers/formatter'
 
 interface StakeForm {
   validator: string;

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -90,7 +90,7 @@
                   <button
                     @click.prevent="setMaxUnstakeOn"
                     v-if="activeForm == 'UNSTAKING'"
-                    :class="{'rounded border border-rGreen text-rGreen w-2/12 h-full ml-6': true, 'bg-rGray text-rGrayDark cursor-not-allowed border border-rGray': !emptyFormValidatorName}"
+                    :class="{'rounded border border-rGreen text-rGreen w-2/12 h-full ml-6': true, 'bg-rGray text-rGrayDark cursor-not-allowed border border-rGray': emptyFormValidatorName}"
                     :disabled="emptyFormValidatorName"
                   >
                     {{ $t('staking.maxUnstakeButton') }}
@@ -477,7 +477,7 @@ const WalletStaking = defineComponent({
 
     const emptyFormValidatorName: ComputedRef<boolean> = computed(() => {
       console.log(!!formValidatorName.value)
-      return !!formValidatorName.value
+      return !formValidatorName.value
     })
 
     return {


### PR DESCRIPTION
This PR stops the user from pressing the `max` button if they have not first entered a `validator address`.  Previously the user could press the `max` button at any time which triggers the state of the `Request Unstake` button to change from disabled to active. As a result, the user can then click the `Request Unstake` button which causes an error, but the user isnt aware, because it doesnt provide any feedback to the user.  Now the state of the `max` button is controlled based on whether the user has entered a value in the `validator address`.  Once an address is entered, the disabled styling of the `max` button is removed.

[See Linear Issue RDX-400 Here](https://linear.app/township/issue/RDX-400/max-unstake-button-should-be-disabled-if-no-validator-address)

In `WalletStaking.vue`

I used class binding to switch the styling of the `max` button to match the disabled `Request Unstake` button only if `formValidatorName` does not have a value.  Once `formValidatorName` has a value, this stying is not applied.

```
<button
  @click.prevent="setMaxUnstakeOn"
  v-if="activeForm == 'UNSTAKING'"
  class="rounded border border-rGreen text-rGreen w-2/12 h-full ml-6"
  :class="formValidatorName === '' && 'bg-rGray text-rGrayDark cursor-not-allowed border border-rGray'"
  :disabled="formValidatorName === ''"
>
  {{ $t('staking.maxUnstakeButton') }}
</button>
```

### Before

https://user-images.githubusercontent.com/83678228/171727953-7633b982-986a-41cd-a0a8-8a99e9928d8b.mp4

### After

https://user-images.githubusercontent.com/83678228/171890783-97686cf1-4b7c-4948-8215-b3d98bd97704.mp4



