### PR TITLE
fix: error thrown when user has been idle

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -101,10 +101,8 @@ let idleInterval = setInterval(() => {
 
   const currentURL = win.webContents.getURL()
   if (currentURL.includes('wallet')) {
-    console.log('user logged in!')
     win.reload()
   }
-  console.log('user is not logged in!')
 }, INACTIVITY_INTERVAL)
 
 const resetInteractionTimer = () => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,6 +1,6 @@
 'use strict'
 
-import electron, { app, ipcMain, protocol, BrowserWindow, powerMonitor, webContents } from 'electron'
+import electron, { app, ipcMain, protocol, BrowserWindow, webContents } from 'electron'
 import { createProtocol } from 'vue-cli-plugin-electron-builder/lib'
 import installExtension, { VUEJS_DEVTOOLS } from 'electron-devtools-installer'
 import path from 'path'

--- a/src/background.ts
+++ b/src/background.ts
@@ -90,7 +90,7 @@ async function createWindow () {
   }
 }
 
-const INACTIVITY_INTERVAL = 10000 // in ms = 1hr
+const INACTIVITY_INTERVAL = 3600000 // in ms = 1hr
 const DEBOUNCE_INTERVAL = 1000
 
 // Set interaction detection time period to 1hr. If user does not move mouse or
@@ -116,18 +116,6 @@ const resetInteractionTimer = () => {
     }
   }, INACTIVITY_INTERVAL)
 }
-
-setInterval(() => {
-  const idle = powerMonitor.getSystemIdleTime()
-  if (!win) return
-
-  if (idle > INACTIVITY_INTERVAL) {
-    const currentURL = win.webContents.getURL()
-    if (currentURL.includes('wallet')) {
-      win.reload()
-    }
-  }
-}, 5000)
 
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,6 +1,6 @@
 'use strict'
 
-import electron, { app, ipcMain, protocol, BrowserWindow, webContents } from 'electron'
+import electron, { app, ipcMain, protocol, BrowserWindow, powerMonitor } from 'electron'
 import { createProtocol } from 'vue-cli-plugin-electron-builder/lib'
 import installExtension, { VUEJS_DEVTOOLS } from 'electron-devtools-installer'
 import path from 'path'
@@ -42,7 +42,7 @@ import { checkForUpdates, downloadUpdate, quitAndInstall } from './updater'
 const pkg = require('../package.json')
 
 const isDevelopment = process.env.NODE_ENV !== 'production'
-let win: BrowserWindow
+let win: BrowserWindow | null
 
 // Scheme must be registered before the app is ready
 protocol.registerSchemesAsPrivileged([
@@ -75,6 +75,10 @@ async function createWindow () {
     require('electron').shell.openExternal(url)
   })
 
+  win.on('closed', () => {
+    win = null
+  })
+
   if (process.env.WEBPACK_DEV_SERVER_URL) {
     // Load the url of the dev server if in development mode
     await win.loadURL(process.env.WEBPACK_DEV_SERVER_URL as string)
@@ -86,22 +90,30 @@ async function createWindow () {
   }
 }
 
-const INACTIVITY_INTERVAL = 3600000
-const DEBOUNCE_INTERVAL = 1000
-// Set interaction detection time period to 1hr. If user does not move mouse or
-// interact with keyboard, refresh app and have User log in again.
-let idleInterval = setInterval(() => { win.reload()}, INACTIVITY_INTERVAL)
+// const INACTIVITY_INTERVAL = 10000
+// const DEBOUNCE_INTERVAL = 2000
+const INACTIVITY_INTERVAL = process.env.INACTIVITY_INTERVAL ? Number(process.env.INACTIVITY_INTERVAL) : 18 // 30 minutes
 
-const resetInteractionTimer = () => {
-  clearInterval(idleInterval)
-  idleInterval = setInterval(() => { win.reload() }, INACTIVITY_INTERVAL)  
-}
+setInterval(() => {
+  const idle = powerMonitor.getSystemIdleTime()
+  console.log('idle time--->', idle)
+  console.log('inactivity interval-->', INACTIVITY_INTERVAL)
+  if (!win) return
+  if (idle > INACTIVITY_INTERVAL) {
+    console.log('activity interval reached!:  idle--->', idle, 'INACTIVITY_INTERVAL--->', INACTIVITY_INTERVAL)
+    const currentURL = win.webContents.getURL()
+    if (currentURL.includes('wallet')) {
+      win.reload()
+    }
+  }
+}, 5000)
 
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
   // On macOS it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform !== 'darwin') {
+    console.log('app.quit called')
     app.quit()
   }
 })
@@ -132,10 +144,10 @@ app.on('ready', async () => {
   }
   createWindow()
 
-  const onEvent = debounce(resetInteractionTimer, DEBOUNCE_INTERVAL)
-  win.webContents.on('before-input-event', onEvent)
-  win.webContents.on('cursor-changed', onEvent)
-  win.webContents.on('before-input-event', onEvent)
+  // const onEvent = debounce(resetInteractionTimer, DEBOUNCE_INTERVAL)
+  // win.webContents.on('before-input-event', onEvent)
+  // win.webContents.on('cursor-changed', onEvent)
+  // win.webContents.on('before-input-event', onEvent)
 
   checkForUpdates()
 })


### PR DESCRIPTION
This PR fixes the bug when a user has been idle, but closed the app window.  Safeguards were add to ensure the window was still active, before the app tries to reload.

## Linear
[See Linear TIcket RDX-460 for Demo Video](https://linear.app/township/issue/RDX-460)