### PR TITLE
fix: update error message when ledger is disconnected

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -137,6 +137,7 @@ const messages = {
       ledgerModal: {
         title: 'Ledger Device Disconnected',
         content: 'Unable to decrypt message. Ensure your device is connected or switch accounts to continue.',
+        disconnectedContent: 'Unable to connect to the active account.  Ensure the correct ledger device is connected and active or switch accounts to continue.',
         buttonText: 'Dismiss'
       },
       hardwareWalletAccounts: 'Hardware Wallet Accounts:'

--- a/src/views/Wallet/WalletLedgerDisconnectedModal.vue
+++ b/src/views/Wallet/WalletLedgerDisconnectedModal.vue
@@ -11,7 +11,7 @@
       </svg>
     </template>
     <template v-slot:content>
-      <p class="mb-5">{{ $t('wallet.ledgerModal.content') }}</p>
+      <p class="mb-5">{{ $t('wallet.ledgerModal.disconnectedContent') }}</p>
       <div class="flex flex-row space-x-5 justify-center">
         <AppButtonCancel @click="handleClose" class="w-44">{{ $t('wallet.ledgerModal.buttonText') }}</AppButtonCancel>
       </div>


### PR DESCRIPTION
This PR changes the error message for `Ledger Device Disconnected` modal to be more descriptive.  I added a `disconnectedContent` property to the `index.ts` file in the text folder.  Previously, the error message displayed `Unable to decrypt message` when the user attempted to copy the address for a disconnected ledger.

[See Linear Issue RDX-405](https://linear.app/township/issue/RDX-405/fix-error-message-when-ledger-isnt-connected)

### Before
<img width="1243" alt="Screen Shot 2022-06-24 at 10 38 03 AM" src="https://user-images.githubusercontent.com/83678228/175558447-2c87ad67-da13-48b1-ab55-40221c02935d.png">


### After
<img width="1243" alt="Screen Shot 2022-06-24 at 10 27 00 AM" src="https://user-images.githubusercontent.com/83678228/175557628-6c3eccaf-d1f1-4390-9b75-baeb99ad72fb.png">

