### PR TITLE
feat: show derived accounts that have been hidden

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -307,7 +307,8 @@ const messages = {
       tabTitlePin: 'Change PIN',
       tabTitleMnemonic: 'Reveal Seed Phrase',
       tabTitleTokens: 'Tokens',
-      tabTitleGateway: 'Choose Gateway'
+      tabTitleGateway: 'Choose Gateway',
+      tabTitleShowAccounts: 'Show Accounts'
     },
     errors: {
       hardwareMismatchTitle: 'Hardware Wallet Account Mismatch',

--- a/src/views/Settings/SettingsShowAccounts.vue
+++ b/src/views/Settings/SettingsShowAccounts.vue
@@ -1,6 +1,12 @@
 <template>
-    <div class="bg-white flex flex-col rounded-md w-full mb-60">
-        settings goes here
+    <div class="bg-white flex flex-col rounded-md w-full h-96">
+        <div class="pt-6 px-6 rounded-md">
+            <p>Hidden Accounts</p>
+            <!-- import hiddenAccounts array, -->
+            <!-- loop through each address and display it to the screen with some way to select it,  -->
+            <!-- once selected update set new hidden accounts array,  -->
+            <!-- then get the updated array to auto update the ui  -->
+        </div>
     </div>
 </template>
 

--- a/src/views/Settings/SettingsShowAccounts.vue
+++ b/src/views/Settings/SettingsShowAccounts.vue
@@ -1,0 +1,15 @@
+<template>
+    <div class="bg-white flex flex-col rounded-md w-full mb-60">
+        settings goes here
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  setup () {
+    return {}
+  }
+})
+</script>

--- a/src/views/Settings/index.vue
+++ b/src/views/Settings/index.vue
@@ -32,6 +32,7 @@
             </div>
           </template>
           <settings-select-node v-if="activeTab === 'nodes'" />
+          <settings-show-accounts v-if="activeTab === 'showAccounts'"/>
         </tabs-content>
       </div>
     </div>
@@ -49,6 +50,7 @@ import SettingsRevealMnemonic from './SettingsRevealMnemonic.vue'
 import SettingsResetPassword from './SettingsResetPassword.vue'
 import SettingsSelectNode from './SettingsSelectNode.vue'
 import SettingsTokens from './SettingsTokens.vue'
+import SettingsShowAccounts from './SettingsShowAccounts.vue'
 import WalletLayout from '@/components/WalletLayout.vue'
 import { Ref, ref } from '@nopr3d/vue-next-rx'
 import { useSettingsTab, useWallet } from '@/composables'
@@ -62,6 +64,7 @@ const SettingsIndex = defineComponent({
     SettingsResetPin,
     SettingsRevealMnemonic,
     SettingsSelectNode,
+    SettingsShowAccounts,
     SettingsTokens,
     TabsContent,
     TabsTab,

--- a/src/views/Settings/index.vue
+++ b/src/views/Settings/index.vue
@@ -8,6 +8,7 @@
           <tabs-tab :isActive="activeTab === 'mnemonic'" @click="() => handleClickTab('mnemonic')" :isDisabled="!connected">{{ $t('settings.tabTitleMnemonic') }}</tabs-tab>
           <tabs-tab :isActive="activeTab === 'tokens'" @click="() => handleClickTab('tokens')">{{ $t('settings.tabTitleTokens') }}</tabs-tab>
           <tabs-tab :isActive="activeTab === 'nodes'" @click="() => handleClickTab('nodes')">{{ $t('settings.tabTitleGateway') }}</tabs-tab>
+          <tabs-tab :isActive="activeTab === 'showAccounts'" @click="() => handleClickTab('showAccounts')">Show Accounts</tabs-tab>
         </div>
         <tabs-content :leftTabIsActive="activeTab === 'password'">
           <settings-reset-password

--- a/src/views/Settings/index.vue
+++ b/src/views/Settings/index.vue
@@ -8,7 +8,7 @@
           <tabs-tab :isActive="activeTab === 'mnemonic'" @click="() => handleClickTab('mnemonic')" :isDisabled="!connected">{{ $t('settings.tabTitleMnemonic') }}</tabs-tab>
           <tabs-tab :isActive="activeTab === 'tokens'" @click="() => handleClickTab('tokens')">{{ $t('settings.tabTitleTokens') }}</tabs-tab>
           <tabs-tab :isActive="activeTab === 'nodes'" @click="() => handleClickTab('nodes')">{{ $t('settings.tabTitleGateway') }}</tabs-tab>
-          <tabs-tab :isActive="activeTab === 'showAccounts'" @click="() => handleClickTab('showAccounts')">Show Accounts</tabs-tab>
+          <tabs-tab :isActive="activeTab === 'showAccounts'" @click="() => handleClickTab('showAccounts')">{{ $t('settings.tabTitleShowAccounts')}}</tabs-tab>
         </div>
         <tabs-content :leftTabIsActive="activeTab === 'password'">
           <settings-reset-password


### PR DESCRIPTION
This PR adds the functionality that allows a user to `unhide` an account that they had previously hidden.  A `Show Accounts` tab is added to the `wallet settings` page that shows the addresses of all of the accounts that have been hidden.

[See Linear Issue #RDX-411 Here](https://linear.app/township/issue/RDX-411/show-derived-accounts-that-have-been-hidden)

### Video Demo

### Before
<img width="1217" alt="Screen Shot 2022-07-18 at 12 49 17 PM" src="https://user-images.githubusercontent.com/83678228/179562158-4a353d26-a318-4b87-9f2f-ec15551389dc.png">

### After