### PR TITLE
chore: add condition to decrypting modal body copy

### DIFF
--- a/src/components/modals/WalletConfirmTransactionModal.vue
+++ b/src/components/modals/WalletConfirmTransactionModal.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="fixed w-screen h-screen z-20 flex items-center justify-center bg-translucent-black">
     <div class="h-modalMedium bg-white rounded-md py-7 px-7 w-full max-w-3xl absolute top-1/2 left-1/2 transform -translate-x-1/3 -translate-y-1/2">
-     <div v-if="shouldShowEncryptionModal && showWalletConfirmTransactionModal">
+     <div v-if="shouldShowEncryptionModal && isHardwareAccount">
         <div class="bg-white h-full flex flex-col flex-1 w-full justify-around box-border mt-52">
           <svg width="40" height="40" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" class="container animate-spin">
             <path fill-rule="evenodd" clip-rule="evenodd" d="M77.8789 52.8857C72.5168 68.6526 57.5862 80.0002 40.0001 80.0002C29.2115 80.0002 19.417 75.7265 12.2241 68.7838L14.9924 65.9158C21.4721 72.1701 30.2851 76.0141 40.0001 76.0141C55.8278 76.0141 69.2758 65.8025 74.1051 51.6023L77.8789 52.8857Z" fill="#052CC0"/>
@@ -145,7 +145,7 @@
           </div>
         </div>
       </form>
-      <div v-else>
+      <div v-if="isHardwareAccount">
         <div class="bg-white h-full flex flex-col flex-1 w-full justify-around box-border mt-52">
           <svg width="40" height="40" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" class="container animate-spin">
             <path fill-rule="evenodd" clip-rule="evenodd" d="M77.8789 52.8857C72.5168 68.6526 57.5862 80.0002 40.0001 80.0002C29.2115 80.0002 19.417 75.7265 12.2241 68.7838L14.9924 65.9158C21.4721 72.1701 30.2851 76.0141 40.0001 76.0141C55.8278 76.0141 69.2758 65.8025 74.1051 51.6023L77.8789 52.8857Z" fill="#052CC0"/>
