### PR TITLE
fix: removing validator address doesn't disable 'Unstake' button

### DIFF
--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -350,7 +350,6 @@ const WalletStaking = defineComponent({
     }
 
     const checkForEmptyValidator = () => {
-      // if user removes validator address
       const validator = safelyUnwrapValidator(values.validator)
       validateField('validator')
       if (!validator) {

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -350,12 +350,11 @@ const WalletStaking = defineComponent({
     }
 
     const checkForEmptyValidator = () => {
-      console.log('this code is run')
       // if user removes validator address
       const validator = safelyUnwrapValidator(values.validator)
-      console.log(validator)
       validateField('validator')
       if (!validator) {
+        setMaxUnstakeOff()
         setMaxUnstakeNotifcationOff()
         setMaxUnstakeOverageNotifcationOff()
       }

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -51,6 +51,7 @@
               :placeholder="$t('staking.validatorPlaceholder')"
               rules="required|validValidator"
               :validateOnInput="true"
+              @input="checkForEmptyValidator"
             />
             <FormErrorMessage name="validator" class="text-sm text-red-400" />
           </div>
@@ -348,6 +349,18 @@ const WalletStaking = defineComponent({
       validateField('validator')
     }
 
+    const checkForEmptyValidator = () => {
+      console.log('this code is run')
+      // if user removes validator address
+      const validator = safelyUnwrapValidator(values.validator)
+      console.log(validator)
+      validateField('validator')
+      if (!validator) {
+        setMaxUnstakeNotifcationOff()
+        setMaxUnstakeOverageNotifcationOff()
+      }
+    }
+
     const compareToMaxUnstakeAmount = () => {
       if (activeForm.value === 'STAKING') return
       const safeAddress = safelyUnwrapValidator(values.validator)
@@ -465,6 +478,7 @@ const WalletStaking = defineComponent({
       const safeAddress = safelyUnwrapValidator(values.validator)
       if (!safeAddress) return ''
       const v = maybeGetValidator(safeAddress)
+      console.log(v, v?.name)
       return v ? v.name : ''
     })
 
@@ -509,7 +523,8 @@ const WalletStaking = defineComponent({
       setForm,
       setMaxUnstakeOff,
       setMaxUnstakeOn,
-      compareToMaxUnstakeAmount
+      compareToMaxUnstakeAmount,
+      checkForEmptyValidator
     }
   }
 })

--- a/src/views/Wallet/WalletStaking.vue
+++ b/src/views/Wallet/WalletStaking.vue
@@ -476,7 +476,6 @@ const WalletStaking = defineComponent({
       const safeAddress = safelyUnwrapValidator(values.validator)
       if (!safeAddress) return ''
       const v = maybeGetValidator(safeAddress)
-      console.log(v, v?.name)
       return v ? v.name : ''
     })
 


### PR DESCRIPTION
This PR adds an onChange handler 'checkForEmptyValidator' that checks if the user changed the validator input. Previously the user could fill both the validator and amount in, then if the validator address was removed, the 'Request Unstake' button did not go back to a disabled state.  As a result, the user could click this button and nothing would happen.

[See Linear Ticket RDX-450 Here](https://linear.app/township/issue/RDX-450)