### PR TITLE
fix: History page was leaving history subscriptions active when changing active addresses

### DIFF
--- a/src/views/Wallet/WalletHistory.vue
+++ b/src/views/Wallet/WalletHistory.vue
@@ -164,9 +164,14 @@ const WalletHistory = defineComponent({
     }
 
     // Fetch new history when active account changes
-    watch((activeAddress), () => {
-      if (activeAddress.value) {
-        updateActiveAccount(activeAddress.value)
+    watch((activeAddress), (newAddress, oldAddress) => {
+      if (!newAddress) return
+      if (newAddress && oldAddress && !newAddress.equals(oldAddress)) {
+        leavingHistory()
+        updateActiveAccount(newAddress)
+      }
+      if (newAddress && oldAddress && newAddress.equals(oldAddress)) {
+        return
       }
       resetHistory()
       fetchTransactions()


### PR DESCRIPTION
Navigating between active accounts on the history page was leaving the transaction subscription active for the old active address and also generating a new sub for the old one.  This PR cleans up those subscriptions for both data consistency and flickering UIs