### PR TITLE
fix: deriving account modal showing during transaction

### DIFF
--- a/src/components/layout/WalletLayout.vue
+++ b/src/components/layout/WalletLayout.vue
@@ -19,7 +19,7 @@
     <wallet-confirm-transaction-modal v-if="shouldShowConfirmation" />
     <wallet-ledger-verify-address-modal v-if="showLedgerVerify && !hardwareError" />
     <wallet-ledger-verify-error-modal v-if="ledgerVerifyError" />
-    <wallet-ledger-interaction-modal v-if="hardwareInteractionState && hardwareInteractionState.length > 0 && hardwareInteractionState != 'error' && transactionState != 'PENDING'" />
+    <wallet-ledger-interaction-modal v-if="hardwareInteractionState && hardwareInteractionState.length > 0 && hardwareInteractionState != 'error' && showDerivingModal" />
     <wallet-ledger-disconnected-modal
       :handleClose="closeModal"
       :hardwareError="hardwareError"
@@ -78,6 +78,7 @@ const WalletIndex = defineComponent({
       showDeleteHWWalletPrompt,
       showDisconnectDeviceModal,
       showHideAccountModal,
+      showDerivingModal,
       showLedgerVerify,
       showNewDevicePopup,
       updateInProcess,
@@ -111,6 +112,7 @@ const WalletIndex = defineComponent({
       ledgerVerifyError,
       shouldShowConfirmation,
       showDeleteHWWalletPrompt,
+      showDerivingModal,
       showDisconnectDeviceModal,
       showHideAccountModal,
       showLedgerVerify,

--- a/src/components/layout/WalletLayout.vue
+++ b/src/components/layout/WalletLayout.vue
@@ -82,7 +82,6 @@ const WalletIndex = defineComponent({
       showLedgerVerify,
       showNewDevicePopup,
       updateInProcess,
-      transactionState,
 
       closeLedgerErrorModal,
       cancelTransaction,
@@ -117,7 +116,6 @@ const WalletIndex = defineComponent({
       showHideAccountModal,
       showLedgerVerify,
       showNewDevicePopup,
-      transactionState,
       updateInProcess,
       walletLoaded,
       closeModal

--- a/src/components/layout/WalletLayout.vue
+++ b/src/components/layout/WalletLayout.vue
@@ -19,7 +19,7 @@
     <wallet-confirm-transaction-modal v-if="shouldShowConfirmation" />
     <wallet-ledger-verify-address-modal v-if="showLedgerVerify && !hardwareError" />
     <wallet-ledger-verify-error-modal v-if="ledgerVerifyError" />
-    <wallet-ledger-interaction-modal v-if="hardwareInteractionState && hardwareInteractionState.length > 0 && hardwareInteractionState != 'error'" />
+    <wallet-ledger-interaction-modal v-if="hardwareInteractionState && hardwareInteractionState.length > 0 && hardwareInteractionState != 'error' && transactionState != 'PENDING'" />
     <wallet-ledger-disconnected-modal
       :handleClose="closeModal"
       :hardwareError="hardwareError"
@@ -81,6 +81,7 @@ const WalletIndex = defineComponent({
       showLedgerVerify,
       showNewDevicePopup,
       updateInProcess,
+      transactionState,
 
       closeLedgerErrorModal,
       cancelTransaction,
@@ -114,6 +115,7 @@ const WalletIndex = defineComponent({
       showHideAccountModal,
       showLedgerVerify,
       showNewDevicePopup,
+      transactionState,
       updateInProcess,
       walletLoaded,
       closeModal

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -176,6 +176,7 @@ userDidCancel.subscribe((didCancel: boolean) => {
     transactionState.value = 'PENDING'
     hardwareError.value = null
     hardwareInteractionState.value = ''
+    showDerivingModal.value = true
   }
 })
 

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -221,10 +221,8 @@ const handleTransactionCompleted = () => {
   cleanupTransactionSubs()
   activeMessage.value = ''
   ledgerState.value = ''
-  // is a transaction always pending after the transaction is complete ??
-  console.log('BEFORE...', transactionState.value)
-  transactionState.value = ''
-  console.log('AFTER...', transactionState.value)
+  transactionState.value = 'PENDING'
+  showDerivingModal.value = true
 
   router.push(`/wallet/${activeAddress.value?.toString()}/history`)
 }

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -150,6 +150,7 @@ const transactionError: Ref<Error | null> = ref(null)
 const userDidConfirm = new Subject<boolean>()
 const userDidCancel = new Subject<boolean>()
 const userConfirmation = new ReplaySubject<ManualUserConfirmTX>()
+const showDerivingModal: Ref<boolean> = ref(true)
 
 userConfirmation
   .pipe(
@@ -220,7 +221,10 @@ const handleTransactionCompleted = () => {
   cleanupTransactionSubs()
   activeMessage.value = ''
   ledgerState.value = ''
-  transactionState.value = 'PENDING'
+  // is a transaction always pending after the transaction is complete ??
+  console.log('BEFORE...', transactionState.value)
+  transactionState.value = ''
+  console.log('AFTER...', transactionState.value)
 
   router.push(`/wallet/${activeAddress.value?.toString()}/history`)
 }
@@ -409,6 +413,7 @@ interface useWalletInterface {
   readonly showDisconnectDeviceModal: ComputedRef<boolean>;
   readonly showNewDevicePopup: Ref<boolean>;
   readonly shouldShowMaxUnstakeConfirmation: Ref<boolean>;
+  readonly showDerivingModal: Ref<boolean>;
   readonly showLedgerVerify: Ref<boolean>;
   readonly switching: ComputedRef<boolean>;
   readonly updateAvailable: Ref<boolean>;
@@ -853,6 +858,7 @@ export default function useWallet (router: Router): useWalletInterface {
     selectedCurrency,
     shouldShowConfirmation,
     shouldShowMaxUnstakeConfirmation,
+    showDerivingModal,
     stakeInput,
     unstakeInput,
     transactionError,

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -281,7 +281,6 @@ const WalletTransaction = defineComponent({
     }
 
     const handleSubmit = async () => {
-      console.log('send transaction pressed')
       showDerivingModal.value = false
 
       if (!meta.value.valid || !selectedCurrency.value) return false

--- a/src/views/Wallet/WalletTransaction.vue
+++ b/src/views/Wallet/WalletTransaction.vue
@@ -166,7 +166,7 @@ const WalletTransaction = defineComponent({
   setup () {
     const router = useRouter()
     const { errors, values, meta, setErrors, resetForm } = useForm<TransactionForm>()
-    const { transferTokens, cancelTransaction, userDidCancel, setActiveTransactionForm, activeAddress, nativeToken, networkPreamble, radix } = useWallet(router)
+    const { transferTokens, cancelTransaction, userDidCancel, setActiveTransactionForm, activeAddress, nativeToken, networkPreamble, radix, showDerivingModal } = useWallet(router)
     const { t } = useI18n({ useScope: 'global' })
     const { tokenInfoFor, fetchBalancesForAddress, tokenBalances, tokenBalanceFor, tokenBalanceForByString } = useTokenBalances(radix)
     const currency: Ref<string | null> = ref(null)
@@ -281,6 +281,9 @@ const WalletTransaction = defineComponent({
     }
 
     const handleSubmit = async () => {
+      console.log('send transaction pressed')
+      showDerivingModal.value = false
+
       if (!meta.value.valid || !selectedCurrency.value) return false
       const safeAddress = safelyUnwrapAddress(values.recipient, networkPreamble.value)
       const safeAmount = safelyUnwrapAmount(values.amount)


### PR DESCRIPTION
This PR adds another conditional to the 'wallet-ledger-interaction-modal' so that the 'deriving account' modal isnt showing if the user has initiated a send tokens transaction.  

This may be a fix for [Linear Ticket RDX-440](https://linear.app/township/issue/RDX-440)