### PR TITLE
Natasha/rdx 464 bug issue when restoring wallet from

### DIFF
--- a/src/components/FormErrorMessage.vue
+++ b/src/components/FormErrorMessage.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="relative my-2 w-full">
     <ErrorMessage :name="name" v-slot="{ message }">
-      <div class="flex flex-row items-center text-rRed absolute" :class="errorClass">
+      <div class="flex flex-row items-center text-rRed absolute text-sm" :class="errorClass">
         <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="mr-3">
           <circle cx="7" cy="7" r="6.5" transform="rotate(90 7 7)" fill="#EF4136" stroke="#EF4136"/>
           <rect x="4" y="5" width="1" height="7" transform="rotate(-45 4 5)" fill="white"/>

--- a/src/components/PinInput.vue
+++ b/src/components/PinInput.vue
@@ -23,7 +23,8 @@
       ref="inputRef"
       v-model="value"
       :data-ci="dataCi"
-      @blur="focusInput()"
+      @blur="focusInput"
+      @keypress="isNumber($event)"
       @input="handleChange"
     />
 
@@ -111,13 +112,19 @@ const PinInput = defineComponent({
 
   methods: {
     handleChange (event: Event) {
+      // console.log(event.target)
       const target = event.target as HTMLInputElement
+      // console.log(target.value)
+      console.log('this.value->', this.value, this.value.length, this)
       if (this.value.length > 4) this.value = this.value.slice(0, 4)
       if (target.value.length >= 4) {
         this.$emit('finished', this.name)
       } else {
         this.$emit('unfinished', this.name)
       }
+    },
+    isNumber (evt: any) {
+      console.log('event from on change', evt)
     }
   },
 

--- a/src/components/PinInput.vue
+++ b/src/components/PinInput.vue
@@ -18,13 +18,13 @@
     </div>
     <input
       :name="name"
-      type="number"
+      type="text"
       class="opacity-0 absolute top-0 left-0 w-full h-full cursor-pointer"
       ref="inputRef"
       v-model="value"
       :data-ci="dataCi"
       @blur="focusInput"
-      @keypress="isNumber($event)"
+      @keypress={c}
       @input="handleChange"
     />
 
@@ -112,12 +112,15 @@ const PinInput = defineComponent({
 
   methods: {
     handleChange (event: Event) {
+      this.value = this.value.replace(/[^0-9]+/, '')
+      // if event value === '- or -#) return out of it
       // console.log(event.target)
       const target = event.target as HTMLInputElement
       // console.log(target.value)
-      console.log('this.value->', this.value, this.value.length, this)
+      console.log('this.value->', this.value, 'this.length->', this.value.length)
       if (this.value.length > 4) this.value = this.value.slice(0, 4)
-      if (target.value.length >= 4) {
+      if (this.value.length >= 4) {
+        console.log('inside if, length is ', target.value.length, this.value.length)
         this.$emit('finished', this.name)
       } else {
         this.$emit('unfinished', this.name)

--- a/src/components/PinInput.vue
+++ b/src/components/PinInput.vue
@@ -96,7 +96,6 @@ const PinInput = defineComponent({
       value.value = value.value.replace(/[^0-9]+/, '')
       if (value.value.length > 4) value.value = value.value.slice(0, 4)
       if (value.value.length >= 4) {
-        console.log('pin >= than 4!')
         context.emit('finished', name.value)
       } else {
         context.emit('unfinished', name.value)

--- a/src/components/PinInput.vue
+++ b/src/components/PinInput.vue
@@ -28,7 +28,7 @@
     />
 
     <div class="relative my-4 w-full text-sm" :class="{'-ml-24': shiftErrorLeft}">
-      <div v-if="errorMessage" class="flex flex-row items-center justify-center text-rRed absolute">
+      <div v-if="errorMessage" class="flex flex-row items-center justify-center text-rRed absolute -mt-2">
         <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="mr-3">
         <circle cx="7" cy="7" r="6.5" transform="rotate(90 7 7)" fill="#EF4136" stroke="#EF4136"/>
         <rect x="4" y="5" width="1" height="7" transform="rotate(-45 4 5)" fill="white"/>
@@ -93,6 +93,7 @@ const PinInput = defineComponent({
     const { value, errorMessage } = useField<string>(name.value, 'required')
 
     const handleChange = () => {
+      console.log(value.value)
       value.value = value.value.replace(/[^0-9]+/, '')
       if (value.value.length > 4) value.value = value.value.slice(0, 4)
       if (value.value.length >= 4) {

--- a/src/components/PinInput.vue
+++ b/src/components/PinInput.vue
@@ -24,7 +24,6 @@
       v-model="value"
       :data-ci="dataCi"
       @blur="focusInput"
-      @keypress={c}
       @input="handleChange"
     />
 
@@ -45,6 +44,7 @@
 import { defineComponent, onMounted, Ref, ref } from 'vue'
 import { useField } from 'vee-validate'
 import PinInputDigit from '@/components/PinInputDigit.vue'
+import { useI18n } from 'vue-i18n'
 
 const PinInput = defineComponent({
   components: {
@@ -82,6 +82,7 @@ const PinInput = defineComponent({
   setup (props) {
     const inputRef = ref<null | { focus:() => null, onblur: any, onfocus: any }> (null)
     const isFocused: Ref<boolean> = ref(false)
+    const { t } = useI18n()
     const focusInput = () => {
       if (props.autofocus && inputRef.value) {
         return inputRef.value.focus()
@@ -95,7 +96,10 @@ const PinInput = defineComponent({
       }
     })
 
+    console.log('props.name-->', props.name)
     const { value, errorMessage } = props.required ? useField<string>(props.name, 'required') : useField<string>(props.name)
+    // const { value, errorMessage } = props.required ? useField<string>(t('validations.pinConfirmation'), 'required') : useField<string>(props.name)
+    console.log('value->', value.value, 'error message-->', errorMessage.value)
 
     return {
       inputRef,
@@ -113,21 +117,15 @@ const PinInput = defineComponent({
   methods: {
     handleChange (event: Event) {
       this.value = this.value.replace(/[^0-9]+/, '')
-      // if event value === '- or -#) return out of it
-      // console.log(event.target)
       const target = event.target as HTMLInputElement
-      // console.log(target.value)
       console.log('this.value->', this.value, 'this.length->', this.value.length)
       if (this.value.length > 4) this.value = this.value.slice(0, 4)
       if (this.value.length >= 4) {
-        console.log('inside if, length is ', target.value.length, this.value.length)
+        console.log('pin >= than 4!')
         this.$emit('finished', this.name)
       } else {
         this.$emit('unfinished', this.name)
       }
-    },
-    isNumber (evt: any) {
-      console.log('event from on change', evt)
     }
   },
 

--- a/src/components/PinInputDigit.vue
+++ b/src/components/PinInputDigit.vue
@@ -23,7 +23,7 @@ export default defineComponent({
 
   computed: {
     showNumber (): boolean {
-      // console.log('values-->', this.values, ' index-->', this.index, 'focused--> ', this.focused)
+      // console.log('showNumber result--->', !!(this.values && this.values.length === this.index + 1 && this.focused))
       return !!(this.values && this.values.length === this.index + 1 && this.focused)
     },
     showDot (): boolean {
@@ -31,6 +31,7 @@ export default defineComponent({
     },
     display (): string {
       if (this.values && this.showNumber) return this.values[this.index]
+      // else if (this.values && this.showDot) return this.values[this.index]
       else if (this.values && this.showDot) return '•'
       else return ''
     }

--- a/src/components/PinInputDigit.vue
+++ b/src/components/PinInputDigit.vue
@@ -23,7 +23,6 @@ export default defineComponent({
 
   computed: {
     showNumber (): boolean {
-      // console.log('showNumber result--->', !!(this.values && this.values.length === this.index + 1 && this.focused))
       return !!(this.values && this.values.length === this.index + 1 && this.focused)
     },
     showDot (): boolean {
@@ -31,7 +30,6 @@ export default defineComponent({
     },
     display (): string {
       if (this.values && this.showNumber) return this.values[this.index]
-      // else if (this.values && this.showDot) return this.values[this.index]
       else if (this.values && this.showDot) return '•'
       else return ''
     }

--- a/src/components/PinInputDigit.vue
+++ b/src/components/PinInputDigit.vue
@@ -23,6 +23,7 @@ export default defineComponent({
 
   computed: {
     showNumber (): boolean {
+      // console.log('values-->', this.values, ' index-->', this.index, 'focused--> ', this.focused)
       return !!(this.values && this.values.length === this.index + 1 && this.focused)
     },
     showDot (): boolean {

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -503,7 +503,7 @@ interface useWalletInterface {
   persistNodeUrl: (url: string) => Promise<void>;
   reloadSubscriptions: () => void;
   reset: () => void;
-  resetWallet: (nextRoute: 'create-wallet' | 'restore-wallet') => void;
+  resetWallet: (nextRoute: 'create-wallet' | 'restore-wallet' | '') => void;
   setActiveAddress: (address: string) => void;
   setHideAccountModal: (val: boolean) => void;
   setLedgerVerify: (val: boolean) => void;

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -23,7 +23,8 @@ const messages = {
       stakeFailed: 'Your transaction failed. Check that you have sufficient XRD to cover your stake plus fee.',
       unstakeFailed: 'Your transaction failed. Check that you are not unstaking more than your total current stake and that you have sufficient XRD to cover the fee.',
       pinMatch: 'Your new pin doesn\'t match',
-      messageRequired: 'You must add a message to be able to encrypt it'
+      messageRequired: 'You must add a message to be able to encrypt it',
+      pinConfirmation: 'Pin confirmation'
     },
     home: {
       welcomeOne: 'Welcome to the Radix Olympia Desktop Wallet.',

--- a/src/text/index.ts
+++ b/src/text/index.ts
@@ -8,7 +8,7 @@ const messages = {
     validations: {
       default: '%{field} is invalid',
       required: '%{field} is required',
-      confirmed: '%{field} do not match',
+      confirmed: '%{field} does not match',
       length: '%{field} is the wrong length',
       max: '%{field} must be less than 160 characters long',
       validAddress: 'Enter a valid address',

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -20,7 +20,7 @@ configure({
     // Pass validation messages through i18n
     let field = context.field
     if (field === 'confirmation') {
-      field = 'Passwords'
+      field = 'Password'
     }
 
     if (field === 'pinConfirmation') {

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -19,15 +19,17 @@ configure({
   generateMessage: (context: FieldContext) => {
     // Pass validation messages through i18n
     let field = context.field
+    console.log('field is-->', field)
     if (field === 'password') {
-      field = 'Password'
+      field = 'password'
     }
 
-    if (field === 'pinConfirmation' || field === 'confirmation') {
-      field = 'Pin confirmation'
+    if (field === 'pinConfirmation') {
+      field = 'pin confirmation'
     }
 
     if (context.rule) {
+      console.log(context.rule.name)
       return i18n.global.t(`validations.${context.rule.name}`, { field: field, params: context.rule.params })
     }
     return i18n.global.t('validations.default', { field: field })

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -19,12 +19,12 @@ configure({
   generateMessage: (context: FieldContext) => {
     // Pass validation messages through i18n
     let field = context.field
-    if (field === 'confirmation') {
+    if (field === 'password') {
       field = 'Password'
     }
 
-    if (field === 'pinConfirmation') {
-      field = 'Pin Confirmation'
+    if (field === 'pinConfirmation' || field === 'confirmation') {
+      field = 'Pin confirmation'
     }
 
     if (context.rule) {

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -23,6 +23,10 @@ configure({
       field = 'Passwords'
     }
 
+    if (field === 'pinConfirmation') {
+      field = 'Pin Confirmation'
+    }
+
     if (context.rule) {
       return i18n.global.t(`validations.${context.rule.name}`, { field: field, params: context.rule.params })
     }

--- a/src/views/CreateWallet/CreateWalletCreatePin.vue
+++ b/src/views/CreateWallet/CreateWalletCreatePin.vue
@@ -19,6 +19,7 @@
         :autofocus="!updatingFirstInput"
         :large="true"
         class="mb-36 max-w-sm"
+        @submit="handleSubmit"
         data-ci="create-wallet-confirm-input"
       >
       </pin-input>

--- a/src/views/CreateWallet/index.vue
+++ b/src/views/CreateWallet/index.vue
@@ -1,9 +1,9 @@
 <template>
   <div data-ci="create-wallet-view" class="flex flex-row min-h-screen">
     <div class="w-72 mr-5 py-8 px-5 text-white leading-snug">
-      <router-link to="/" class="flex">
+      <button @click="resetAndReturn" class="flex">
         <img alt="Radix DLT Logo" src="../../assets/logo.svg" class="w-30 mb-12 ">
-      </router-link>
+      </button>
       <wizard-heading
         :name="$t('createWallet.recoveryTitle')"
         :isActiveStep="step === 0 || step === 1"
@@ -35,14 +35,14 @@
         :disabled="step < 3"
         @click="() => {
           step = 3
-          resetPinTrigger = resetPinTrigger + 1
         }"
       >
       </wizard-heading>
       <div class="border border-white rounded p-3 mb-8" v-if="step === 3">{{ $t('createWallet.pinHelpOne') }}</div>
       <div class="border border-white rounded p-3 mb-8" v-if="step === 4">{{ $t('createWallet.pinHelpTwo') }}</div>
 
-      <router-link
+      <button
+        @click="resetAndReturn"
         to="/"
         data-ci="home-button"
         class="hover:text-rGreen cursor-pointer transition-colors inline-flex flex-row items-center absolute bottom-8"
@@ -52,7 +52,7 @@
           <path d="M12 15L7 10L12 5" class="stroke-current" stroke-miterlimit="10"/>
         </svg>
         {{ $t('createWallet.startOver') }}
-      </router-link>
+      </button>
     </div>
 
     <div class="bg-white pt-headerHeight pb-8 px-11 flex-1">
@@ -114,7 +114,7 @@ const CreateWallet = defineComponent({
 
   setup () {
     const router = useRouter()
-    const { activeNetwork, createWallet, radix, loginWithWallet, setPin, setNetwork, setWallet, walletLoaded, waitUntilAllLoaded } = useWallet(router)
+    const { activeNetwork, createWallet, radix, loginWithWallet, resetWallet, setPin, setNetwork, setWallet, walletLoaded, waitUntilAllLoaded } = useWallet(router)
     const { setState } = useSidebar()
     const newWallet: Ref<WalletT | null> = ref(null)
     const mnemonicStrength: Ref<StrengthT> = ref(StrengthT.WORD_COUNT_12)
@@ -174,6 +174,10 @@ const CreateWallet = defineComponent({
       })
     }
 
+    const resetAndReturn = () => {
+      resetWallet('')
+    }
+
     return {
       mnemonic,
       mnemonicStrength,
@@ -186,7 +190,8 @@ const CreateWallet = defineComponent({
       handleCreateWallet,
       handleEnterPin,
       handleCreatePin,
-      handleSetSeedStrength
+      handleSetSeedStrength,
+      resetAndReturn
     }
   }
 })

--- a/src/views/CreateWallet/index.vue
+++ b/src/views/CreateWallet/index.vue
@@ -91,7 +91,7 @@
 
 <script lang="ts">
 import { computed, ComputedRef, defineComponent, ref, Ref } from 'vue'
-import { Mnemonic, MnemomicT, WalletT, StrengthT } from '@radixdlt/application'
+import { Mnemonic, MnemomicT, Network, WalletT, StrengthT } from '@radixdlt/application'
 import CreateWalletCreatePasscode from './CreateWalletCreatePasscode.vue'
 import CreateWalletCreatePin from './CreateWalletCreatePin.vue'
 import CreateWalletViewMnemonic from './CreateWalletViewMnemonic.vue'
@@ -134,7 +134,7 @@ const CreateWallet = defineComponent({
     if (!network) {
       radix.connect(defaultNetwork).then(() => {
         return firstValueFrom(radix.ledger.networkId())
-      }).then((net: any) => {
+      }).then((net: Network) => {
         setNetwork(net)
         network = net
       }).catch(() => {

--- a/src/views/RestoreWallet/index.vue
+++ b/src/views/RestoreWallet/index.vue
@@ -1,9 +1,9 @@
 <template>
   <div data-ci="create-wallet-view" class="flex flex-row h-screen">
     <div class="w-72 mr-5 py-8 px-5 text-white leading-snug">
-      <router-link to="/" class="flex">
+      <button class="flex" @click="resetAndReturn">
         <img alt="Radix DLT Logo" src="../../assets/logo.svg" class="w-30 mb-12 ">
-      </router-link>
+      </button>
       <wizard-heading
         :name="$t('restoreWallet.recoveryTitle')"
         :isActiveStep="step === 0"
@@ -12,8 +12,7 @@
           step = 0
           pinIsSet = false
         }"
-      >
-      </wizard-heading>
+      />
       <div v-if="step === 0">
         <div class="border border-white rounded p-3 mb-8">{{ $t('restoreWallet.recoveryHelp') }}</div>
       </div>
@@ -27,8 +26,7 @@
           step = 1
           pinIsSet = false
         }"
-      >
-      </wizard-heading>
+      />
       <div class="border border-white rounded p-3 mb-8" v-if="step === 1">{{ $t('restoreWallet.passwordHelp') }}</div>
       <wizard-heading
         :name="$t('restoreWallet.pinTitle')"
@@ -38,15 +36,14 @@
         @click="() => {
           step = 2
           pinIsSet = false
-          resetPinTrigger = resetPinTrigger + 1
         }"
-      >
-      </wizard-heading>
+      />
       <div class="border border-white rounded p-3 mb-8" v-if="step === 2 && !pinIsSet">{{ $t('restoreWallet.pinHelpOne') }}</div>
       <div class="border border-white rounded p-3 mb-8" v-if="step === 3 && !pinIsSet">{{ $t('restoreWallet.pinHelpTwo') }}</div>
       <div class="border border-white rounded p-3 mb-8" v-if="step === 3 && pinIsSet">{{ $t('restoreWallet.disclaimerHelp') }}</div>
 
-      <router-link
+      <button
+        @click="resetAndReturn"
         to="/"
         data-ci="home-button"
         class="hover:text-rGreen cursor-pointer transition-colors inline-flex flex-row items-center absolute bottom-8"
@@ -56,7 +53,7 @@
           <path d="M12 15L7 10L12 5" class="stroke-current" stroke-miterlimit="10"/>
         </svg>
         {{ $t('createWallet.startOver') }}
-      </router-link>
+      </button>
     </div>
     <div class="bg-white flex-1 overflow-y-scroll" v-if="pinIsSet">
       <multiple-accounts-disclaimer
@@ -68,27 +65,24 @@
       <restore-wallet-enter-mnemonic
         v-if="step == 0"
         @confirm="captureMnemonic"
-      >
-      </restore-wallet-enter-mnemonic>
+      />
       <create-wallet-create-passcode
         v-if="step == 1"
         @confirm="createWallet"
-      >
-      </create-wallet-create-passcode>
+      />
 
       <create-wallet-create-pin
         v-if="(step == 2 || step == 3) && !pinIsSet"
         @confirm="handleCreatePin"
         @enteredPin="handleEnterPin"
-      >
-      </create-wallet-create-pin>
+      />
     </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent, ref, Ref } from 'vue'
-import { MnemomicT, Mnemonic, Network, WalletT } from '@radixdlt/application'
+import { MnemomicT, Network, WalletT } from '@radixdlt/application'
 import WizardHeading from '@/components/WizardHeading.vue'
 import { initWallet, storePin } from '@/actions/vue/create-wallet'
 import RestoreWalletEnterMnemonic from './RestoreWalletEnterMnemonic.vue'
@@ -115,7 +109,7 @@ const RestoreWallet = defineComponent({
     const passcode: Ref<string> = rxRef('')
     const mnemonic: Ref<MnemomicT | null> = rxRef(null)
     const router = useRouter()
-    const { loginWithWallet, setNetwork, walletLoaded, setWallet, waitUntilAllLoaded } = useWallet(router)
+    const { loginWithWallet, setNetwork, walletLoaded, setWallet, waitUntilAllLoaded, resetWallet } = useWallet(router)
     const { setState } = useSidebar()
     const newWallet: Ref<WalletT | null> = ref(null)
     const pinIsSet: Ref<boolean> = ref(false)
@@ -148,6 +142,10 @@ const RestoreWallet = defineComponent({
       storePin(pin)
     }
 
+    const resetAndReturn = () => {
+      resetWallet('')
+    }
+
     const completeWalletRestore = (isUnderstood: boolean) => {
       if (isUnderstood) {
         loginWithWallet(passcode.value).then((client) => {
@@ -177,7 +175,8 @@ const RestoreWallet = defineComponent({
       captureMnemonic,
       completeWalletRestore,
       handleEnterPin,
-      handleCreatePin
+      handleCreatePin,
+      resetAndReturn
     }
   }
 })

--- a/src/views/RestoreWallet/index.vue
+++ b/src/views/RestoreWallet/index.vue
@@ -74,7 +74,6 @@
       <create-wallet-create-pin
         v-if="(step == 2 || step == 3) && !pinIsSet"
         @confirm="handleCreatePin"
-        @enteredPin="handleEnterPin"
       />
     </div>
   </div>
@@ -130,15 +129,13 @@ const RestoreWallet = defineComponent({
       step.value = 1
     }
 
-    const handleEnterPin = (val: boolean) => {
-      val ? step.value = 3 : step.value = 2
-    }
-
     const handleCreatePin = (pin: string) => {
+      console.log('new pin who dis', pin)
       pinIsSet.value = true
       if (!newWallet.value) return
       setWallet(newWallet.value)
       storePin(pin)
+      step.value = 3
     }
 
     const resetAndReturn = () => {
@@ -173,7 +170,6 @@ const RestoreWallet = defineComponent({
       createWallet,
       captureMnemonic,
       completeWalletRestore,
-      handleEnterPin,
       handleCreatePin,
       resetAndReturn
     }

--- a/src/views/RestoreWallet/index.vue
+++ b/src/views/RestoreWallet/index.vue
@@ -89,7 +89,6 @@ import RestoreWalletEnterMnemonic from './RestoreWalletEnterMnemonic.vue'
 import CreateWalletCreatePasscode from '@/views/CreateWallet/CreateWalletCreatePasscode.vue'
 import CreateWalletCreatePin from '@/views/CreateWallet/CreateWalletCreatePin.vue'
 import MultipleAccountsDisclaimer from '@/views/CreateWallet/MultipleAccountsDisclaimer.vue'
-import { ref as rxRef } from '@nopr3d/vue-next-rx'
 import { saveDerivedAccountsIndex } from '@/actions/vue/data-store'
 import { useSidebar, useWallet } from '@/composables'
 import { useRouter } from 'vue-router'
@@ -105,9 +104,9 @@ const RestoreWallet = defineComponent({
   },
 
   setup () {
-    const step = rxRef(0)
-    const passcode: Ref<string> = rxRef('')
-    const mnemonic: Ref<MnemomicT | null> = rxRef(null)
+    const step = ref(0)
+    const passcode: Ref<string> = ref('')
+    const mnemonic: Ref<MnemomicT | null> = ref(null)
     const router = useRouter()
     const { loginWithWallet, setNetwork, walletLoaded, setWallet, waitUntilAllLoaded, resetWallet } = useWallet(router)
     const { setState } = useSidebar()

--- a/src/views/Settings/SettingsResetPin.vue
+++ b/src/views/Settings/SettingsResetPin.vue
@@ -36,8 +36,8 @@
 
     <div class="text-rGrayDark mb-2 mt-10">{{ $t('settings.confirmationPinLabel') }}</div>
     <pin-input
-      name="confirmation"
-      :values="values.confirmation"
+      name="pinConfirmation"
+      :values="values.pinConfirmation"
       :autofocus="activePin === 2"
       class="mb-6 max-w-sm"
       data-ci="confirmation"
@@ -71,7 +71,7 @@ import { useI18n } from 'vue-i18n'
 interface ResetPinForm {
   password: string;
   pin: string;
-  confirmation: string;
+  pinConfirmation: string;
 }
 
 const SettingsResetPin = defineComponent({
@@ -89,14 +89,14 @@ const SettingsResetPin = defineComponent({
     const isValidPin = ref(false)
     const updatedPin = ref(false)
     const resetFormForNonmatchingPins = () => {
-      const newValues = { password: values.password, pin: '', confirmation: '' }
-      const newErrors = { confirmation: t('validations.pinMatch') }
+      const newValues = { password: values.password, pin: '', pinConfirmation: '' }
+      const newErrors = { pinConfirmation: t('validations.pinMatch') }
       resetForm({ values: newValues, errors: newErrors })
       activePin.value = 1
     }
 
     const handleComparePin = () => {
-      if (values.pin === values.confirmation) {
+      if (values.pin === values.pinConfirmation) {
         isValidPin.value = true
       } else {
         resetFormForNonmatchingPins()
@@ -108,7 +108,7 @@ const SettingsResetPin = defineComponent({
     }
 
     const handleResetPin = async () => {
-      if (values.pin !== values.confirmation) {
+      if (values.pin !== values.pinConfirmation) {
         resetFormForNonmatchingPins()
         return Promise.resolve()
       }
@@ -132,13 +132,13 @@ const SettingsResetPin = defineComponent({
     })
 
     const firstPinClicked = () => {
-      const newValues = { password: values.password, pin: '', confirmation: '' }
+      const newValues = { password: values.password, pin: '', pinConfirmation: '' }
       resetForm({ values: newValues })
       activePin.value = 1
     }
 
     const secondPinClicked = () => {
-      const newValues = { ...values, pinCnfirmation: '' }
+      const newValues = { ...values, pinConfirmation: '' }
       resetForm({ values: newValues })
       activePin.value = 2
     }

--- a/src/views/Settings/SettingsResetPin.vue
+++ b/src/views/Settings/SettingsResetPin.vue
@@ -34,7 +34,7 @@
     >
     </pin-input>
 
-    <div class="text-rGrayDark mb-4">{{ $t('settings.confirmationPinLabel') }}</div>
+    <div class="text-rGrayDark mb-2 mt-12">{{ $t('settings.confirmationPinLabel') }}</div>
     <pin-input
       name="confirmation"
       :values="values.confirmation"

--- a/src/views/Settings/SettingsResetPin.vue
+++ b/src/views/Settings/SettingsResetPin.vue
@@ -29,7 +29,7 @@
       class="mb-6 max-w-sm"
       data-ci="pin"
       @finished="activePin = 2"
-      @click="activePin = 1"
+      @click="firstPinClicked"
       :required=false
     >
     </pin-input>
@@ -43,7 +43,7 @@
       data-ci="confirmation"
       @finished="handleComparePin"
       @unfinished="handleUnfinishedPin"
-      @click="activePin = 2"
+      @click="secondPinClicked"
       :required=false
     >
     </pin-input>
@@ -131,6 +131,18 @@ const SettingsResetPin = defineComponent({
       return meta.value.dirty ? !meta.value.valid : true
     })
 
+    const firstPinClicked = () => {
+      const newValues = { password: values.password, pin: '', confirmation: '' }
+      resetForm({ values: newValues })
+      activePin.value = 1
+    }
+
+    const secondPinClicked = () => {
+      const newValues = { ...values, pinCnfirmation: '' }
+      resetForm({ values: newValues })
+      activePin.value = 2
+    }
+
     return {
       /* refs */
       activePin,
@@ -146,6 +158,8 @@ const SettingsResetPin = defineComponent({
       handleComparePin,
       handleUnfinishedPin,
       handleResetPin,
+      firstPinClicked,
+      secondPinClicked,
 
       /* computed */
       disableSubmit

--- a/src/views/Settings/SettingsResetPin.vue
+++ b/src/views/Settings/SettingsResetPin.vue
@@ -36,8 +36,8 @@
 
     <div class="text-rGrayDark mb-4">{{ $t('settings.confirmationPinLabel') }}</div>
     <pin-input
-      name="confirmationPin"
-      :values="values.confirmationPin"
+      name="confirmation"
+      :values="values.confirmation"
       :autofocus="activePin === 2"
       class="mb-6 max-w-sm"
       data-ci="confirmation"
@@ -64,15 +64,14 @@ import PinInput from '@/components/PinInput.vue'
 import { storePin, touchKeystore } from '@/actions/vue/create-wallet'
 import ButtonSubmit from '@/components/ButtonSubmit.vue'
 import PasswordField from '@/components/PasswordField.vue'
-import { Result } from 'neverthrow'
 import FormErrorMessage from '@/components/FormErrorMessage.vue'
-import { Keystore, KeystoreT } from '@radixdlt/application'
+import { Keystore } from '@radixdlt/application'
 import { useI18n } from 'vue-i18n'
 
 interface ResetPinForm {
   password: string;
   pin: string;
-  confirmationPin: string;
+  confirmation: string;
 }
 
 const SettingsResetPin = defineComponent({
@@ -90,15 +89,14 @@ const SettingsResetPin = defineComponent({
     const isValidPin = ref(false)
     const updatedPin = ref(false)
     const resetFormForNonmatchingPins = () => {
-      console.log('rest form for non matching pins called!!')
-      const newValues = { password: values.password, pin: '', confirmationPin: '' }
-      const newErrors = { confirmationPin: t('validations.pinMatch') }
+      const newValues = { password: values.password, pin: '', confirmation: '' }
+      const newErrors = { confirmation: t('validations.pinMatch') }
       resetForm({ values: newValues, errors: newErrors })
       activePin.value = 1
     }
 
     const handleComparePin = () => {
-      if (values.pin === values.confirmationPin) {
+      if (values.pin === values.confirmation) {
         isValidPin.value = true
       } else {
         resetFormForNonmatchingPins()
@@ -110,7 +108,7 @@ const SettingsResetPin = defineComponent({
     }
 
     const handleResetPin = async () => {
-      if (values.pin !== values.confirmationPin) {
+      if (values.pin !== values.confirmation) {
         resetFormForNonmatchingPins()
         return Promise.resolve()
       }
@@ -118,7 +116,7 @@ const SettingsResetPin = defineComponent({
         const keystore = await touchKeystore()
         const decryptedResult = await Keystore.decrypt({ keystore, password: values.password })
         if (decryptedResult.isOk()) {
-          const storePinResult = await storePin(values.pin)
+          await storePin(values.pin)
           resetForm()
           updatedPin.value = true
         } else {

--- a/src/views/Settings/SettingsResetPin.vue
+++ b/src/views/Settings/SettingsResetPin.vue
@@ -34,7 +34,7 @@
     >
     </pin-input>
 
-    <div class="text-rGrayDark mb-2 mt-8">{{ $t('settings.confirmationPinLabel') }}</div>
+    <div class="text-rGrayDark mb-2 mt-10">{{ $t('settings.confirmationPinLabel') }}</div>
     <pin-input
       name="confirmation"
       :values="values.confirmation"

--- a/src/views/Settings/SettingsResetPin.vue
+++ b/src/views/Settings/SettingsResetPin.vue
@@ -90,6 +90,7 @@ const SettingsResetPin = defineComponent({
     const isValidPin = ref(false)
     const updatedPin = ref(false)
     const resetFormForNonmatchingPins = () => {
+      console.log('??')
       const newValues = { password: values.password, pin: '', confirmationPin: '' }
       const newErrors = { confirmationPin: t('validations.pinMatch') }
       resetForm({ values: newValues, errors: newErrors })

--- a/src/views/Settings/SettingsResetPin.vue
+++ b/src/views/Settings/SettingsResetPin.vue
@@ -90,7 +90,7 @@ const SettingsResetPin = defineComponent({
     const isValidPin = ref(false)
     const updatedPin = ref(false)
     const resetFormForNonmatchingPins = () => {
-      console.log('??')
+      console.log('rest form for non matching pins called!!')
       const newValues = { password: values.password, pin: '', confirmationPin: '' }
       const newErrors = { confirmationPin: t('validations.pinMatch') }
       resetForm({ values: newValues, errors: newErrors })

--- a/src/views/Settings/SettingsResetPin.vue
+++ b/src/views/Settings/SettingsResetPin.vue
@@ -21,7 +21,7 @@
       <FormErrorMessage name="password" />
     </div>
 
-    <div class="text-rGrayDark mt-12 mb-2">{{ $t('settings.pinLabel') }}</div>
+    <div class="text-rGrayDark mt-10 mb-2">{{ $t('settings.pinLabel') }}</div>
     <pin-input
       name="pin"
       :values="values.pin"
@@ -34,7 +34,7 @@
     >
     </pin-input>
 
-    <div class="text-rGrayDark mb-2 mt-12">{{ $t('settings.confirmationPinLabel') }}</div>
+    <div class="text-rGrayDark mb-2 mt-8">{{ $t('settings.confirmationPinLabel') }}</div>
     <pin-input
       name="confirmation"
       :values="values.confirmation"
@@ -48,7 +48,7 @@
     >
     </pin-input>
 
-    <ButtonSubmit class="w-72 mx-auto mt-8" :disabled="disableSubmit">
+    <ButtonSubmit class="w-72 mx-auto mt-6" :disabled="disableSubmit">
       {{ $t('settings.confirm') }}
     </ButtonSubmit>
     <div v-if="updatedPin" class="text-rGrayDark text-sm mt-4">


### PR DESCRIPTION
This PR fixes inputs in the `restore wallet from seed phrase` and `change pin` screens not allowing a user to type after pressing the `-` key.  The input was changed from type=number to type=text, then a regex was used to find and replace the `e` with an empty space.  When a user clicks in the `enter pin` input it now clears both inputs and allows the user to type again.  The error message copy was also updated.

[Linear Ticket RDX-464](https://linear.app/township/issue/RDX-464)