### PR TITLE
fix: update function to pass in amount as string

### DIFF
--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -356,7 +356,7 @@ const WalletStaking = defineComponent({
     const compareToMaxUnstakeAmount = () => {
       if (activeForm.value === 'STAKING') return
       const safeAddress = safelyUnwrapValidator(values.validator)
-      const safeAmount = safelyUnwrapAmount(Number(values.amount))
+      const safeAmount = safelyUnwrapAmount(values.amount)
       if (!safeAddress || !safeAmount) return
 
       const activeValidatorStakeAmount = getActiveStakeAmountForValidator(safeAddress)


### PR DESCRIPTION
This PR updates the app to handle the user-entered amount as a `string` rather than a `number`.  The recent change from [this PR](https://github.com/radixdlt/olympia-wallet/pull/455#event-6798032238) handles precision loss. As a result the current build of the app failed, because it still used the amount as a number.  With this change, there is no longer an error upon building the app and I am able to complete a transaction as expected.

[See Linear Issue RDX-403 Here](https://linear.app/township/issue/RDX-403/update-function-to-use-amount-as-string)

### Before
<img width="780" alt="Screen Shot 2022-06-14 at 11 57 21 AM" src="https://user-images.githubusercontent.com/83678228/173622569-27b4715f-4fd6-47ab-8c7b-cba794f21532.png">


### After 

In `WalletStaking.vue`

Inside the `compareToMaxUnstakeAmount` function the `values.amount` was first parsed as a Number and then passed as the parameter to the `safelyUnwrapAmount` function.  I removed this parsing, so the original string is passed in.  

```
const safeAmount = safelyUnwrapAmount(values.amount)
```