### PR TITLE
fix: User should not be able to submit a transaction with a blank encrypted message

### DIFF
--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -22,7 +22,8 @@ const messages = {
       transactionFailed: 'Your transaction failed. Check that you have sufficient XRD to cover the transfer plus fee.',
       stakeFailed: 'Your transaction failed. Check that you have sufficient XRD to cover your stake plus fee.',
       unstakeFailed: 'Your transaction failed. Check that you are not unstaking more than your total current stake and that you have sufficient XRD to cover the fee.',
-      pinMatch: 'Your new pin doesn\'t match'
+      pinMatch: 'Your new pin doesn\'t match',
+      messageRequired: 'You must add a message to be able to encrypt it'
     },
     home: {
       welcomeOne: 'Welcome to the Radix Olympia Desktop Wallet.',


### PR DESCRIPTION
- fix: ErrorModalApi is catching all generic errors
- fix: add an error message when a user has selected to encrypt a message but has not entered a message
