### PR TITLE
fix: save needed value in wallet deletion process

### DIFF
--- a/src/actions/electron/data-store.ts
+++ b/src/actions/electron/data-store.ts
@@ -80,7 +80,7 @@ export const getHardwareDeviceAccounts = (event: IpcMainInvokeEvent, network: st
 }
 
 export const resetStore = (event: IpcMainInvokeEvent) => {
-  console.log('resetStore called here ', store);
+  console.log(' resetStore called in src/actions/electron/data-store ', store)
   return store.clear()
 }
 

--- a/src/actions/electron/data-store.ts
+++ b/src/actions/electron/data-store.ts
@@ -79,9 +79,12 @@ export const getHardwareDeviceAccounts = (event: IpcMainInvokeEvent, network: st
   return hardwareStoreList
 }
 
-export const resetStore = (event: IpcMainInvokeEvent) => {
+export const resetStore = (event: IpcMainInvokeEvent): void => {
   console.log(' resetStore called in src/actions/electron/data-store ', store)
-  return store.clear()
+  const acceptedTos = store.get('acceptedTos', false)
+  store.clear()
+  store.set('acceptedTos', acceptedTos)
+  return
 }
 
 export const persistNodeSelection = (event: IpcMainInvokeEvent, data: string): void => {

--- a/src/actions/electron/data-store.ts
+++ b/src/actions/electron/data-store.ts
@@ -80,6 +80,7 @@ export const getHardwareDeviceAccounts = (event: IpcMainInvokeEvent, network: st
 }
 
 export const resetStore = (event: IpcMainInvokeEvent) => {
+  console.log('resetStore called here ', store);
   return store.clear()
 }
 

--- a/src/actions/electron/data-store.ts
+++ b/src/actions/electron/data-store.ts
@@ -80,7 +80,6 @@ export const getHardwareDeviceAccounts = (event: IpcMainInvokeEvent, network: st
 }
 
 export const resetStore = (event: IpcMainInvokeEvent): void => {
-  console.log(' resetStore called in src/actions/electron/data-store ', store)
   const acceptedTos = store.get('acceptedTos', false)
   store.clear()
   store.set('acceptedTos', acceptedTos)

--- a/src/actions/vue/data-store.ts
+++ b/src/actions/vue/data-store.ts
@@ -58,7 +58,6 @@ export const getHardwareDevices = async (network: Network): Promise<HardwareDevi
 }
 
 export const resetStore = (): Promise<string> => new Promise((resolve) => {
-  console.log('other resetStore called in src/actions/vue/data-store')
   resolve(window.ipcRenderer.invoke('reset-store'))
 })
 

--- a/src/actions/vue/data-store.ts
+++ b/src/actions/vue/data-store.ts
@@ -58,6 +58,7 @@ export const getHardwareDevices = async (network: Network): Promise<HardwareDevi
 }
 
 export const resetStore = (): Promise<string> => new Promise((resolve) => {
+  console.log('other resetStore called in src/actions/vue/data-store')
   resolve(window.ipcRenderer.invoke('reset-store'))
 })
 


### PR DESCRIPTION
This PR revises the deletion process so the entire 'wallet.json' file isnt cleared when you delete/restore a wallet.  The 'wallet.json' file holds information about a users wallet such as if they have accepted the 'terms of service'.  Previously, this entire file was cleared which left no memory if whether or not the user has already accepted the terms of service.  As a result, after deleting/refreshing a wallet the terms of service would appear after refresh.  Now, the 'acceptedTos' value is preserved, so when the 'wallet.json' file is cleared, this 'acceptedTos' value is immediately added back to 'wallet.json'.  Whenever a user deletes/restores a wallet, the app now remembers that the user has accepted the terms of service so it is not shown, the enter password view is shown instead.

[See Linear Issue RDX-401 Here](https://linear.app/township/issue/RDX-401/improve-wallet-delete-process)

### Before

https://user-images.githubusercontent.com/83678228/172881043-2b878d21-7d8b-4408-94e8-f5c836ff8027.mp4

### After

https://user-images.githubusercontent.com/83678228/172887936-d12b25e1-80f2-4a31-8565-235ce07de824.mp4

In 'src/actions/electron/data-store.ts`

A variable `acceptedTos` is added to get current value of the `acceptedTos` property inside of the `wallet.json`.  This value is  preserved so that when the wallet is cleared, this value is immediately added back to `wallet.json`, so the app will know if the user has already accepted the terms of service.
```
export const resetStore = (event: IpcMainInvokeEvent): void => {
  const acceptedTos = store.get('acceptedTos', false)
  store.clear()
  store.set('acceptedTos', acceptedTos)
  return
}
```
