### PR TITLE
fix: Create a new HardwareWalletLedger on every ledger interaction

### DIFF
--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -119,9 +119,6 @@ const unstakeInput: Ref<UnstakeTokensInput | null> = ref(null)
 const transactionErrorMessage: Ref<string | null> = ref(null)
 const transactionFee: Ref<AmountT | null> = ref(null)
 const transferInput: Ref<TransferTokensInput | null> = ref(null)
-const hardwareWalletConnection = HardwareWalletLedger.create({
-  send: sendAPDU
-})
 
 const setWallet = (newWallet: WalletT) => {
   wallet.value = newWallet
@@ -590,7 +587,9 @@ const createNewHardwareAccount = async () => {
       keyDerivation: HDPathRadix.create({
         address: { index: 0, isHardened: true }
       }),
-      hardwareWalletConnection,
+      hardwareWalletConnection: HardwareWalletLedger.create({
+        send: sendAPDU
+      }),
       alsoSwitchTo: false,
       verificationPrompt: false
     }))
@@ -605,10 +604,14 @@ const createNewHardwareAccount = async () => {
         keyDerivation: HDPathRadix.create({
           address: { index: newIndex, isHardened: true }
         }),
-        hardwareWalletConnection,
+        hardwareWalletConnection: HardwareWalletLedger.create({
+          send: sendAPDU
+        }),
         alsoSwitchTo: false,
         verificationPrompt: false
       }))
+
+      const newAccountName = `Hardware Account ${newIndex + 1}`
 
       newHardwareDevices = hardwareDevices.value.map((hwd) => {
         if (hwd.name !== hardwareDevice.name) return hwd
@@ -652,7 +655,9 @@ const connectHardwareWallet = async (hwaddr: HardwareAddress): Promise<AccountT 
       keyDerivation: HDPathRadix.create({
         address: { index: hwaddr.index, isHardened: true }
       }),
-      hardwareWalletConnection,
+      hardwareWalletConnection: HardwareWalletLedger.create({
+        send: sendAPDU
+      }),
       alsoSwitchTo: true,
       verificationPrompt: false
     }))


### PR DESCRIPTION
Reverts an earlier change that was introduced while debugging occasional
duplicate ledger messages [solved in
radixdlt-javascript#203](https://github.com/radixdlt/radixdlt-javascript/pull/203).

If the ledger falls asleep, the wallet should be able to reconnect to it.


**Steps to replicate**
1.  Connect a ledger and send a transaction from that account
2. Let the ledger fall asleep by waiting
3. Reactivate the ledger and reenter your pin
4. Send another transaction from a ledger account, if fixed it will work.