### PR TITLE
fix: deriving account modal copy

### DIFF
--- a/src/components/modals/WalletLedgerInteractionModal.vue
+++ b/src/components/modals/WalletLedgerInteractionModal.vue
@@ -62,8 +62,10 @@ const WalletLedgerInteractionModal = defineComponent({
       }
     })
 
+    console.log('hardware interaction state ', hardwareInteractionState.value)
+
     const interactionBody: ComputedRef<string> = computed(() => {
-      if (hardwareInteractionState.value === '') return ''
+      if (hardwareInteractionState.value === 'DERIVING' || hardwareInteractionState.value === '') return ''
       if (showCancelButton.value) {
         return t(`wallet.ledgerInteractionState.${hardwareInteractionState.value}.body`)
       } else {

--- a/src/components/modals/WalletLedgerInteractionModal.vue
+++ b/src/components/modals/WalletLedgerInteractionModal.vue
@@ -62,8 +62,6 @@ const WalletLedgerInteractionModal = defineComponent({
       }
     })
 
-    console.log('hardware interaction state ', hardwareInteractionState.value)
-
     const interactionBody: ComputedRef<string> = computed(() => {
       if (hardwareInteractionState.value === 'DERIVING' || hardwareInteractionState.value === '') return ''
       if (showCancelButton.value) {


### PR DESCRIPTION
This PR fixes the conditional that controls whether or not the `WalletLedgerInteractionModal` displays both title and body text.  An extension to the conditional was added if the `hardwareInteractionState` value is equal to `DERIVING`, the modal should not have any body text and only show `Deriving Account`.

See Loom Video in [linear ticket RDX-465](https://linear.app/township/issue/RDX-465)