### PR TITLE
Verify Address and Initial HW wallet bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@headlessui/vue": "^1.3.0",
     "@ledgerhq/hw-transport-node-hid": "^6.24.1",
     "@nopr3d/vue-next-rx": "^1.0.6",
-    "@radixdlt/application": "4.0.17",
+    "@radixdlt/application": "4.0.18",
     "@radixdlt/crypto": "^2.1.12",
     "@radixdlt/hardware-ledger": "^2.1.31",
     "@radixdlt/networking": "^2.1.14",

--- a/src/actions/electron/hardware-wallet.ts
+++ b/src/actions/electron/hardware-wallet.ts
@@ -1,20 +1,27 @@
 import TransportNodeHid from '@ledgerhq/hw-transport-node-hid'
 import { IpcMainInvokeEvent } from 'electron/main'
 
-export const sendAPDU = async (event: IpcMainInvokeEvent, apdu: { cla: number, ins: number, p1: number, p2: number, data?: string }) => {
+type APDU = { cla: number, ins: number, p1: number, p2: number, data?: string }
+let lastAPDU: APDU | null = null 
+
+export const sendAPDU = async (event: IpcMainInvokeEvent, apdu: APDU) => {
   const paths = await TransportNodeHid.list()
   if (paths.length === 0) throw Error('No device found.')
-
-  const transport = await TransportNodeHid.open(paths[0])
+  if (paths.length > 1) throw Error('Too Many Devices Enabled')
+  if (lastAPDU && lastAPDU === apdu) {
+    console.warn('duplicate message', apdu)
+    return
+  }
   let result
   try {
+    const transport = await TransportNodeHid.open(paths[0])
     result = await transport.send(apdu.cla, apdu.ins, apdu.p1, apdu.p2, apdu.data ? Buffer.from(apdu.data, 'hex') : undefined)
-  } catch (e) {
+    lastAPDU = apdu
     await transport.close()
+  } catch (e) {
+    console.log('hi there', e)
     throw e
   }
-
-  await transport.close()
 
   return result
 }

--- a/src/actions/electron/hardware-wallet.ts
+++ b/src/actions/electron/hardware-wallet.ts
@@ -9,7 +9,6 @@ export const sendAPDU = async (event: IpcMainInvokeEvent, apdu: APDU) => {
   if (paths.length === 0) throw Error('No device found.')
   if (paths.length > 1) throw Error('Too Many Devices Enabled')
   if (lastAPDU && lastAPDU === apdu) {
-    console.warn('duplicate message', apdu)
     return
   }
   let result
@@ -19,7 +18,6 @@ export const sendAPDU = async (event: IpcMainInvokeEvent, apdu: APDU) => {
     lastAPDU = apdu
     await transport.close()
   } catch (e) {
-    console.log('hi there', e)
     throw e
   }
 

--- a/src/components/AccountListItem.vue
+++ b/src/components/AccountListItem.vue
@@ -25,7 +25,6 @@
         :address="addressVal"
         :checkForHardwareAddress=true
         class="hover:text-rGreen active:text-rGreenDark"
-        @verifyHardwareAddress="verifyHardwareWalletAddress()"
       />
     </div>
   </div>
@@ -58,7 +57,7 @@ const AccountListItem = defineComponent({
 
   setup (props) {
     const router = useRouter()
-    const { accountNameFor, activeAddress, verifyHardwareWalletAddress, setHideAccountModal } = useWallet(router)
+    const { accountNameFor, activeAddress, setHideAccountModal } = useWallet(router)
 
     const { setState } = useSidebar()
     const address = toRef(props, 'address')
@@ -90,8 +89,7 @@ const AccountListItem = defineComponent({
       activeAddress,
       editName,
       hideAccount,
-      isActiveAccount,
-      verifyHardwareWalletAddress
+      isActiveAccount
     }
   }
 })

--- a/src/components/AccountListPreview.vue
+++ b/src/components/AccountListPreview.vue
@@ -31,7 +31,6 @@
         :address="addressVal"
         :checkForHardwareAddress=true
         class="hover:text-rGreen active:text-rGreenDark"
-        @verifyHardwareAddress="verifyHardwareWalletAddress()"
       />
     </div>
   </div>
@@ -64,7 +63,7 @@ const AccountListPreview = defineComponent({
 
   setup (props) {
     const router = useRouter()
-    const { accountNameFor, activeAddress, verifyHardwareWalletAddress } = useWallet(router)
+    const { accountNameFor, activeAddress } = useWallet(router)
 
     const { setState } = useSidebar()
     const address = toRef(props, 'address')
@@ -91,8 +90,7 @@ const AccountListPreview = defineComponent({
       }),
       activeAddress,
       editName,
-      isActiveAccount,
-      verifyHardwareWalletAddress
+      isActiveAccount
     }
   }
 })

--- a/src/components/ClickToCopy.vue
+++ b/src/components/ClickToCopy.vue
@@ -34,13 +34,14 @@ const ClickToCopy = defineComponent({
     const { address, checkForHardwareAddress } = toRefs(props)
     const potentialHWAddress = hardwareDevices.value.flatMap((v) => v.addresses).find((a) => a.address.toString() === address.value)
 
-    const copyText = () => {
+    const copyText = async () => {
       if (checkForHardwareAddress.value && potentialHWAddress && activeAddress.value?.toString() === address.value) {
-        activateAccount(() => {
+        try {
+          const activeAccount = await activateAccount()
           verifyHardwareWalletAddress()
-        }).catch((e) => {
+        } catch {
           toast.error('Unable to connect to Ledger')
-        })
+        }
       } else {
         copyToClipboard(address.value)
         toast.success('Copied to Clipboard')

--- a/src/components/HardwareAccountListItem.vue
+++ b/src/components/HardwareAccountListItem.vue
@@ -25,7 +25,6 @@
         :address="addressVal"
         :checkForHardwareAddress=true
         class="hover:text-rGreen active:text-rGreenDark"
-        @verifyHardwareAddress="verifyHardwareWalletAddress()"
       />
     </div>
   </div>
@@ -58,7 +57,7 @@ const AccountListItem = defineComponent({
 
   setup (props) {
     const router = useRouter()
-    const { accountNameFor, activeAddress, verifyHardwareWalletAddress, setHideAccountModal } = useWallet(router)
+    const { accountNameFor, activeAddress, setHideAccountModal } = useWallet(router)
 
     const { setState } = useSidebar()
     const address = toRef(props, 'address')
@@ -90,8 +89,7 @@ const AccountListItem = defineComponent({
       activeAddress,
       editName,
       hideAccount,
-      isActiveAccount,
-      verifyHardwareWalletAddress
+      isActiveAccount
     }
   }
 })

--- a/src/views/Wallet/WalletHistory.vue
+++ b/src/views/Wallet/WalletHistory.vue
@@ -10,7 +10,6 @@
             <click-to-copy
               :address="activeAddress.toString()"
               :checkForHardwareAddress=true
-              @verifyHardwareAddress="verifyHardwareWalletAddress"
             />
           </div>
         </div>
@@ -114,8 +113,7 @@ const WalletHistory = defineComponent({
       hardwareAccount,
       nativeToken,
       hardwareError,
-      radix,
-      verifyHardwareWalletAddress
+      radix
     } = useWallet(router)
 
     if (!activeAddress.value) {
@@ -201,8 +199,7 @@ const WalletHistory = defineComponent({
       previousPage,
       resetHistory,
       shouldShowDecryptModal,
-      transactionsWithMessages,
-      verifyHardwareWalletAddress
+      transactionsWithMessages
     }
   }
 })

--- a/src/views/Wallet/WalletOverview.vue
+++ b/src/views/Wallet/WalletOverview.vue
@@ -9,7 +9,6 @@
             <click-to-copy
               :address="activeAddress.toString()"
               :checkForHardwareAddress=true
-              @verifyHardwareAddress="verifyHardwareWalletAddress()"
             />
           </div>
         </div>
@@ -152,7 +151,6 @@ const WalletOverview = defineComponent({
       explorerUrlBase,
       nativeToken,
       radix,
-      verifyHardwareWalletAddress,
       hasWallet
     } = useWallet(router)
 
@@ -258,8 +256,7 @@ const WalletOverview = defineComponent({
       createRRIUrl,
       handleHideToken,
       handleRequestHideToken,
-      truncateRRIStringForDisplay,
-      verifyHardwareWalletAddress
+      truncateRRIStringForDisplay
     }
   }
 })

--- a/src/views/Wallet/WalletSidebarAccounts.vue
+++ b/src/views/Wallet/WalletSidebarAccounts.vue
@@ -160,7 +160,6 @@ const WalletSidebarAccounts = defineComponent({
       hardwareDevices,
       derivedAccountIndex,
       activeNetwork,
-      verifyHardwareWalletAddress,
       createNewHardwareAccount,
       setDisconnectDeviceModal
     } = useWallet(router)
@@ -235,7 +234,6 @@ const WalletSidebarAccounts = defineComponent({
         router.push(`/wallet/${account.address.toString()}/account-edit-name`)
       },
       connectHardwareWallet,
-      verifyHardwareWalletAddress,
       createNewHardwareAccount,
       isActiveDevice (hardwareDevice: HardwareDevice) {
         return !!hardwareDevice.addresses.find((hwaddr) => {

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -9,7 +9,6 @@
             <click-to-copy
               :address="activeAddress.toString()"
               :checkForHardwareAddress=true
-              @verifyHardwareAddress="verifyHardwareAddress()"
             />
           </div>
         </div>
@@ -168,7 +167,7 @@ const WalletTransaction = defineComponent({
   setup () {
     const router = useRouter()
     const { errors, values, meta, setErrors, resetForm } = useForm<TransactionForm>()
-    const { activeAddress, activateAccount, hardwareAccount, nativeToken, networkPreamble, radix, verifyHardwareWalletAddress } = useWallet(router)
+    const { activeAddress, activateAccount, hardwareAccount, nativeToken, networkPreamble, radix } = useWallet(router)
     const { t } = useI18n({ useScope: 'global' })
     const { tokenInfoFor, fetchBalancesForAddress, tokenBalances, tokenBalanceFor, tokenBalanceForByString } = useTokenBalances(radix)
     const { cancelTransaction, userDidCancel, setActiveTransactionForm, transferTokens } = useTransactions(radix, router, activeAddress.value, hardwareAccount.value)
@@ -352,8 +351,7 @@ const WalletTransaction = defineComponent({
       handleSubmit,
       loadedAllData,
       setErrors,
-      tokenInfoFor,
-      verifyHardwareWalletAddress
+      tokenInfoFor
     }
   }
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1533,10 +1533,10 @@
     prelude-ts "^1.0.2"
     rxjs "7.0.0"
 
-"@radixdlt/application@4.0.17":
-  version "4.0.17"
-  resolved "https://registry.yarnpkg.com/@radixdlt/application/-/application-4.0.17.tgz#c9f1c5b0dba3c0d8ecbbc37124ba9f7ad3ee6354"
-  integrity sha512-Akpi23+4d7cIu4I/qUUzgrgIOFgz1fPIZ/iCJ8Z483EIOvOIDWJS9FdK1AnpPZ022boWsGvMY6U5h8FdDQO7UA==
+"@radixdlt/application@4.0.18":
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/@radixdlt/application/-/application-4.0.18.tgz#c77db58d28d0a678271a99c7fbd477c7506c6366"
+  integrity sha512-DvTjFODoMZMcVkDnGsduWjKtVB/a5GXhatp8FDMyCjDU9/TcDdLbkEkevK8S6msmZpYsqfVhBs8cDi9w1eqq6Q==
   dependencies:
     "@open-rpc/mock-server" "1.7.2"
     "@open-rpc/schema-utils-js" "1.14.3"


### PR DESCRIPTION
https://www.loom.com/share/f9e3042553144e07af3aceb057ee5659

Depends on the changes in https://github.com/radixdlt/radixdlt-javascript/pull/202

This PR cleans up two edge cases where the SDK / Wallet were depending on `wallet` state to correctly derive and message the correct ledger device.

**Verify HW Address**
From my understanding of the SDK, in the above PR, I've updated the wallet functionality for displaying the address on the ledger device to no longer observe and pipe through the `activeAccount` observable.  On major wallet / hw account / active account changes, this caused the verify function to send three+ equivalent, duplicate messages through the `sendAPDU` tunnel.  

**Deriving new HW Devices**
It seems that another side effect of this observable magic is that hw accounts would not always correctly derive.