### PR TITLE
fix: Sanitize account names while displaying them for export

### DIFF
--- a/src/views/Settings/ExportAccountListItem.vue
+++ b/src/views/Settings/ExportAccountListItem.vue
@@ -11,7 +11,7 @@
     </div>
     <div class="flex flex-col gap-2 flex-1">
       <div>
-        <span v-if="name" class="text-sm mr-2">{{ name }}</span>
+        <span v-if="name" class="text-sm mr-2">{{ cleanedUpName }}</span>
         <span v-if="isHidden" class="text-sm text-rGrayMed">(Hidden)</span>
       </div>
       <div class="flex items-center gap-1 text-xs text-rBlue">
@@ -24,6 +24,7 @@
 <script lang="ts">
 import { defineComponent, PropType, toRef, computed } from 'vue'
 import { AccountAddressT } from '@radixdlt/application'
+import { sanitizeName } from '@/helpers/exportAsCode'
 
 export default defineComponent({
   props: {
@@ -48,9 +49,16 @@ export default defineComponent({
   setup (props) {
     const address = toRef(props, 'address')
     const selected = toRef(props, 'selected')
+    const name = toRef(props, 'name')
+    const cleanedUpName = computed(() => {
+      if (!name.value) return null
+      const sanitized = sanitizeName(name.value)
+      return sanitized.substring(0, sanitized.length - 1)
+    })
     const addressSelected = computed(() => selected.value.includes(address.value.toString()))
     return {
-      addressSelected
+      addressSelected,
+      cleanedUpName
     }
   }
 })


### PR DESCRIPTION
Account names can contain a lot of characters that need to be sanitized before exporting them to the Babylon Wallet.  This PR updates the export interface to display the sanitized names, so that it's easier to compare actual export results compared to expectations.