### PR TITLE
fix: remove disabled cursor

### DIFF
--- a/src/views/Settings/SettingsSelectDecimal.vue
+++ b/src/views/Settings/SettingsSelectDecimal.vue
@@ -8,7 +8,6 @@
             <div class="flex items-center w-full">
               <AppRadioIndicator
                 :enabled="decimalType === 'us'"
-                :disabled="decimalType !== 'us'"
                 class="mr-2 cursor-pointer "
                 @click="setDecimalType('us')"
                 />
@@ -20,7 +19,6 @@
             <div class="flex items-center">
               <AppRadioIndicator
               :enabled="decimalType === 'europe'"
-              :disabled="decimalType !== 'europe'"
               class="mr-2 cursor-pointer"
               @click="setDecimalType('europe')"
               />


### PR DESCRIPTION
This PR removes the disabled cursor from the radio buttons in the 'Display' tab.

[See Linear Ticket RDX-455](https://linear.app/township/issue/RDX-455)