### PR TITLE
fix: Always close a ledger connection correctly

### DIFF
--- a/src/actions/electron/hardware-wallet.ts
+++ b/src/actions/electron/hardware-wallet.ts
@@ -8,13 +8,15 @@ export const sendAPDU = async (event: IpcMainInvokeEvent, apdu: APDU) => {
   if (paths.length === 0) throw Error('No device found.')
   if (paths.length > 1) throw Error('Too Many Devices Enabled')
   let result
+  const transport = await TransportNodeHid.open(paths[0])
   try {
-    const transport = await TransportNodeHid.open(paths[0])
     result = await transport.send(apdu.cla, apdu.ins, apdu.p1, apdu.p2, apdu.data ? Buffer.from(apdu.data, 'hex') : undefined)
     await transport.close()
   } catch (e) {
+    await transport.close()
+    console.error(e)
     throw e
   }
-
+  await transport.close()
   return result
 }

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -265,7 +265,7 @@ const errorHandler = (err: any) => {
       }
     })
     cancelTransaction()
-  } else if (err.toString().indexOf('Error: Failed to sign tx with Ledger') >= 0 && err.toString().includes('(0x6985')) {
+  } else if (err.toString().indexOf('Failed to sign tx with Ledger') >= 0 && err.toString().includes('(0x6985')) {
     setError({
       ...err,
       type: 'HARDWARE',
@@ -274,7 +274,7 @@ const errorHandler = (err: any) => {
       }
     })
     cancelTransaction()
-  } else if (err.toString().indexOf('Error: Failed to sign tx with Ledger') >= 0 && err.toString().includes('(0x530c')) {
+  } else if (err.toString().indexOf('Failed to sign tx with Ledger') >= 0 && err.toString().includes('(0x530c')) {
     setError({
       ...err,
       type: 'HARDWARE',


### PR DESCRIPTION
[Linear Issue](https://linear.app/township/issue/RDX-447)

This PR fixes a regression where if a user rejected a transaction on the ledger, the ledger would become unavailable until restarting the server.

This occurred because the connection was left open after an unexpected response from the device.
