### PR TITLE
fix: Remove undefined functions

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -33,9 +33,7 @@ import {
   hideAccount,
   unhideAccount,
   getDecimalType,
-  setDecimalType,
-  setDecimalTypeToUs,
-  setDecimalTypeToEurope
+  setDecimalType
 } from './actions/electron/data-store'
 import { getIsUpdateAvailable, getIsUpdateDownloaded } from './actions/electron/general'
 import { sendAPDU } from './actions/electron/hardware-wallet'
@@ -182,8 +180,6 @@ ipcMain.handle('unhide-accounts', unhideAccount)
 ipcMain.handle('get-decimal-type', getDecimalType)
 ipcMain.handle('set-decimal-type', setDecimalType)
 
-ipcMain.handle('set-decimal-type-to-us', setDecimalTypeToUs)
-ipcMain.handle('set-decimal-type-to-europe', setDecimalTypeToEurope)
 // Exit cleanly on request from parent process in development mode.
 if (isDevelopment) {
   if (process.platform === 'win32') {


### PR DESCRIPTION
Latest has a regression where we're missing two files, causing the background.ts boot to fail.