@@ -212,7 +212,7 @@ const WalletConfirmTransactionModal = defineComponent({
       transactionState,
       transferInput,
       selectedCurrency,
-      showWalletConfirmTransactionModal,
+      isHardwareAccount,
       activeAddresIsSoftwareAccount
     } = useWallet(router)
     const { tokenBalances, tokenBalanceFor, tokenInfoFor } = useTokenBalances(radix)
@@ -388,7 +388,7 @@ const WalletConfirmTransactionModal = defineComponent({
       shouldShowEncryptionModal,
       shouldShowLedgerModal,
       shouldShowMaxUnstakeConfirmation,
-      showWalletConfirmTransactionModal,
+      isHardwareAccount,
       stakeInput,
       unstakeInput,
       toContent,

--- a/src/components/modals/WalletConfirmTransactionModal.vue
+++ b/src/components/modals/WalletConfirmTransactionModal.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="fixed w-screen h-screen z-20 flex items-center justify-center bg-translucent-black">
     <div class="h-modalMedium bg-white rounded-md py-7 px-7 w-full max-w-3xl absolute top-1/2 left-1/2 transform -translate-x-1/3 -translate-y-1/2">
-     <div v-if="shouldShowEncryptionModal">
+     <div v-if="shouldShowEncryptionModal && showWalletConfirmTransactionModal">
         <div class="bg-white h-full flex flex-col flex-1 w-full justify-around box-border mt-52">
           <svg width="40" height="40" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" class="container animate-spin">
             <path fill-rule="evenodd" clip-rule="evenodd" d="M77.8789 52.8857C72.5168 68.6526 57.5862 80.0002 40.0001 80.0002C29.2115 80.0002 19.417 75.7265 12.2241 68.7838L14.9924 65.9158C21.4721 72.1701 30.2851 76.0141 40.0001 76.0141C55.8278 76.0141 69.2758 65.8025 74.1051 51.6023L77.8789 52.8857Z" fill="#052CC0"/>
@@ -211,9 +211,13 @@ const WalletConfirmTransactionModal = defineComponent({
       transactionFee,
       transactionState,
       transferInput,
-      selectedCurrency
+      selectedCurrency,
+      showWalletConfirmTransactionModal,
+      activeAddresIsSoftwareAccount
     } = useWallet(router)
     const { tokenBalances, tokenBalanceFor, tokenInfoFor } = useTokenBalances(radix)
+
+    activeAddresIsSoftwareAccount()
 
     const subs = new Subscription()
     const loading = ref(true)
@@ -384,6 +388,7 @@ const WalletConfirmTransactionModal = defineComponent({
       shouldShowEncryptionModal,
       shouldShowLedgerModal,
       shouldShowMaxUnstakeConfirmation,
+      showWalletConfirmTransactionModal,
       stakeInput,
       unstakeInput,
       toContent,

--- a/src/components/modals/WalletConfirmTransactionModal.vue
+++ b/src/components/modals/WalletConfirmTransactionModal.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="fixed w-screen h-screen z-20 flex items-center justify-center bg-translucent-black">
-    <div class=" h-modalMedium bg-red-500 rounded-md py-7 px-7 w-full max-w-3xl absolute top-1/2 left-1/2 transform -translate-x-1/3 -translate-y-1/2">
-     <div v-if="shouldShowEncryptionModal && isHardwareAccount">
+    <div class="h-modalMedium bg-white rounded-md py-7 px-7 w-full max-w-3xl absolute top-1/2 left-1/2 transform -translate-x-1/3 -translate-y-1/2">
+     <div v-if="shouldShowEncryptionModal">
         <div class="bg-white h-full flex flex-col flex-1 w-full justify-around box-border mt-52">
           <svg width="40" height="40" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" class="container animate-spin">
             <path fill-rule="evenodd" clip-rule="evenodd" d="M77.8789 52.8857C72.5168 68.6526 57.5862 80.0002 40.0001 80.0002C29.2115 80.0002 19.417 75.7265 12.2241 68.7838L14.9924 65.9158C21.4721 72.1701 30.2851 76.0141 40.0001 76.0141C55.8278 76.0141 69.2758 65.8025 74.1051 51.6023L77.8789 52.8857Z" fill="#052CC0"/>
@@ -145,7 +145,7 @@
           </div>
         </div>
       </form>
-      <div v-else-if="isHardwareAccount">
+      <div v-else>
         <div class="bg-white h-full flex flex-col flex-1 w-full justify-around box-border mt-52">
           <svg width="40" height="40" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" class="container animate-spin">
             <path fill-rule="evenodd" clip-rule="evenodd" d="M77.8789 52.8857C72.5168 68.6526 57.5862 80.0002 40.0001 80.0002C29.2115 80.0002 19.417 75.7265 12.2241 68.7838L14.9924 65.9158C21.4721 72.1701 30.2851 76.0141 40.0001 76.0141C55.8278 76.0141 69.2758 65.8025 74.1051 51.6023L77.8789 52.8857Z" fill="#052CC0"/>
@@ -158,7 +158,6 @@
           <div class="text-center mt-4 text-rGrayDark text-sm">{{ $t(`confirmation.transactionState.${transactionState}`) }}</div>
         </div>
       </div>
-      <div v-else></div>
     </div>
   </div>
 </template>
@@ -292,11 +291,11 @@ const WalletConfirmTransactionModal = defineComponent({
     })
 
     const shouldShowBuildingModal: ComputedRef<boolean> = computed(() =>
-      transactionState.value === 'INITIATED' || transactionState.value === 'BUILT_FROM_INTENT'
+      transactionState.value === 'INITIATED' || transactionState.value === 'BUILT_FROM_INTENT' || transactionState.value === 'PENDING'
     )
 
     const shouldShowEncryptionModal: ComputedRef<boolean> = computed(() => {
-      return transactionState.value === 'PENDING'
+      return transactionState.value === 'PENDING' && isHardwareAccount.value
     })
 
     // Show ledger modal when hw-signing is in progress and the transaction is CONFIRMED

--- a/src/components/modals/WalletConfirmTransactionModal.vue
+++ b/src/components/modals/WalletConfirmTransactionModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="fixed w-screen h-screen z-20 flex items-center justify-center bg-translucent-black">
-    <div class="h-modalMedium bg-white rounded-md py-7 px-7 w-full max-w-3xl absolute top-1/2 left-1/2 transform -translate-x-1/3 -translate-y-1/2">
+    <div class=" h-modalMedium bg-red-500 rounded-md py-7 px-7 w-full max-w-3xl absolute top-1/2 left-1/2 transform -translate-x-1/3 -translate-y-1/2">
      <div v-if="shouldShowEncryptionModal && isHardwareAccount">
         <div class="bg-white h-full flex flex-col flex-1 w-full justify-around box-border mt-52">
           <svg width="40" height="40" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" class="container animate-spin">
@@ -145,7 +145,7 @@
           </div>
         </div>
       </form>
-      <div v-if="isHardwareAccount">
+      <div v-else-if="isHardwareAccount">
         <div class="bg-white h-full flex flex-col flex-1 w-full justify-around box-border mt-52">
           <svg width="40" height="40" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" class="container animate-spin">
             <path fill-rule="evenodd" clip-rule="evenodd" d="M77.8789 52.8857C72.5168 68.6526 57.5862 80.0002 40.0001 80.0002C29.2115 80.0002 19.417 75.7265 12.2241 68.7838L14.9924 65.9158C21.4721 72.1701 30.2851 76.0141 40.0001 76.0141C55.8278 76.0141 69.2758 65.8025 74.1051 51.6023L77.8789 52.8857Z" fill="#052CC0"/>
@@ -158,6 +158,7 @@
           <div class="text-center mt-4 text-rGrayDark text-sm">{{ $t(`confirmation.transactionState.${transactionState}`) }}</div>
         </div>
       </div>
+      <div v-else></div>
     </div>
   </div>
 </template>

--- a/src/components/modals/WalletLedgerInteractionModal.vue
+++ b/src/components/modals/WalletLedgerInteractionModal.vue
@@ -35,8 +35,11 @@ const WalletLedgerInteractionModal = defineComponent({
       hideLedgerInteraction,
       cancelTransaction,
       hardwareInteractionState,
-      showLedgerInteractionModalBody
+      showLedgerInteractionModalBody,
+      isSoftwareAccount
     } = useWallet(router)
+
+    isSoftwareAccount()
 
     const interactionTitle: ComputedRef<string> = computed(() => {
       if (hardwareInteractionState.value === '') return ''

--- a/src/components/modals/WalletLedgerInteractionModal.vue
+++ b/src/components/modals/WalletLedgerInteractionModal.vue
@@ -11,7 +11,7 @@
           <div class="text-center mt-8 text-rGrayDark text-lg">
             {{interactionTitle}}
           </div>
-          <div class="text-center mt-4 text-rBlack text-sm">
+          <div v-if="showLedgerInteractionModalBody" class="text-center mt-4 text-rBlack text-sm">
             {{interactionBody}}
           </div>
         </div>
@@ -34,7 +34,8 @@ const WalletLedgerInteractionModal = defineComponent({
     const {
       hideLedgerInteraction,
       cancelTransaction,
-      hardwareInteractionState
+      hardwareInteractionState,
+      showLedgerInteractionModalBody
     } = useWallet(router)
 
     const interactionTitle: ComputedRef<string> = computed(() => {
@@ -51,6 +52,7 @@ const WalletLedgerInteractionModal = defineComponent({
       hideLedgerInteraction,
       interactionTitle,
       interactionBody,
+      showLedgerInteractionModalBody,
       close () {
         hideLedgerInteraction()
         cancelTransaction()

--- a/src/components/modals/WalletLedgerInteractionModal.vue
+++ b/src/components/modals/WalletLedgerInteractionModal.vue
@@ -36,10 +36,10 @@ const WalletLedgerInteractionModal = defineComponent({
       cancelTransaction,
       hardwareInteractionState,
       showLedgerInteractionModalBody,
-      isSoftwareAccount
+      activeAddresIsSoftwareAccount
     } = useWallet(router)
 
-    isSoftwareAccount()
+    activeAddresIsSoftwareAccount()
 
     const interactionTitle: ComputedRef<string> = computed(() => {
       if (hardwareInteractionState.value === '') return ''

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -105,11 +105,9 @@ const wallet: Ref<WalletT | null> = ref(null)
 const latestAddress: Ref<string> = ref('')
 const loadingLatestAddress: Ref<boolean> = ref(true)
 const transactionSubs = new Subscription()
-
 const activeMessage: Ref<string> = ref('')
 const activeMessageInTransaction: Ref<MessageInTransaction | null> = ref(null)
 const activeTransactionForm: Ref<string | null> = ref(null)
-
 const selectedCurrency: Ref<Decoded.TokenAmount | null> = ref(null)
 const shouldShowConfirmation: Ref<boolean> = ref(false)
 const shouldShowMaxUnstakeConfirmation: Ref<boolean> = ref(false)
@@ -120,7 +118,7 @@ const transactionErrorMessage: Ref<string | null> = ref(null)
 const transactionFee: Ref<AmountT | null> = ref(null)
 const transferInput: Ref<TransferTokensInput | null> = ref(null)
 const showLedgerInteractionModalBody: Ref<boolean> = ref(true)
-const showWalletConfirmTransactionModal: Ref<boolean> = ref(true)
+const isHardwareAccount: Ref<boolean> = ref(false)
 
 // check if software or hardware address
 const activeAddresIsSoftwareAccount = () => {
@@ -133,10 +131,10 @@ const activeAddresIsSoftwareAccount = () => {
     })
   if (hardwareAddress) {
     showLedgerInteractionModalBody.value = true
-    showWalletConfirmTransactionModal.value = true
+    isHardwareAccount.value = true
   } else {
     showLedgerInteractionModalBody.value = false
-    showWalletConfirmTransactionModal.value = false
+    isHardwareAccount.value = false
   }
   // hardwareAddress ? showLedgerInteractionModalBody.value = true : showLedgerInteractionModalBody.value = false
 }
@@ -432,7 +430,7 @@ interface useWalletInterface {
   readonly showNewDevicePopup: Ref<boolean>;
   readonly showLedgerInteractionModalBody: Ref<boolean>;
   readonly shouldShowMaxUnstakeConfirmation: Ref<boolean>;
-  readonly showWalletConfirmTransactionModal: Ref<boolean>;
+  readonly isHardwareAccount: Ref<boolean>;
   readonly showDerivingModal: Ref<boolean>;
   readonly showLedgerVerify: Ref<boolean>;
   readonly switching: ComputedRef<boolean>;
@@ -892,7 +890,7 @@ export default function useWallet (router: Router): useWalletInterface {
     shouldShowMaxUnstakeConfirmation,
     showDerivingModal,
     showLedgerInteractionModalBody,
-    showWalletConfirmTransactionModal,
+    isHardwareAccount,
     stakeInput,
     unstakeInput,
     transactionError,

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -130,8 +130,6 @@ const isSoftwareAccount = () => {
       if (!activeAddress.value) return false
       return addr.address.equals(activeAddress.value)
     })
-  // console.log('hardwareAddress-->', hardwareAddress?.address.toString())
-  // console.log('active address--->', activeAddress.value?.toString())
   hardwareAddress ? showLedgerInteractionModalBody.value = true : showLedgerInteractionModalBody.value = false
 }
 

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -130,8 +130,8 @@ const isSoftwareAccount = () => {
       if (!activeAddress.value) return false
       return addr.address.equals(activeAddress.value)
     })
-  console.log('hardwareAddress-->', hardwareAddress?.address.toString())
-  console.log('active address--->', activeAddress.value?.toString())
+  // console.log('hardwareAddress-->', hardwareAddress?.address.toString())
+  // console.log('active address--->', activeAddress.value?.toString())
   hardwareAddress ? showLedgerInteractionModalBody.value = true : showLedgerInteractionModalBody.value = false
 }
 
@@ -455,7 +455,6 @@ interface useWalletInterface {
   stakeTokens: (input: StakeTokensInput) => void;
   transferTokens: (input: TransferTokensInput, message: MessageInTransaction, sc: Decoded.TokenAmount) => void;
   unstakeTokens: (input: UnstakeTokensInput) => void;
-
   accountNameFor: (address: AccountAddressT) => string;
   accountRenamed: (newName: string) => void;
   addAccount: () => Promise<AccountT | false>;
@@ -490,6 +489,7 @@ interface useWalletInterface {
   createNewHardwareAccount: () => void;
   closeLedgerErrorModal: () => void;
   setDecimalType: (decimalType: string) => void;
+  isSoftwareAccount: () => void;
 }
 
 const walletLoaded = async () => {
@@ -947,6 +947,7 @@ export default function useWallet (router: Router): useWalletInterface {
     createWallet,
     hideLedgerInteraction,
     initWallet,
+    isSoftwareAccount,
     persistNodeUrl,
     setActiveAddress,
     setHideAccountModal,

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -136,7 +136,6 @@ const activeAddresIsSoftwareAccount = () => {
     showLedgerInteractionModalBody.value = false
     isHardwareAccount.value = false
   }
-  // hardwareAddress ? showLedgerInteractionModalBody.value = true : showLedgerInteractionModalBody.value = false
 }
 
 const setWallet = (newWallet: WalletT) => {

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -119,6 +119,21 @@ const unstakeInput: Ref<UnstakeTokensInput | null> = ref(null)
 const transactionErrorMessage: Ref<string | null> = ref(null)
 const transactionFee: Ref<AmountT | null> = ref(null)
 const transferInput: Ref<TransferTokensInput | null> = ref(null)
+const showLedgerInteractionModalBody: Ref<boolean> = ref(true)
+
+// check if software or hardware address
+const isSoftwareAccount = () => {
+  const hardwareAddress =
+  hardwareDevices.value
+    .flatMap((device) => device.addresses)
+    .find((addr: HardwareAddress) => {
+      if (!activeAddress.value) return false
+      return addr.address.equals(activeAddress.value)
+    })
+  console.log('hardwareAddress-->', hardwareAddress?.address.toString())
+  console.log('active address--->', activeAddress.value?.toString())
+  hardwareAddress ? showLedgerInteractionModalBody.value = true : showLedgerInteractionModalBody.value = false
+}
 
 const setWallet = (newWallet: WalletT) => {
   wallet.value = newWallet
@@ -409,6 +424,7 @@ interface useWalletInterface {
   readonly showHideAccountModal: Ref<boolean>;
   readonly showDisconnectDeviceModal: ComputedRef<boolean>;
   readonly showNewDevicePopup: Ref<boolean>;
+  readonly showLedgerInteractionModalBody: Ref<boolean>;
   readonly shouldShowMaxUnstakeConfirmation: Ref<boolean>;
   readonly showDerivingModal: Ref<boolean>;
   readonly showLedgerVerify: Ref<boolean>;
@@ -868,6 +884,7 @@ export default function useWallet (router: Router): useWalletInterface {
     shouldShowConfirmation,
     shouldShowMaxUnstakeConfirmation,
     showDerivingModal,
+    showLedgerInteractionModalBody,
     stakeInput,
     unstakeInput,
     transactionError,

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -120,6 +120,7 @@ const transactionErrorMessage: Ref<string | null> = ref(null)
 const transactionFee: Ref<AmountT | null> = ref(null)
 const transferInput: Ref<TransferTokensInput | null> = ref(null)
 const showLedgerInteractionModalBody: Ref<boolean> = ref(true)
+const showWalletConfirmTransactionModal: Ref<boolean> = ref(true)
 
 // check if software or hardware address
 const activeAddresIsSoftwareAccount = () => {
@@ -130,7 +131,14 @@ const activeAddresIsSoftwareAccount = () => {
       if (!activeAddress.value) return false
       return addr.address.equals(activeAddress.value)
     })
-  hardwareAddress ? showLedgerInteractionModalBody.value = true : showLedgerInteractionModalBody.value = false
+  if (hardwareAddress) {
+    showLedgerInteractionModalBody.value = true
+    showWalletConfirmTransactionModal.value = true
+  } else {
+    showLedgerInteractionModalBody.value = false
+    showWalletConfirmTransactionModal.value = false
+  }
+  // hardwareAddress ? showLedgerInteractionModalBody.value = true : showLedgerInteractionModalBody.value = false
 }
 
 const setWallet = (newWallet: WalletT) => {
@@ -424,6 +432,7 @@ interface useWalletInterface {
   readonly showNewDevicePopup: Ref<boolean>;
   readonly showLedgerInteractionModalBody: Ref<boolean>;
   readonly shouldShowMaxUnstakeConfirmation: Ref<boolean>;
+  readonly showWalletConfirmTransactionModal: Ref<boolean>;
   readonly showDerivingModal: Ref<boolean>;
   readonly showLedgerVerify: Ref<boolean>;
   readonly switching: ComputedRef<boolean>;
@@ -883,6 +892,7 @@ export default function useWallet (router: Router): useWalletInterface {
     shouldShowMaxUnstakeConfirmation,
     showDerivingModal,
     showLedgerInteractionModalBody,
+    showWalletConfirmTransactionModal,
     stakeInput,
     unstakeInput,
     transactionError,

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -122,7 +122,7 @@ const transferInput: Ref<TransferTokensInput | null> = ref(null)
 const showLedgerInteractionModalBody: Ref<boolean> = ref(true)
 
 // check if software or hardware address
-const isSoftwareAccount = () => {
+const activeAddresIsSoftwareAccount = () => {
   const hardwareAddress =
   hardwareDevices.value
     .flatMap((device) => device.addresses)
@@ -487,7 +487,7 @@ interface useWalletInterface {
   createNewHardwareAccount: () => void;
   closeLedgerErrorModal: () => void;
   setDecimalType: (decimalType: string) => void;
-  isSoftwareAccount: () => void;
+  activeAddresIsSoftwareAccount: () => void;
 }
 
 const walletLoaded = async () => {
@@ -945,7 +945,7 @@ export default function useWallet (router: Router): useWalletInterface {
     createWallet,
     hideLedgerInteraction,
     initWallet,
-    isSoftwareAccount,
+    activeAddresIsSoftwareAccount,
     persistNodeUrl,
     setActiveAddress,
     setHideAccountModal,


### PR DESCRIPTION
This PR adds a conditional to the body of the 'Decrypting Message' modal that differentiates between a software and hardware account, so the the body is only shown when the active account is a hardware account.

Update:
I renamed the 'isSoftwareAccount' function to 'activeAddresIsSoftwareAccount' per Scott's suggestion and ensured the 'Submitting Transactions' modal is only shown at the end of a send tokens transaction, 

[See Linear Ticket RDX-448](https://linear.app/township/issue/RDX-448)